### PR TITLE
Removal of image_comparison in favour of ImageTesting decorator.

### DIFF
--- a/lib/cartopy/tests/mpl/test_caching.py
+++ b/lib/cartopy/tests/mpl/test_caching.py
@@ -16,8 +16,6 @@
 # along with cartopy.  If not, see <http://www.gnu.org/licenses/>.
 import gc
 
-import numpy as np
-from matplotlib.testing.decorators import image_comparison as mpl_image_comparison
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 from matplotlib.collections import PatchCollection

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -15,13 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with cartopy.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
-from matplotlib.testing.decorators import image_comparison as mpl_image_comparison
 import matplotlib.pyplot as plt
-import matplotlib.patches as mpatches
-from matplotlib.collections import PatchCollection
-from matplotlib.path import Path
-import shapely.geometry
 
 import cartopy.crs as ccrs
 

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -186,7 +186,7 @@ def test_axes_natural_earth_interface():
     ax.natural_earth_shp('lakes', facecolor='blue')
 
 
-@image_comparison(baseline_images=['pcolormesh_global_wrap1'])
+@ImageTesting(['pcolormesh_global_wrap1'])
 def test_pcolormesh_global_with_wrap1():
     # make up some realistic data with bounds (such as data from the UM)
     nx, ny = 36, 18
@@ -208,7 +208,7 @@ def test_pcolormesh_global_with_wrap1():
     ax.set_global() # make sure everything is visible
 
 
-@image_comparison(baseline_images=['pcolormesh_global_wrap2'])
+@ImageTesting(['pcolormesh_global_wrap2'])
 def test_pcolormesh_global_with_wrap2():
     # make up some realistic data with bounds (such as data from the UM)
     nx, ny = 36, 18
@@ -234,7 +234,7 @@ def test_pcolormesh_global_with_wrap2():
     ax.set_global() # make sure everything is visible
 
 
-@image_comparison(baseline_images=['pcolormesh_global_wrap3'])
+@ImageTesting(['pcolormesh_global_wrap3'])
 def test_pcolormesh_global_with_wrap3():
     nx, ny = 33, 17
     xbnds = np.linspace(-1.875, 358.125, nx, endpoint=True)
@@ -267,7 +267,7 @@ def test_pcolormesh_global_with_wrap3():
     ax.set_global() # make sure everything is visible
 
 
-@image_comparison(baseline_images=['pcolormesh_limited_area_wrap'])
+@ImageTesting(['pcolormesh_limited_area_wrap'])
 def test_pcolormesh_limited_area_wrap():
     # make up some realistic data with bounds (such as data from the UM's North
     # Atlantic Europe model)

--- a/lib/cartopy/tests/mpl/test_shapely_to_mpl.py
+++ b/lib/cartopy/tests/mpl/test_shapely_to_mpl.py
@@ -16,7 +16,6 @@
 # along with cartopy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-from matplotlib.testing.decorators import image_comparison as mpl_image_comparison
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 from matplotlib.collections import PatchCollection

--- a/lib/cartopy/tests/test_img_nest.py
+++ b/lib/cartopy/tests/test_img_nest.py
@@ -23,8 +23,6 @@ import os
 
 from nose.tools import assert_equal, assert_raises
 import numpy as np
-from matplotlib.testing.decorators import image_comparison as mpl_image_comparison
-import matplotlib.pyplot as plt
 import shapely.geometry
 
 import cartopy.crs as ccrs

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -17,9 +17,6 @@
 
 from nose.tools import assert_equal, assert_raises
 from numpy.testing import assert_array_almost_equal as assert_arr_almost
-import numpy as np
-from matplotlib.testing.decorators import image_comparison as mpl_image_comparison
-import matplotlib.pyplot as plt
 import shapely.geometry
 
 import cartopy.crs as ccrs


### PR DESCRIPTION
Fixes #124 by removing `image_comparison` in favour of `ImageTesting`. Also removed a series of unused imports in the associated test files.
