### PR TITLE
More lenient end-point merging.

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -179,7 +179,6 @@ class Projection(CRS):
                              multi_line_string[0].coords[-1])):
             result_geometry = LinearRing(multi_line_string[0].coords[:-1])
         elif n_lines > 1:
-            line_strings = list(multi_line_string)
             # Stitch together segments which are close to continuous.
             # This is important when:
             # 1) The first source point projects into the map and the
@@ -192,7 +191,7 @@ class Projection(CRS):
             line_strings = list(multi_line_string)
             any_modified = False
             i = 0
-            while i < len(line_strings) - 1:
+            while i < len(line_strings):
                 modified = False
                 j = 0
                 while j < len(line_strings):
@@ -202,6 +201,8 @@ class Projection(CRS):
                         last_coords = list(line_strings[j].coords)
                         first_coords = list(line_strings[i].coords)[1:]
                         combo = sgeom.LineString(last_coords + first_coords)
+                        if j < i:
+                            i, j = j, i
                         del line_strings[j], line_strings[i]
                         line_strings.append(combo)
                         modified = True

--- a/lib/cartopy/tests/test_linear_ring.py
+++ b/lib/cartopy/tests/test_linear_ring.py
@@ -18,7 +18,6 @@
 
 import unittest
 
-from nose.tools import assert_is_instance
 from shapely import geometry
 
 import cartopy.crs as ccrs
@@ -128,6 +127,37 @@ class TestMisc(unittest.TestCase):
             result = target_proj.project_geometry(linear_ring, src_proj)
         except ValueError:
             self.fail("Failed to project LinearRing.")
+
+    def test_stitch(self):
+        # The following LinearRing wanders in/out of the map domain
+        # but importantly the "vertical" lines at 0'E and 360'E are both
+        # chopped by the map boundary. This results in their ends being
+        # *very* close to each other and confusion over which occurs
+        # first when navigating around the boundary.
+        # Check that these ends are stitched together to avoid the
+        # boundary ordering ambiguity.
+        # NB. This kind of polygon often occurs with MPL's contouring.
+        coords = [(0.0, -70.70499926182919),
+                  (0.0, -71.25),
+                  (0.0, -72.5),
+                  (0.0, -73.49076371657017),
+                  (360.0, -73.49076371657017),
+                  (360.0, -72.5),
+                  (360.0, -71.25),
+                  (360.0, -70.70499926182919),
+                  (350, -73),
+                  (10, -73)]
+        src_proj = ccrs.PlateCarree()
+        target_proj = ccrs.Stereographic(80)
+        linear_ring = geometry.polygon.LinearRing(coords)
+        result = target_proj.project_geometry(linear_ring, src_proj)
+        self.assertEqual(len(result), 1)
+
+        # Check the stitch works in either direction.
+        linear_ring = geometry.polygon.LinearRing(coords[::-1])
+        result = target_proj.project_geometry(linear_ring, src_proj)
+        self.assertEqual(len(result), 1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes a problem spotted in the process of dealing with #130, where central_latitude=80.
