### PR TITLE
Trying to build Cartopy on Windows 7 with 64 bit EPD 7.3

### DIFF
--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -23,6 +23,7 @@ the package wouldn't be as rich or diverse as it is today:
  * Carwyn Pelley
  * Andrew Dawson
  * Patrick Peglar
+ * Christoph Gohlke
 
 
 Thank you!

--- a/lib/cartopy/_trace.cpp
+++ b/lib/cartopy/_trace.cpp
@@ -24,6 +24,12 @@
 
 #include "_trace.h"
 
+#ifdef _MSC_VER
+#include <float.h>
+#define isnan _isnan
+#define isfinite _finite
+#endif
+
 
 Interpolator::~Interpolator(){}
 
@@ -89,7 +95,7 @@ void SphericalInterpolator::set_line(const Point &start, const Point &end)
     m_start = start;
     m_end = end;
 
-    if (start.x != end.x or start.y != end.y)
+    if (start.x != end.x || start.y != end.y)
     {
         double lon, lat;
         double t, x, y;
@@ -407,7 +413,7 @@ bool straightAndDomain(double t_start, const Point &p_start,
         }
         else
         {
-            valid = 0.0 < along and along < 1.0;
+            valid = 0.0 < along && along < 1.0;
             if (valid)
             {
                 double separation;
@@ -497,7 +503,7 @@ void bisect(double t_start, const Point &p_start, const Point &p_end,
         }
         else
         {
-            valid = (!isfinite(p_current.x)) or (!isfinite(p_current.y));
+            valid = (!isfinite(p_current.x)) || (!isfinite(p_current.y));
         }
 #ifdef DEBUG
         std::cerr << "   => valid: " << valid << std::endl;

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,20 @@ from distutils.sysconfig import get_config_var
 from distutils.util import convert_path
 import fnmatch
 import os
+import sys
 
 from Cython.Distutils import build_ext
 import numpy as np
+
+
+if sys.platform.startswith('win'):
+    def get_config_var(name):
+        return '.'
+    geos = 'geos'
+    extra_extension_args = {}
+else:
+    geos = 'geos_c'
+    extra_extension_args = dict(runtime_library_dirs=[get_config_var('LIBDIR')])
 
 
 def file_walk_relative(top, remove=''):
@@ -152,17 +163,17 @@ setup(
     # requires proj4 headers
     ext_modules=[
         Extension('cartopy.trace', ['lib/cartopy/trace.pyx', 'lib/cartopy/_trace.cpp'],
-                  include_dirs=[get_config_var('INCLUDEDIR')],
-                  libraries=['geos_c', 'proj'],
+                  include_dirs=[get_config_var('INCLUDEDIR'), './lib/cartopy'],
+                  libraries=[geos, 'proj'],
                   library_dirs=[get_config_var('LIBDIR')],
-                  runtime_library_dirs=[get_config_var('LIBDIR')],
                   language='c++',
+                  **extra_extension_args
                   ),
         Extension('cartopy._crs', ['lib/cartopy/_crs.pyx'],
                   include_dirs=[get_config_var('INCLUDEDIR'), np.get_include()],
                   libraries=['proj'],
                   library_dirs=[get_config_var('LIBDIR')],
-                  runtime_library_dirs=[get_config_var('LIBDIR')],
+                  **extra_extension_args
                   ),
     ],
 


### PR DESCRIPTION
Trying to build Caropy on Windows 7, with 64 bit EPD 7.3:

```
c:\Users\rsignell\Documents\GitHub\cartopy>python setup.py build
running build
running build_py
running build_ext
cythoning lib/cartopy/trace.pyx to lib/cartopy\trace.cpp
Traceback (most recent call last):
  File "setup.py", line 170, in <module>
    cmdclass={'build_ext': build_ext, 'header_check': HeaderCheck},
  File "C:\python27_epd64\lib\distutils\core.py", line 152, in setup
    dist.run_commands()
  File "C:\python27_epd64\lib\distutils\dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "C:\python27_epd64\lib\distutils\dist.py", line 972, in run_command
    cmd_obj.run()
  File "C:\python27_epd64\lib\distutils\command\build.py", line 127, in run
    self.run_command(cmd_name)
  File "C:\python27_epd64\lib\distutils\cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "C:\python27_epd64\lib\distutils\dist.py", line 972, in run_command
    cmd_obj.run()
  File "C:\python27_epd64\lib\site-packages\Cython\Distutils\build_ext.py", line
 163, in run
    _build_ext.build_ext.run(self)
  File "C:\python27_epd64\lib\distutils\command\build_ext.py", line 339, in run
    self.build_extensions()
  File "C:\python27_epd64\lib\site-packages\Cython\Distutils\build_ext.py", line
 170, in build_extensions
    ext.sources = self.cython_sources(ext.sources, ext)
  File "C:\python27_epd64\lib\site-packages\Cython\Distutils\build_ext.py", line
 317, in cython_sources
    full_module_name=module_name)
  File "C:\python27_epd64\lib\site-packages\Cython\Compiler\Main.py", line 646,
in compile
    return compile_single(source, options, full_module_name)
  File "C:\python27_epd64\lib\site-packages\Cython\Compiler\Main.py", line 591,
in compile_single
    return run_pipeline(source, options, full_module_name)
  File "C:\python27_epd64\lib\site-packages\Cython\Compiler\Main.py", line 483,
in run_pipeline
    err, enddata = Pipeline.run_pipeline(pipeline, source)
  File "C:\python27_epd64\lib\site-packages\Cython\Compiler\Pipeline.py", line 3
15, in run_pipeline
    data = phase(data)
  File "C:\python27_epd64\lib\site-packages\Cython\Compiler\Pipeline.py", line 3
1, in parse
    check_module_name = not Options.embed)
  File "C:\python27_epd64\lib\site-packages\Cython\Compiler\Main.py", line 151,
in find_module
    pxd_pathname = self.find_pxd_file(module_name, pos)
  File "C:\python27_epd64\lib\site-packages\Cython\Compiler\Main.py", line 185,
in find_pxd_file
    pxd = self.search_include_directories(qualified_name, ".pxd", pos, sys_path=
True)
  File "C:\python27_epd64\lib\site-packages\Cython\Compiler\Main.py", line 254,
in search_include_directories
    path = os.path.join(dir, dotted_filename)
  File "C:\python27_epd64\lib\ntpath.py", line 96, in join
    assert len(path) > 0
TypeError: object of type 'NoneType' has no len()

c:\Users\rsignell\Documents\GitHub\cartopy>
```
