### PR TITLE
Update URL of NACIS Natural Earth data

### DIFF
--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -261,7 +261,8 @@ class NEShpDownloader(Downloader):
     # define the NaturalEarth url template. The natural earth website
     # returns a 302 status if accessing directly, so we use the nacis
     # url directly
-    _NE_URL_TEMPLATE = ('http://www.nacis.org/naturalearth/{resolution}'
+    _NE_URL_TEMPLATE = ('http://www.naturalearthdata.com/'
+                        'http//www.naturalearthdata.com/download/{resolution}'
                         '/{category}/ne_{resolution}_{name}.zip')
 
     def __init__(self,


### PR DESCRIPTION
As of 20/08/2014 the URL http://www.nacis.org/naturalearth/ for downloading coastline data from NACIS is not valid. A new URL http://www.naturalearthdata.com/http//www.naturalearthdata.com/download/ was added and tested. Coastline data was succesfully downloaded and plotted with the new URL.
