### PR TITLE
BUG: Broken cartopy img_transform masks

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2013, Met Office
+# (C) British Crown Copyright 2011 - 2014, Met Office
 #
 # This file is part of cartopy.
 #
@@ -765,6 +765,7 @@ class GeoAxes(matplotlib.axes.Axes):
                                      target_proj=self.projection,
                                      target_res=regrid_shape,
                                      target_extent=target_extent,
+                                     mask_extrapolated=True,
                                      )
 
             # As a workaround to a matplotlib limitation, turn any images

--- a/lib/cartopy/tests/test_img_transform.py
+++ b/lib/cartopy/tests/test_img_transform.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013, Met Office
+# (C) British Crown Copyright 2014, Met Office
 #
 # This file is part of cartopy.
 #
@@ -21,7 +21,9 @@ import cartopy.img_transform as img_trans
 import cartopy.crs as ccrs
 
 
-def test_griding_data():
+def test_griding_data_std_range():
+    # Data which exists inside the standard projection bounds i.e.
+    # [-180, 180].
     target_prj = ccrs.PlateCarree()
     # create 3 data points
     lats = np.array([45, 20, -45])
@@ -32,7 +34,8 @@ def test_griding_data():
     target_x, target_y, extent = img_trans.mesh_projection(target_prj, 8, 4)
 
     image = img_trans.regrid(data, lons, lats, data_trans, target_prj,
-                             target_x, target_y)
+                             target_x, target_y,
+                             mask_extrapolated=True)
 
     # The expected image. n.b. on a map the data is reversed in the y axis.
     expected = np.array([[3., 3., 3., 3., 3., 3., 3., 3.],
@@ -40,8 +43,49 @@ def test_griding_data():
                          [1., 1., 1., 1., 2., 2., 2., 2.],
                          [1., 1., 1., 1., 1., 2., 2., 1.]], dtype=np.float64)
 
+    expected_mask = np.array(
+        [[True, True, True, True, True, True, True, True],
+         [True, True, False, False, False, False, True, True],
+         [True, True, False, False, False, False, True, True],
+         [True, True, True, True, True, True, True, True]])
+
     assert_array_equal([-180,  180,  -90,   90], extent)
     assert_array_equal(expected, image)
+    assert_array_equal(expected_mask, image.mask)
+
+
+def test_griding_data_outside_projection():
+    # Data which exists outside the standard projection e.g. [0, 360] rather
+    # than [-180, 180].
+    target_prj = ccrs.PlateCarree()
+    # create 3 data points
+    lats = np.array([45, 20, -45])
+    lons = np.array([60, 180, 300])
+    data = np.array([1, 2, 3])
+    data_trans = ccrs.Geodetic()
+
+    target_x, target_y, extent = img_trans.mesh_projection(target_prj, 8, 4)
+
+    image = img_trans.regrid(data, lons, lats, data_trans, target_prj,
+                             target_x, target_y,
+                             mask_extrapolated=True)
+
+    # The expected image. n.b. on a map the data is reversed in the y axis.
+    expected = np.array(
+        [[3, 3, 3, 3, 3, 3, 3, 3],
+         [2, 3, 3, 3, 3, 1, 2, 2],
+         [2, 2, 3, 1, 1, 1, 1, 2],
+         [2, 2, 1, 1, 1, 1, 1, 2]], dtype=np.float64)
+
+    expected_mask = np.array(
+        [[True, True, True, True, True, True, True, True],
+         [False, False, False, True, True, False, False, False],
+         [False, False, False, True, True, False, False, False],
+         [True, True, True, True, True, True, True, True]])
+
+    assert_array_equal([-180,  180,  -90,   90], extent)
+    assert_array_equal(expected, image)
+    assert_array_equal(expected_mask, image.mask)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Putting this PR up here as I have not managed to finish the fixes for the bugs I found before Christmas.

Relates to changes made in https://github.com/SciTools/cartopy/pull/370
(specifically commit https://github.com/SciTools/cartopy/commit/02e764c511b72abfc50a6273c688b9bf65ec9316)

**Two bugs:**
**1.** Mask array operations which are unsuitable for the case when `dat.mask = False`
`TypeError: 'numpy.bool_' object does not support item assignment`

Should instead be indexing the array itself and assigning a np.ma.masked value to these indexes.
i.e. `dat[index] = np.ma.masked` to mask these indexes.

**2.** The rectangle specified is unsuitable for the general case of determining which target points fall outside the source domain.

``` Python
outside_source_domain = ((target_in_source_x < source_x_coords.min()) |
    (target_in_source_x > source_x_coords.max()) |
    (target_in_source_y < source_y_coords.min()) |
    (target_in_source_y > source_y_coords.max()))
```

This issue reveals itself when running one of the iris tests which has data on the range [0, 360] rather than [-180, 180].

These bugs currently don't allow iris to work with cartopy master.
