### PR TITLE
Add `GeoAxes.add_wmts()`.

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1545,6 +1545,8 @@ class GeoAxes(matplotlib.axes.Axes):
         Add images from the specified WMTS layer to cover the current or
         specified extent.
 
+        This function requires owslib to work.
+
         Args:
 
             * wmts - The URL of the WMTS, or an


### PR DESCRIPTION
Simple, proof-of-concept implementation of WMTS support on a GeoAxes.

Open issues (some perhaps out of scope):
- The API (i.e. `GeoAxes.add_wmts()`) and how it relates to the existing API (e.g. `GeoAxes.add_feature()`) and future WxS integration.
- Thin seams sometimes visible between tiles.
- Does not respect limits of layers which only provide a subset of tiles (via. TileMatrixLimits).
- Coping with CRSs with YX axis order, such as EPSG 4326 (lat-lon).

Also:
- Not an interactive implementation - it will not request more tiles as you zoom in on an interactive plot.

See #405.
