### PR TITLE
fix Img.world_files

### DIFF
--- a/lib/cartopy/io/img_nest.py
+++ b/lib/cartopy/io/img_nest.py
@@ -152,7 +152,7 @@ class Img(collections.namedtuple('Img', _img_class_attrs)):
                 result = os.path.join(dirname, result)
             return result
 
-        result.extend(map(_convert_basename, result))
+        result += [_convert_basename(r) for r in result]
         return result
 
     def __array__(self):


### PR DESCRIPTION
While looking at travis testing on Python 3, I was experiencing a hang on a doctest. What's strange is that I could have sworn tests would complete (and fail) under Python 3.4 before.

**Commit message**

testing under Python 3, the doctest hangs because of the `map` usage

(`map` returns a lazy "map object", and extending it's argument with its result
is a problem)

this was missed in the recent partial Python3 port

using a list comprehension seems nicer than forcing the map object to evaluate
with

``` python
list(map(_convert_basename, result))
```
