### PR TITLE
Allow for very minor source/rendering differences.

### DIFF
--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -39,7 +39,7 @@ REGIONAL_IMG = os.path.join(config['repo_data_dir'], 'raster', 'sample',
                             'Miriam.A2012270.2050.2km.jpg')
 
 
-@ImageTesting(['web_tiles'])
+@ImageTesting(['web_tiles'], tolerance=0.5)
 def test_web_tiles():
     extent = [-15, 0.1, 50, 60]
     target_domain = shapely.geometry.Polygon([[extent[0], extent[1]],


### PR DESCRIPTION
An example diff image that the new tolerance just about lets pass:
![result-web_tiles-failed-diff](https://cloud.githubusercontent.com/assets/917914/3410602/8e02949a-fde9-11e3-9df8-c8045e56e480.png)
