### PR TITLE
Utility function to add cyclic points.

### DIFF
--- a/lib/cartopy/tests/test_util.py
+++ b/lib/cartopy/tests/test_util.py
@@ -1,0 +1,75 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <http://www.gnu.org/licenses/>.
+from nose.tools import raises
+import numpy as np
+import numpy.ma as ma
+from numpy.testing import assert_array_equal
+
+from cartopy.util import add_cyclic_point
+
+
+class Test_add_cyclic_point(object):
+
+    @classmethod
+    def setup_class(cls):
+        cls.lons = np.arange(0, 360, 60)
+        cls.data2d = np.ones([3, 6]) * np.arange(6)
+        cls.data4d = np.ones([4, 6, 2, 3]) * \
+            np.arange(6)[..., np.newaxis, np.newaxis]
+
+    def test_data_only(self):
+        c_data = add_cyclic_point(self.data2d)
+        r_data = np.concatenate((self.data2d, self.data2d[:, :1]), axis=1)
+        assert_array_equal(c_data, r_data)
+
+    def test_data_and_coord(self):
+        c_data, c_lons = add_cyclic_point(self.data2d, coord=self.lons)
+        r_data = np.concatenate((self.data2d, self.data2d[:, :1]), axis=1)
+        r_lons = np.concatenate((self.lons, np.array([360.])))
+        assert_array_equal(c_data, r_data)
+        assert_array_equal(c_lons, r_lons)
+
+    def test_data_only_with_axis(self):
+        c_data = add_cyclic_point(self.data4d, axis=1)
+        r_data = np.concatenate((self.data4d, self.data4d[:, :1]), axis=1)
+        assert_array_equal(c_data, r_data)
+
+    def test_data_and_coord_with_axis(self):
+        c_data, c_lons = add_cyclic_point(self.data4d, coord=self.lons, axis=1)
+        r_data = np.concatenate((self.data4d, self.data4d[:, :1]), axis=1)
+        r_lons = np.concatenate((self.lons, np.array([360.])))
+        assert_array_equal(c_data, r_data)
+        assert_array_equal(c_lons, r_lons)
+
+    def test_masked_data(self):
+        new_data = ma.masked_less(self.data2d, 3)
+        c_data = add_cyclic_point(new_data)
+        r_data = ma.concatenate((self.data2d, self.data2d[:, :1]), axis=1)
+        assert_array_equal(c_data, r_data)
+
+    @raises(ValueError)
+    def test_invalid_coord_dimensionality(self):
+        lons2d = np.repeat(self.lons[np.newaxis], 3, axis=0)
+        c_data, c_lons = add_cyclic_point(self.data2d, coord=lons2d)
+
+    @raises(ValueError)
+    def test_invalid_coord_size(self):
+        c_data, c_lons = add_cyclic_point(self.data2d, coord=self.lons[:-1])
+
+    @raises(ValueError)
+    def test_invalid_axis(self):
+        c_data = add_cyclic_point(self.data2d, axis=-3)

--- a/lib/cartopy/util.py
+++ b/lib/cartopy/util.py
@@ -1,0 +1,109 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <http://www.gnu.org/licenses/>.
+"""
+This module contains utilities that are useful in conjunction with
+cartopy.
+
+"""
+import numpy as np
+import numpy.ma as ma
+
+
+def add_cyclic_point(data, coord=None, axis=-1):
+    """
+    Add a cyclic point to an array and optionally a corresponding
+    coordinate.
+
+    Args:
+
+    * data:
+        An n-dimensional array of data to add a cyclic point to.
+
+    Kwargs:
+
+    * coord:
+        A 1-dimensional array which specifies the coordinate values for
+        the dimension the cyclic point is to be added to. The coordinate
+        values must be regularly spaced.
+
+    * axis:
+        Specifies the axis of the data array to add the cyclic point to.
+        Defaults to the right-most axis.
+
+    Returns:
+
+    * cyclic_data:
+        The data array with a cyclic point added.
+
+    * cyclic_coord:
+        The coordinate with a cyclic point, only returned if the coord
+        keyword was supplied.
+
+    Examples:
+
+    Adding a cyclic point to a data array, where the cyclic dimension is
+    the right-most dimension
+
+    >>> import numpy as np
+    >>> data = np.ones([5, 6]) * np.arange(6)
+    >>> cyclic_data = add_cyclic_point(data)
+    >>> print cyclic_data
+    [[ 0.  1.  2.  3.  4.  5.  0.]
+     [ 0.  1.  2.  3.  4.  5.  0.]
+     [ 0.  1.  2.  3.  4.  5.  0.]
+     [ 0.  1.  2.  3.  4.  5.  0.]
+     [ 0.  1.  2.  3.  4.  5.  0.]]
+
+    Adding a cyclic point to a data array and an associated coordinate
+
+    >>> lons = np.arange(0, 360, 60)
+    >>> cyclic_data, cyclic_lons = add_cyclic_point(data, coord=lons)
+    >>> print cyclic_data
+    [[ 0.  1.  2.  3.  4.  5.  0.]
+     [ 0.  1.  2.  3.  4.  5.  0.]
+     [ 0.  1.  2.  3.  4.  5.  0.]
+     [ 0.  1.  2.  3.  4.  5.  0.]
+     [ 0.  1.  2.  3.  4.  5.  0.]]
+    >>> print cyclic_lons
+    [  0  60 120 180 240 300 360]
+
+    """
+    if coord is not None:
+        if coord.ndim != 1:
+            raise ValueError('The coordinate must be 1-dimensional.')
+        if len(coord) != data.shape[axis]:
+            raise ValueError('The length of the coordinate does not match '
+                             'the size of the corresponding dimension of '
+                             'the data array: len(coord) = {}, '
+                             'data.shape[{}] = {}.'.format(
+                                 len(coord), axis, data.shape[axis]))
+        delta_coord = np.diff(coord)
+        if not np.allclose(delta_coord, delta_coord[0]):
+            raise ValueError('The coordinate must be equally spaced.')
+        new_coord = ma.concatenate((coord, coord[-1:] + delta_coord[0]))
+    slicer = [slice(None)] * data.ndim
+    try:
+        slicer[axis] = slice(0, 1)
+    except IndexError:
+        raise ValueError('The specified axis does not correspond to an '
+                         'array dimension.')
+    new_data = ma.concatenate((data, data[slicer]), axis=axis)
+    if coord is None:
+        return_value = new_data
+    else:
+        return_value = new_data, new_coord
+    return return_value


### PR DESCRIPTION
This PR introduces a new function to add cyclic points to data arrays and coordinates, addressing issue #393.

I went for an API that allows the coordinate to be optional, thus making it easy to apply to multiple arrays separately, and I feel this means the function itself need not accept more than one array at a time. Supporting multiple array inputs would mean either making assumptions about the similarity of the input arrays, or lots of explicit checking, which would complicate an otherwise straightforward approach.

Masked arrays are handled by using `numpy.ma.concatenate` throughout, which does the correct thing for both masked and unmasked arrays.
