### PR TITLE
Download script additions

### DIFF
--- a/tools/download.py
+++ b/tools/download.py
@@ -40,7 +40,7 @@ ALL_SCALES = ('110m', '50m', '10m')
 FEATURE_DEFN_GROUPS = {
     # Only need one GSHHS resolution because they *all* get downloaded
     # from one file.
-    'gshhs': GSHHSFeature(scale='c'),
+    'gshhs': GSHHSFeature(scale='f'),
     'physical': (
         ('physical', 'coastline', ALL_SCALES),
         ('physical', 'land', ALL_SCALES),


### PR DESCRIPTION
This PR makes three additions to the `tools/download.py` script:
- Use `choices` argument from ArgumentParser to simplify the code a bit. There's no need to test whether the user supplied a valid option, or print out a list of options, since ArgumentParser can do that for us.
- Add an option that sets the directory in which files will be saved. I expect this to be used by people like packagers, who wish to download the datasets to be placed in packages. In that case, it's not helpful to place the downloads in the user cache, but rather somewhere visible is more useful.
- Increase resolution for GSHHS, or else it won't be downloaded (since 'c' is already included.)
