### PR TITLE
BLD: Travis scipy update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,13 @@ python:
   - 2.7
 
 install:
+# add repo
+# access to scipy 0.12.0 https://launchpad.net/~pylab/+archive/stable
+# access to numpy 1.7.0b2 https://launchpad.net/~tukss/+archive/ppa
+  - sudo add-apt-repository -y ppa:pylab/stable
+  - sudo add-apt-repository -y ppa:tukss/ppa
+  - ./.travis_no_output sudo apt-get update
+
   - ./.travis_no_output sudo apt-get install python-scipy python-pip cython
   - ./.travis_no_output sudo /usr/bin/pip install https://downloads.sourceforge.net/project/matplotlib/matplotlib/matplotlib-1.3.1/matplotlib-1.3.1.tar.gz
   # http://www.webupd8.org/2010/10/fix-nopubkey-error-for-extras-ubuntu.html


### PR DESCRIPTION
Use scipy from an unofficial ppa so that we can use v0.12.0 rather than
what's available in ubuntu 12.04 (v0.9.0).

Use numpy from an unofficial ppa so that we can use v1.7.0b2

Reference:
https://github.com/SciTools/iris/pull/960
