### PR TITLE
DOC: Fixed whatsnew references

### DIFF
--- a/docs/source/cartopy/crs.rst
+++ b/docs/source/cartopy/crs.rst
@@ -1,1 +1,0 @@
-.. autofunction:: cartopy.crs.epsg

--- a/docs/source/cartopy/io/img_tiles.rst
+++ b/docs/source/cartopy/io/img_tiles.rst
@@ -1,2 +1,26 @@
-.. automodule:: cartopy.io.img_tiles
-    :members:
+Accessing web-based image tiles
+===============================
+
+.. autoclass:: cartopy.io.img_tiles.GoogleTiles
+
+   .. automethod:: __init__
+
+.. autoclass:: cartopy.io.img_tiles.MapQuestOSM
+
+   .. automethod:: __init__
+
+.. autoclass:: cartopy.io.img_tiles.MapQuestOpenAerial
+
+   .. automethod:: __init__
+
+.. autoclass:: cartopy.io.img_tiles.OSM
+
+   .. automethod:: __init__
+
+.. autoclass:: cartopy.io.img_tiles.StamenTerrain
+
+   .. automethod:: __init__
+
+.. autoclass:: cartopy.io.img_tiles.QuadtreeTiles
+
+   .. automethod:: __init__

--- a/docs/source/cartopy/io/ogc_clients.rst
+++ b/docs/source/cartopy/io/ogc_clients.rst
@@ -1,2 +1,5 @@
+RasterSources and accessing WMS and WMTS
+========================================
+
 .. automodule:: cartopy.io.ogc_clients
     :members:

--- a/docs/source/cartopy/io/srtm.rst
+++ b/docs/source/cartopy/io/srtm.rst
@@ -1,2 +1,0 @@
-.. automodule:: cartopy.io.srtm
-    :members:

--- a/docs/source/cartopy/util/util.rst
+++ b/docs/source/cartopy/util/util.rst
@@ -1,2 +1,5 @@
+Miscellaneous cartopy utilities
+===============================
+
 .. automodule:: cartopy.util
     :members:

--- a/docs/source/crs/index.rst
+++ b/docs/source/crs/index.rst
@@ -39,3 +39,7 @@ coordinate reference systems which are 3 dimensional and could not be drawn dire
 .. autoclass:: cartopy.crs.Geocentric(globe=None)
 
 .. autoclass:: cartopy.crs.RotatedGeodetic
+
+There is also a function for calling epsg.io with a specified code, returning the corresponding cartopy projection, see below.
+
+.. autofunction:: cartopy.crs.epsg

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -15,11 +15,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with cartopy.  If not, see <http://www.gnu.org/licenses/>.
 
-
 """
 Implements image tile identification and fetching from various sources.
 
-Tile generation is explicitly not yet implemented.
+
+The matplotlib interface can make use of tile objects (defined below) via the
+:meth:`cartopy.mpl.geoaxes.GeoAxes.add_image` method. For example, to add a
+MapQuest open aeriel tileset to an axes at zoom level 2, do
+``ax.add_image(MapQuestAeriel(), 2)``. An example of using tiles in this way
+can be found at :ref:`example-eyja_volcano`.
 
 """
 from __future__ import division

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -18,6 +18,14 @@
 Implements RasterSource classes which can retrieve imagery from web services
 such as WMS and WMTS.
 
+The matplotlib interface can make use of RasterSources via the
+:meth:`cartopy.mpl.geoaxes.GeoAxes.add_raster` method,
+with additional specific methods which make use of this for WMS and WMTS
+(:meth:`~cartopy.mpl.geoaxes.GeoAxes.add_wms` and
+:meth:`~cartopy.mpl.geoaxes.GeoAxes.add_wmts`). An example of using WMTS in
+this way can be found at :ref:`examples-wmts`.
+
+
 """
 from __future__ import absolute_import, division
 

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -52,7 +52,7 @@ def GOOGLE_IMAGE_URL_REPLACEMENT(self, tile):
 
 def test_google_tile_styles():
     """
-    Tests that settings the Google Maps tile style works as expected.
+    Tests that setting the Google Maps tile style works as expected.
 
     This is essentially just assures information is properly propagated through
     the class structure.


### PR DESCRIPTION
Interim solution to https://github.com/SciTools/cartopy/pull/431, fixing the references made within the 0.11.0 whatsnew.
