### PR TITLE
Clear image accumulator to avoid ghosting.

### DIFF
--- a/lib/cartopy/mpl/ogc_artist.py
+++ b/lib/cartopy/mpl/ogc_artist.py
@@ -247,7 +247,7 @@ class WMTSArtist(matplotlib.artist.Artist):
                     image_cache[img_key] = img
                 if big_img is None:
                     size = (img.size[0] * n_cols, img.size[1] * n_rows)
-                    big_img = self._pil_image.new('RGBA', size, None)
+                    big_img = self._pil_image.new('RGBA', size, (0, 0, 0, 0))
                 top = (row - min_row) * tile_matrix.tileheight
                 left = (col - min_col) * tile_matrix.tilewidth
                 big_img.paste(img, (left, top))


### PR DESCRIPTION
Currently the `big_img` isn't cleared before use, so if some of the sources tiles don't exist you can end up with uninitialised data in the final image.

This PR clears `big_img` to fully transparent before use.
