### PR TITLE
test image permission

### DIFF
--- a/lib/cartopy/tests/mpl/__init__.py
+++ b/lib/cartopy/tests/mpl/__init__.py
@@ -79,7 +79,7 @@ class ImageTesting(object):
                           'issue.')
         else:
             image_output_directory = os.path.join(os.getcwd(),
-                                              'cartopy_test_output')
+                                                  'cartopy_test_output')
 
     def __init__(self, img_names, tolerance=1e-3):
         self.img_names = img_names


### PR DESCRIPTION
This change returns an error message if the stated directory in the tests and the current directory are both unable to be written to during image creation for testing
