### PR TITLE
Added default ellipse to CRS

### DIFF
--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -54,9 +54,12 @@ cdef class CRS:
 
     """
     def __init__(self, proj4_params):
-        proj4_params = dict(proj4_params)
-        self.proj4_params = proj4_params
-        init_items = ['+{}={}'.format(k, v) for k, v in proj4_params.iteritems()]
+        self.proj4_params = dict(proj4_params)
+        # Use WGS84 ellipse if one is not specified in proj4_params
+        if 'ellps' not in self.proj4_params:
+            self.proj4_params['ellps'] = 'WGS84'
+        init_items = ['+{}={}'.format(k, v) for
+                      k, v in self.proj4_params.iteritems()]
         self.proj4_init = ' '.join(init_items)
         self.proj4 = pj_init_plus(self.proj4_init)
         if not self.proj4:


### PR DESCRIPTION
Prevents errors on systems without 'proj_def.dat' i.e.

```
>>> cartopy.crs.Robinson()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/esc24/cartopy/build/lib.linux-x86_64-2.7/cartopy/crs.py", line 588, in __init__
    super(Robinson, self).__init__(proj4_params, central_longitude)
  File "/home/esc24/cartopy/build/lib.linux-x86_64-2.7/cartopy/crs.py", line 543, in __init__
    super(_WarpedRectangularProjection, self).__init__(proj4_params)
  File "_crs.pyx", line 63, in cartopy._crs.CRS.__init__ (lib/cartopy/_crs.c:1488)
cartopy._crs.Proj4Error: Error from proj.4: major axis or radius = 0 or not given
```

See this very old thread: http://lists.maptools.org/pipermail/proj/2001-February/000140.html
