### PR TITLE
Added a version switcher on the documentation.

### DIFF
--- a/docs/source/_static/version_switch.js
+++ b/docs/source/_static/version_switch.js
@@ -1,3 +1,6 @@
+// Copyright 2013 PSF. Licensed under the PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+// File originates from the cpython source found in Doc/tools/sphinxext/static/version_switch.js
+
 (function() {
   'use strict';
 

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -7,7 +7,7 @@
      <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
 
      <link rel="stylesheet" href="{{ pathto('_static/layout.css', 1) }}" type="text/css" />
-     <!-- <script type="text/javascript" src="{{ pathto('_static/version_switch.js', 1) }}"></script> -->
+     <!-- Point to the *latest* version switcher. This will allow the latest versions to appear on older documentation. -->
      <script type="text/javascript" src="http://scitools.org.uk/cartopy/docs/latest/_static/version_switch.js"></script>
 {% endblock %}
 


### PR DESCRIPTION
Implements a rudimentary version switcher. Most of the javascript has come out of the python source itself, minus the `jquery` magic at the bottom.
