### PR TITLE
Caught case where the pcolormesh has masked pcolor values.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - yes | ./.travis_no_output sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
   - ./.travis_no_output sudo apt-get update
   - ./.travis_no_output sudo apt-get install libgeos-dev libproj-dev
-  - ./.travis_no_output sudo /usr/bin/pip install --use-mirrors shapely nose pyshp pep8
+  - ./.travis_no_output sudo /usr/bin/pip install --use-mirrors shapely nose pyshp pep8 mock
   # its always version 2 currently
   - if [[ $TRAVIS_PYTHON_VERSION == '2.'* ]]; then ./.travis_no_output sudo /usr/bin/pip install --use-mirrors PIL; fi
   # install cartopy in the .local directory (in lieu of using virtual env...)

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1109,17 +1109,19 @@ class GeoAxes(matplotlib.axes.Axes):
                         pcolor_data.mask = pcolor_data.mask | C_mask
 
                     pts = pts.reshape((Ny, Nx, 2))
-                    pcolor_col = self.pcolor(pts[..., 0], pts[..., 1],
-                                             pcolor_data, **kwargs)
-                    pcolor_col.set_cmap(cmap)
-                    pcolor_col.set_norm(norm)
-                    pcolor_col.set_clim(vmin, vmax)
-                    # scale the data according to the *original* data
-                    pcolor_col.norm.autoscale_None(C)
+                    if np.any(~pcolor_data.mask):
+                        pcolor_col = self.pcolor(pts[..., 0], pts[..., 1],
+                                                 pcolor_data, **kwargs)
+                        pcolor_col.set_cmap(cmap)
+                        pcolor_col.set_norm(norm)
+                        pcolor_col.set_clim(vmin, vmax)
+                        # scale the data according to the *original* data
+                        pcolor_col.norm.autoscale_None(C)
 
-                    # put the pcolor_col on the pcolormesh collection so that
-                    # if really necessary, users can do things post this method
-                    collection._wrapped_collection_fix = pcolor_col
+                        # put the pcolor_col on the pcolormesh collection so
+                        # that if really necessary, users can do things post
+                        # this method
+                        collection._wrapped_collection_fix = pcolor_col
 
         return collection
 

--- a/lib/cartopy/tests/mpl/test_pseudo_color.py
+++ b/lib/cartopy/tests/mpl/test_pseudo_color.py
@@ -1,0 +1,51 @@
+# (C) British Crown Copyright 2013, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <http://www.gnu.org/licenses/>.
+
+import matplotlib.pyplot as plt
+import mock
+from nose.tools import assert_equal
+import numpy as np
+
+import cartopy.crs as ccrs
+
+
+def test_pcolormesh_fully_masked():
+    data = np.ma.masked_all((30, 40))
+
+    # Check that a fully masked data array doesn't trigger a pcolor call.
+    with mock.patch('cartopy.mpl.geoaxes.GeoAxes.pcolor') as pcolor:
+        ax = plt.axes(projection=ccrs.PlateCarree())
+        ax.pcolormesh(np.linspace(-90, 90, 40), np.linspace(0, 360, 30), data)
+        assert_equal(pcolor.call_count, 0, ("pcolor shouldn't have been "
+                                            "called, but was."))
+
+
+def test_pcolormesh_partially_masked():
+    data = np.ma.masked_all((30, 40))
+    data[0:100] = 10
+
+    # Check that a partially masked data array does trigger a pcolor call.
+    with mock.patch('cartopy.mpl.geoaxes.GeoAxes.pcolor') as pcolor:
+        ax = plt.axes(projection=ccrs.PlateCarree())
+        ax.pcolormesh(np.linspace(-90, 90, 40), np.linspace(0, 360, 30), data)
+        assert_equal(pcolor.call_count, 1, ("pcolor should have been "
+                                            "called exactly once."))
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(argv=['-sv', '--with-doctest'], exit=False)


### PR DESCRIPTION
There is a bug in matplotlib which restricts pcolor plots to data arrays which have at least one non-masked value (https://github.com/matplotlib/matplotlib/pull/2336). This is a problem for cartopy when it tries to handle a warped pcolormesh, as inbetween the wrapping, it draws a pcolor. This change adds a check to ensure that a pcolor being drawn actually contains non-masked data, otherwise it just skips the step.

```
import cartopy.crs as ccrs
import matplotlib.pyplot as plt
import numpy as np

import numpy.random

data = np.ma.masked_all((30, 40))

plt.axes(projection=ccrs.PlateCarree())
plt.pcolormesh(np.linspace(-90, 90, 40), np.linspace(0, 360, 30), data)
plt.show()
```
