### PR TITLE
mbtiles

### DIFF
--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -334,3 +334,32 @@ def _merge_tiles(tiles):
         img[img_slice] = tile_img
 
     return img, [min(xs), max(xs), min(ys), max(ys)], 'lower'
+
+
+class MBTiles(GoogleTiles):
+    ''' Retrieve tile data from MBTiles sqlite database instead of a url '''
+    def __init__(self, tile_db):
+        self.tile_db = tile_db
+        GoogleTiles.__init__(self)
+
+    def get_image(self, tile):
+        import cStringIO
+        import sqlite3
+
+        x, y, z = tile
+        sql_select = ('select zoom_level, tile_column, tile_row, tile_data' +
+            ' from tiles')
+        sql_where = 'where zoom_level=%s and tile_column=%s and tile_row=%s;' \
+            % (z, x, y)
+        con = sqlite3.connect(self.tile_db)
+        tiles = con.execute(sql_select + ' ' + sql_where)
+        tile_from_db = tiles.fetchone()
+
+        try:
+            im_data = tile_from_db[3]
+        except TypeError:
+            raise TypeError('No image data available for requested tile')
+
+        img = Image.open(cStringIO.StringIO(im_data))
+        img = img.convert(self.desired_tile_form)
+        return img, self.tileextent(tile), 'lower'

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -347,6 +347,7 @@ class MBTiles(GoogleTiles):
         import sqlite3
 
         x, y, z = tile
+        y = (1 << z) - y - 1
         sql_select = ('select zoom_level, tile_column, tile_row, tile_data' +
             ' from tiles')
         sql_where = 'where zoom_level=%s and tile_column=%s and tile_row=%s;' \

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -116,6 +116,15 @@ def test_image_for_domain():
                        [11.25, 61.60639637]])
 
 
+def test_tile_find_images():
+    gt = cimgt.GoogleTiles()
+    # test the find_images method on a Tile instance.
+    target_domain = sgeom.box(-10, 60, 10, 70)
+
+    assert_equal([(7, 4, 4), (7, 5, 4), (8, 4, 4), (8, 5, 4)],
+                 list(gt.find_images(target_domain, 4)))
+
+
 def test_quadtree_wts():
     qt = cimgt.QuadtreeTiles()
 


### PR DESCRIPTION
This PR contains code I received from @iedwards for plotting map backgrounds from an mbtiles database. The source data is a [6GB mbtiles database] (https://drive.google.com/file/d/0B1nV2W9moCwwaFpsZzVxZ1lqOGs/edit?usp=sharing) created by a colleague, so I'll just include an image of the output:

![mblatlon](https://f.cloud.github.com/assets/2048530/2049287/7c7b488e-8a5d-11e3-8a47-5081f2ee6e7f.png)

The code to produce this plot:
```

import matplotlib.pyplot as plt
import cartopy.crs as ccrs
from cartopy.io import img_tiles

plt.figure(figsize=(14,12))

tiles = img_tiles.MBTiles('open-streetsz11.mbtiles')
# tiles = img_tiles.OSM()

ax = plt.subplot(311, projection=ccrs.Mercator(), title="Level 9")
ax.set_extent([-4.6, -2.6, 50.35, 50.65])
ax.add_image(tiles, 9)
ax.coastlines("10m")

ax = plt.subplot(312, projection=ccrs.Mercator(), title="Level 10")
ax.set_extent([-4.2, -3.0, 50.4, 50.6])
ax.add_image(tiles, 10)

ax = plt.subplot(313, projection=ccrs.Mercator(), title="Level 11")
ax.set_extent([-3.9, -3.3, 50.45, 50.55])
ax.add_image(tiles, 11)

plt.show()
```