### PR TITLE
Added __getstate__ attr to cartopy.io.img_nest.Img class

### DIFF
--- a/lib/cartopy/io/img_nest.py
+++ b/lib/cartopy/io/img_nest.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2013, Met Office
+# (C) British Crown Copyright 2011 - 2014, Met Office
 #
 # This file is part of cartopy.
 #
@@ -72,10 +72,8 @@ class Img(collections.namedtuple('Img', _img_class_attrs)):
 
     def __getstate__(self):
         """
-        Force the state of the instance to equal it's __dict__ method.
-
-        When pickling, this ensures that any new attributes introduced to the
-        class are included in the pickled object.
+        Override the default to ensure when pickling that any new attributes
+        introduced are included in the pickled object.
 
         """
         return self.__dict__

--- a/lib/cartopy/tests/test_img_nest.py
+++ b/lib/cartopy/tests/test_img_nest.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2013, Met Office
+# (C) British Crown Copyright 2011 - 2014, Met Office
 #
 # This file is part of cartopy.
 #
@@ -297,11 +297,14 @@ def test_nest():
     assert_equal(nest_z0_z1._ancestry,
                  nest_z0_z1_from_pickle._ancestry)
 
-    # Check that __getattr__ for Img is working correctly.
-    target = sgeom.box(0, 0, 10000, 10000)
-    gen = nest_z0_z1.find_images(target, 'aerial z0 test')
-    img = gen.next()[1]  # Generator returns tuple: (z, Img)
-    assert_equal(hasattr(img, '_bbox'), True)
+
+def test_img_pickle_round_trip():
+    """Check that __getstate__ for Img instances is working correctly."""
+
+    img = cimg_nest.Img('imaginary file', (0, 1, 2, 3), 'lower', (1, 2))
+    img_from_pickle = pickle.loads(pickle.dumps(img))
+    assert_equal(img, img_from_pickle)
+    assert_equal(hasattr(img_from_pickle, '_bbox'), True)
 
 
 def requires_wmts_data(function):


### PR DESCRIPTION
This adds a `__getstate__` attribute to `cartopy.io.img_nest.Img` to ensure pickling of such objects functions correctly. By default pickle does not pick up non-default attributes that are added to an object, such as `_bbox` that is added to `Img` by its `__init__`.

This can be demonstrated with the following example:

``` python
class NT(namedtuple('NT', 'foo')):
    def __init__(self, *args):
        self._bar = None


class NT2(namedtuple('NT2', 'foo')):
    def __init__(self, *args):
        self._bar = None
    def __getstate__(self):
        return self.__dict__


>>> t = NT(5)
>>> print t._bar
None
>>> u = pickle.loads(pickle.dumps(t))
>>> print u._bar
AttributeError: 'NT' object has no attribute '_bar'

>>> t2 = NT2(5)
>>> print t2._bar
None
>>> u2 = pickle.loads(pickle.dumps(t2))
print u2._bar
None
```

See http://docs.python.org/2/library/pickle.html?highlight=pickle#object.__getstate__.
