### PR TITLE
Added a summary of the whole cartopy package to the docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lib/cartopy/_crs.c
 lib/cartopy/_crs.so
 docs/build
 lib/cartopy/tests/mpl/output/
+docs/source/cartopy_outline.rst
 
 # some data files:
 lib/cartopy/data/SRTM3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2012, Met Office
+# (C) British Crown Copyright 2011 - 2013, Met Office
 #
 # This file is part of cartopy.
 #
@@ -43,7 +43,9 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 
+extensions = [
+              'cartopy.sphinxext.summarise_package',
+              'sphinx.ext.autodoc', 
               'sphinx.ext.doctest', 
               'sphinx.ext.intersphinx',
               'sphinx.ext.coverage', 
@@ -321,3 +323,12 @@ extlinks = {'issues': ('https://github.com/SciTools/cartopy/issues?state=open&la
 
 
 plot_formats = [('png', 80)]
+
+
+############ package summary extension ###########
+
+summarise_package_names = ['cartopy']
+summarise_package_exclude_directories = [['tests', 'examples', 'sphinxext']]
+summarise_package_fnames = ['cartopy_outline.rst']
+
+

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -34,6 +34,9 @@ from cartopy._crs import CRS, Geocentric, Geodetic, PROJ4_RELEASE
 import cartopy.trace
 
 
+__document_these__ = ['CRS', 'Geocentric', 'Geodetic']
+
+
 class RotatedGeodetic(CRS):
     """
     Defines a rotated latitude/longitude coordinate system with spherical

--- a/lib/cartopy/sphinxext/__init__.py
+++ b/lib/cartopy/sphinxext/__init__.py
@@ -1,0 +1,16 @@
+# (C) British Crown Copyright 2011 - 2013, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <http://www.gnu.org/licenses/>.

--- a/lib/cartopy/sphinxext/summarise_package.py
+++ b/lib/cartopy/sphinxext/summarise_package.py
@@ -1,0 +1,208 @@
+# (C) British Crown Copyright 2011 - 2013, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <http://www.gnu.org/licenses/>.
+
+import inspect
+import itertools
+import os
+import sys
+
+
+def walk_module(mod_name, exclude_folders=None):
+    """
+    Recursively walks the given module name.
+
+    Returns:
+
+        A generator of::
+
+            (fully_qualified_import_name,
+             root_directory_of_subpackage,
+             fname_in_root_directory,
+             sub_folders_in_root_directory)
+
+    """
+    __import__(mod_name)
+    mod = sys.modules[mod_name]
+    mod_dir = os.path.dirname(mod.__file__)
+    exclude_folders = exclude_folders or []
+
+    for root, folders, files in os.walk(mod_dir):
+        for folder in exclude_folders:
+            try:
+                folders.remove(folder)
+            except ValueError:
+                pass
+
+        # only allow python packages
+        if not '__init__.py' in files:
+            del folders[:]
+            continue
+
+        is_py_src = lambda fname: fname.endswith(
+            '.py') or fname.endswith('.so')
+        files = filter(is_py_src, files)
+
+        for fname in files:
+            sub_mod_name = mod_name
+            relpath = os.path.relpath(root, mod_dir)
+            if relpath == '.':
+                relpath = ''
+
+            for sub_mod in filter(None, relpath.split(os.path.sep)):
+                sub_mod_name += '.' + sub_mod
+
+            if fname != '__init__.py':
+                sub_mod_name += '.' + os.path.splitext(fname)[0]
+
+            yield sub_mod_name, root, fname, folders
+
+
+def objects_to_document(module_name):
+    """
+    Creates a generator of (obj_name, obj) that the given module of the
+    given name should document.
+
+    The module name may be any importable, including submodules
+    (e.g. ``cartopy.io```)
+
+    """
+    __import__(module_name)
+    module = sys.modules[module_name]
+    elems = dir(module)
+
+    if '__all__' in elems:
+        document_these = [(obj, getattr(module, obj))
+                          for obj in module.__all__]
+    else:
+        document_these = [(obj, getattr(module, obj)) for obj in elems
+                          if not inspect.ismodule(getattr(module, obj)) and
+                          not obj.startswith('_')]
+
+        is_from_this_module = lambda x: ( 
+            getattr(x[1], '__module__', '') == module_name)
+
+        document_these = filter(is_from_this_module, document_these)
+        document_these = sorted(document_these,
+                                key=lambda x: (type(x[1]),
+                                               not x[0].isupper(),
+                                               x[0]))
+
+    # allow a developer to add other things to the documentation
+    if hasattr(module, '__document_these__'):
+        extra_objects_to_document = tuple((obj, getattr(module, obj))
+                                          for obj in module.__document_these__)
+        document_these = extra_objects_to_document + tuple(document_these)
+
+    return document_these
+
+
+def main(package_name, exclude_folders=None):
+    """
+    Return a string containing the rst that documents the given package name.
+
+    """
+    result = ''
+    mod_walk = walk_module(package_name, exclude_folders=exclude_folders)
+    for mod, _, fname, folders in mod_walk:
+        for folder in folders:
+            if folder.startswith('_'):
+                folders.remove(folder)
+        if fname.startswith('_') and fname != '__init__.py':
+            continue
+
+        result += '\n'
+        result += mod + '\n'
+        result += '*' * len(mod) + '\n'
+
+        result += '\n'
+        result += '.. currentmodule:: {}\n'.format(mod) + '\n'
+        result += '.. csv-table::\n' + '\n'
+
+        table_elements = itertools.cycle(('\n\t', ) + (', ', ) * 3)
+        for table_elem, (obj_name, _) in zip(table_elements,
+                                             objects_to_document(mod)):
+            result += '{}:py:obj:`{}`'.format(table_elem, obj_name)
+
+        result += '\n'
+
+    return result
+
+
+def gen_summary_rst(app):
+    """
+    Creates the rst file to summarise the desired packages.
+
+    """
+    package_names = app.config.summarise_package_names
+    exclude_dirs = app.config.summarise_package_exclude_directories
+    fnames = app.config.summarise_package_fnames
+
+    if isinstance(package_names, basestring):
+        package_names = [package_names]
+
+    if package_names is None:
+        raise ValueError('Please define a config value containing a list '
+                         'of packages to summarise.')
+
+    if exclude_dirs is None:
+        exclude_dirs = [None] * len(package_names)
+    else:
+        exception = ValueError('Please provide a list of exclude directory '
+                               'lists (one list for each package to '
+                               'summarise).')
+
+        if len(exclude_dirs) != len(package_names):
+            raise exception
+
+        for exclude_dirs_individual in exclude_dirs:
+            if isinstance(exclude_dirs_individual, basestring):
+                raise exception
+
+    if fnames is None:
+        fnames = ['outline_of_{}.rst'.format(package_name)
+                  for package_name in package_names]
+    else:
+        if isinstance(fnames, basestring) or len(fnames) != len(package_names):
+            raise TypeError('Please provide a list of filenames for each of '
+                            'the packages which are to be summarised.')
+
+    outdir = app.builder.srcdir
+
+    for package_name, out_fname, exclude_folders in zip(package_names,
+                                                        fnames,
+                                                        exclude_dirs):
+        out_fpath = os.path.join(outdir, out_fname)
+        content = main(package_name, exclude_folders=exclude_folders)
+        with open(out_fpath, 'w') as fh:
+            fh.write(content)
+
+
+def setup(app):
+    """
+    Defined the Sphinx application interface for the summary generation.
+
+    """
+    app.connect('builder-inited', gen_summary_rst)
+
+    # Allow users to define a config value to determine the names to summarise
+    app.add_config_value('summarise_package_names', None, 'env')
+
+    # Allow users to define a config value to determine the folders to exclude
+    app.add_config_value('summarise_package_exclude_directories', None, 'env')
+
+    # Allow users to define a config value to determine name of the output file
+    app.add_config_value('summarise_package_fnames', None, 'env')


### PR DESCRIPTION
Adds a fairly basic, automated, outline of the cartopy codebase in the documentation. This page will be useful for quickly finding documentation & for developers to identify areas of undocumented code (a lot of it at this stage!).

NOTE: The new page is currently not linked too. There are several such pages and I intend to turn the whole thing into a coherent documentation stream in a separate PR.

reviewer: cpelley
