### PR TITLE
Make a map from an EPSG code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,9 @@ install:
   - yes | ./.travis_no_output sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
   - ./.travis_no_output sudo apt-get update
   - ./.travis_no_output sudo apt-get install libgeos-dev libproj-dev
-  - ./.travis_no_output sudo /usr/bin/pip install --use-mirrors shapely nose pyshp mock
-  - ./.travis_no_output sudo /usr/bin/pip install pep8==1.4.5 owslib six
+  - ./.travis_no_output sudo /usr/bin/pip install --use-mirrors shapely nose
+  - ./.travis_no_output sudo /usr/bin/pip install --use-mirrors pyshp mock
+  - ./.travis_no_output sudo /usr/bin/pip install pep8==1.4.5 owslib six pyepsg
   # its always version 2 currently
   - ./.travis_no_output sudo /usr/bin/pip install --use-mirrors pillow
   # install cartopy in the .local directory (in lieu of using virtual env...)

--- a/lib/cartopy/_epsg.py
+++ b/lib/cartopy/_epsg.py
@@ -1,0 +1,96 @@
+# (C) British Crown Copyright 2014, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Provides support for converting EPSG codes to Projection instances.
+
+"""
+import cartopy.crs as ccrs
+import numpy as np
+import pyepsg
+import shapely.geometry as sgeom
+
+
+_GLOBE_PARAMS = {'datum': 'datum',
+                 'ellps': 'ellipse',
+                 'a': 'semimajor_axis',
+                 'b': 'semiminor_axis',
+                 'f': 'flattening',
+                 'rf': 'inverse_flattening',
+                 'towgs84': 'towgs84',
+                 'nadgrids': 'nadgrids'}
+
+
+class _EPSGProjection(ccrs.Projection):
+    def __init__(self, code):
+        projection = pyepsg.get(code)
+        if not isinstance(projection, pyepsg.ProjectedCRS):
+            raise ValueError('EPSG code does not define a projection')
+
+        self.epsg_code = code
+
+        proj4_str = projection.as_proj4().strip()
+        terms = [term.strip('+').split('=') for term in proj4_str.split(' ')]
+        globe_terms = filter(lambda term: term[0] in _GLOBE_PARAMS, terms)
+        globe = ccrs.Globe(**{_GLOBE_PARAMS[name]: value for name, value in
+                              globe_terms})
+        other_terms = []
+        for term in terms:
+            if term[0] not in _GLOBE_PARAMS:
+                if len(term) == 1:
+                    other_terms.append([term[0], None])
+                else:
+                    other_terms.append(term)
+        super(_EPSGProjection, self).__init__(other_terms, globe)
+
+        # Convert lat/lon bounds to projected bounds.
+        # GML defines gmd:EX_GeographicBoundingBox as:
+        #   Geographic area of the entire dataset referenced to WGS 84
+        # NB. We can't use a polygon transform at this stage because
+        # that relies on the existence of the map boundary... the very
+        # thing we're trying to work out! ;-)
+        x0, x1, y0, y1 = projection.domain_of_validity()
+        geodetic = ccrs.Geodetic()
+        lons = np.array([x0, x0, x1, x1])
+        lats = np.array([y0, y1, y1, y0])
+        points = self.transform_points(geodetic, lons, lats)
+        x = points[:, 0]
+        y = points[:, 1]
+        self.bounds = (x.min(), x.max(), y.min(), y.max())
+
+    def __repr__(self):
+        return '_EPSGProjection({})'.format(self.epsg_code)
+
+    @property
+    def boundary(self):
+        x0, x1, y0, y1 = self.bounds
+        return sgeom.LineString([(x0, y0), (x0, y1), (x1, y1), (x1, y0),
+                                 (x0, y0)])
+
+    @property
+    def x_limits(self):
+        x0, x1, y0, y1 = self.bounds
+        return (x0, x1)
+
+    @property
+    def y_limits(self):
+        x0, x1, y0, y1 = self.bounds
+        return (y0, y1)
+
+    @property
+    def threshold(self):
+        x0, x1, y0, y1 = self.bounds
+        return min(x1 - x0, y1 - y0) / 100.

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1411,3 +1411,20 @@ def _find_gt(a, x):
         if v.distance > x:
             return v
     return a[0]
+
+
+def epsg(code):
+    """
+    Return the projection which corresponds to the given EPSG code.
+
+    The EPSG code must correspond to a "projected coordinate system",
+    so EPSG codes such as 4326 (WGS-84) which define a "geodetic coordinate
+    system" will not work.
+
+    .. note::
+        The conversion is performed by querying http://epsg.io/ so a
+        live internet connection is required.
+
+    """
+    import cartopy._epsg
+    return cartopy._epsg._EPSGProjection(code)


### PR DESCRIPTION
This is one route to enabling [EPSG codes](http://www.epsg.org/) to automatically create the appropriate definitions in Cartopy. It defines a generic `Projection` subclass which is parameterised by proj.4 init string and area of validity.

NB. It makes use of http://epsg.io/ to obtain run-time dynamic definitions of EPSG codes in terms of proj.4 strings and the area of validity. Access to this website is defered to a spin-off package: [pyepsg](https://pypi.python.org/pypi/pyepsg).

---

An alternative (or follow-up) to this route would be to add the concept of a "Map". A `Projection` would then just have:
- the numerical transformation,
- the boundary set to the maximum range of coordinates over which the transform is defined.

A `Map` would restrict the boundary of a `Projection` (and possibly a `CRS`) to a particular region of interest.

We could then define translations from proj.4 init strings and projections (and vice versa), and from EPSG coordinate systems to maps.

NB. In this model the `OSGB` class would cease to be a `Projection` and instead would be a `Map`.
