### PR TITLE
Adding proj4 crs method

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1436,3 +1436,19 @@ def epsg(code):
     """
     import cartopy._epsg
     return cartopy._epsg._EPSGProjection(code)
+
+
+def proj4(proj4_str, xmin=-180., ymin=-90., xmax=180., ymax=90.):
+    """
+    Return the projection which corresponds to the given proj4 string.
+
+    The proj4 string must correspond to a "projected coordinate system"
+    so EPSG codes such as 4326 (WGS-84) which define a "geodetic coordinate
+    system" will not work.
+
+    .. note::
+        A proj4 string doesn't contain the area of validity, so you can either
+        specify the bounds, or have them default to the entire globe.
+    """
+    import cartopy._epsg
+    return cartopy._epsg._Proj4Projection(proj4_str, xmin, xmax, ymin, ymax)


### PR DESCRIPTION
Hi all,

This change modifies _EPSGProjection by making it a subclass of a new _Proj4Projection which takes a proj4 string and optionally projection bounds as parameters. Also adds a proj4 method to crs.py which calls the _Proj4Projection class directly so you can instantiate the projection given a proj4 string rather than just an EPSG code.

Any issues please give me a shout (and I'll email through the CLA tomorrow from work)
