### PR TITLE
Fix 2D result orientation.

### DIFF
--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -273,16 +273,15 @@ cdef class CRS:
 
         # call proj.4. The result array is modified in place.
         status = pj_transform(src_crs.proj4, self.proj4, npts, 3,
-                              &result[0, 0], &result[0, 1], &result[0, 2]);
-                              
+                              &result[0, 0], &result[0, 1], &result[0, 2])
+
         if self.is_geodetic():
             result = np.rad2deg(result)
         #if status:
         #    raise Proj4Error()
 
         if len(result_shape) > 2:
-            transpose_order = tuple(range(result.ndim)[::-1]) + (2, )
-            return result.reshape(result_shape).transpose(transpose_order)
+            return result.reshape(result_shape)
 
         return result
 

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -79,23 +79,22 @@ class TestCRS(unittest.TestCase):
         self.assertTrue('+y_0=1500000' in proj4_init)
 
     def test_transform_points_nD(self):
-        rlons = np.array([[350., 352.], [350., 352.]])
-        rlats = np.array([[-5., -0.], [-4., -1.]])
+        rlons = np.array([[350., 352., 354.], [350., 352., 354.]])
+        rlats = np.array([[-5., -0., 1.], [-4., -1., 0.]])
 
         src_proj = ccrs.RotatedGeodetic(pole_longitude=178.0,
                                         pole_latitude=38.0)
         target_proj = ccrs.Geodetic()
         res = target_proj.transform_points(x=rlons, y=rlats,
                                            src_crs=src_proj)
-
-        unrotated_lon, unrotated_lat, _ = res.transpose()
+        unrotated_lon = res[..., 0]
+        unrotated_lat = res[..., 1]
 
         # Solutions derived by proj4 direct.
-        solx = np.array([[-16.42176094, -14.85892262],
-                         [-16.71055023, -14.58434624]])
-        soly = np.array([[46.00724251, 51.29188893],
-                         [46.98728486, 50.30706042]])
-
+        solx = np.array([[-16.42176094, -14.85892262, -11.90627520],
+                         [-16.71055023, -14.58434624, -11.68799988]])
+        soly = np.array([[46.00724251, 51.29188893, 52.59101488],
+                         [46.98728486, 50.30706042, 51.60004528]])
         assert_arr_almost_eq(unrotated_lon, solx)
         assert_arr_almost_eq(unrotated_lat, soly)
 
@@ -108,8 +107,8 @@ class TestCRS(unittest.TestCase):
         target_proj = ccrs.Geodetic()
         res = target_proj.transform_points(x=rlons, y=rlats,
                                            src_crs=src_proj)
-
-        unrotated_lon, unrotated_lat, _ = res.transpose()
+        unrotated_lon = res[..., 0]
+        unrotated_lat = res[..., 1]
 
         # Solutions derived by proj4 direct.
         solx = np.array([-16.42176094, -14.85892262,


### PR DESCRIPTION
This fixes a bug in `CRS.transform_points` which corrupts the return shape for 2D arrays of points.

With the bug, supplying arrays with shape (40, 50) gives a result array with shape (50, 40, 3).

With this fix, supplying arrays with shape (40, 50) gives a result array with shape (40, 50, 3).
