### PR TITLE
BF - correct location of allow_rasterization.

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -25,6 +25,7 @@ import warnings
 import weakref
 
 import matplotlib
+import matplotlib.artist
 import matplotlib.axes
 from matplotlib.image import imread
 import matplotlib.transforms as mtransforms
@@ -258,7 +259,7 @@ class GeoAxes(matplotlib.axes.Axes):
         # XXX TODO: Needs working on
         self.img_factories.append([factory, args, kwargs])
 
-    @matplotlib.axes.allow_rasterization
+    @matplotlib.artist.allow_rasterization
     def draw(self, renderer=None, inframe=False):
         """
         Extends the standard behaviour of :func:`matplotlib.axes.Axes.draw`.


### PR DESCRIPTION
The code used the decorator `matplotlib.axes.allow_rasterization` which is part of the internal API of `matplotlib.axes` and has gone away since matplotlib/matplotlib#1931. The correct location to obtain this decorator is `matplotlib.artist.allow_rasterization`.
