### PR TITLE
Added __hash__ to Projection

### DIFF
--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -153,6 +153,10 @@ cdef class CRS:
                 result = self.proj4_init != other.proj4_init
         return result
 
+    def __hash__(self):
+        """Hashes the CRS based on its proj4_init string."""
+        return hash(self.proj4_init)
+
     def __reduce__(self):
         """
         Implements the __reduce__ API so that unpickling produces a stateless
@@ -175,10 +179,6 @@ cdef class CRS:
     # TODO
     #def __str__
     #def _geod(self): # to return the pyproj.Geod
-
-    def __hash__(self):
-        """Hashes the CRS based on its class and proj4_init string."""
-        return hash((type(self), self.proj4_init))
 
     def _as_mpl_transform(self, axes=None):
         """

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -86,15 +86,6 @@ class Projection(CRS):
         'MultiPolygon': '_project_multipolygon',
     }
 
-    def __eq__(self, other):
-        # XXX handle params that have been set to the default value on one,
-        # but not the other?
-        return (isinstance(self, type(other)) and
-                self.proj4_params == other.proj4_params)
-
-    def __ne__(self, other):
-        return not self == other
-
     @abstractproperty
     def boundary(self):
         pass
@@ -841,10 +832,13 @@ class LambertConformal(Projection):
         self._y_limits = bounds[1], bounds[3]
 
     def __eq__(self, other):
-        same = super(LambertConformal, self).__eq__(other)
-        if isinstance(other, LambertConformal) and hasattr(other, "cutoff"):
-            same = same and self.cutoff == other.cutoff
-        return same
+        res = super(LambertConformal, self).__eq__(other)
+        if hasattr(other, "cutoff"):
+            res = res and self.cutoff == other.cutoff
+        return res
+
+    def __hash__(self):
+        return hash((self.proj4_init, self.cutoff))
 
     @property
     def boundary(self):

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -34,7 +34,7 @@ class TestCRS(unittest.TestCase):
         north = ccrs.NorthPolarStereo()
         self.assertEqual(stereo, north)
         self.assertFalse(stereo != north)
-        self.assertNotEqual(hash(stereo), hash(north))
+        self.assertEqual(hash(stereo), hash(north))
 
         self.assertEqual(ccrs.Geodetic(), ccrs.Geodetic())
 


### PR DESCRIPTION
Under Python 3.3 if you define `__eq__` but no `__hash__` your object is unhashable by default. From the docs:

"A class that overrides `__eq__()` and does not define `__hash__()` will have its `__hash__()` implicitly set to None."

Projections need to be hashable for them to be used by matplotlib so I added a `__hash__`. Whilst I can now produce fantastic looking plots with coastlines under python 3.3 I get the following test failure:

``` ======================================================================
FAIL: test_hash (cartopy.tests.test_crs.TestCRS)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/edward.campbell/cartopy/lib/cartopy/tests/test_crs.py", line 37, in test_hash
    self.assertNotEqual(hash(stereo), hash(north))
AssertionError: 8249766656978016100 == 8249766656978016100
```

On closer examination `test_hash` demands that

``` python
stereo = ccrs.Stereographic(90)
north = ccrs.NorthPolarStereo()
self.assertEqual(stereo, north)
self.assertNotEqual(hash(stereo), hash(north))
```

This is in direct conflict with the requirement in the python docs:

"The only required property is that objects which compare equal have the same hash value"

This PR defines a `__hash__` methods for `cartopy.crs.Projection` and also **flips the logic in the test**. I suspect the existing hash behaviour was intentional so this change will break something.
