### PR TITLE
doc: Fix version switcher JS

### DIFF
--- a/docs/source/_static/version_switch.js
+++ b/docs/source/_static/version_switch.js
@@ -19,12 +19,12 @@
   function build_select(current_version, current_release) {
     var buf = ['<select>'];
 
-    $.each(all_versions, function(version, title) {
-      buf.push('<option value="' + version + '"');
+    $.each(all_versions, function(path, version) {
+      buf.push('<option value="' + path + '"');
       if (version == current_version)
         buf.push(' selected="selected">' + current_release + '</option>');
       else
-        buf.push('>' + title + '</option>');
+        buf.push('>' + version + '</option>');
     });
 
     buf.push('</select>');


### PR DESCRIPTION
The version parser incorrectly splits by character, which means stuff like v0.10 will be treated as v0.1, and thus the selector will never have a selection (because there is no v0.1). Additionally, the regex doesn't handle multi-digit versions, and would popup an error about the wrong domain.

Also, the default selection was determined by comparing the _path_ value with the current version, instead of comparing the version value (for the selector) with the current version. Consequently, no default selection would be made, and you'd always have the latest selected (meaning you could never switch _to_ the latest.)
