### PR TITLE
Fix virtual destructor compiler warning

### DIFF
--- a/lib/cartopy/_trace.h
+++ b/lib/cartopy/_trace.h
@@ -45,6 +45,7 @@ class Interpolator
     virtual void set_line(Point &start, Point &end);
     virtual Point interpolate(double t)=0;
     virtual Point project(Point &point)=0;
+    virtual ~Interpolator();
 
     protected:
     Point m_start, m_end;


### PR DESCRIPTION
A 'delete' was called on a virtual object, Interpolator *p. Presumably,
p will actually point to a derived interpolator, say
CartersianInterpolator. In this case calling evoking a 'delete' on p
should call the destructor of the derived interpolator.
