### PR TITLE
Close some figures when tests complete.

### DIFF
--- a/lib/cartopy/tests/mpl/test_pseudo_color.py
+++ b/lib/cartopy/tests/mpl/test_pseudo_color.py
@@ -32,6 +32,7 @@ def test_pcolormesh_fully_masked():
         ax.pcolormesh(np.linspace(-90, 90, 40), np.linspace(0, 360, 30), data)
         assert_equal(pcolor.call_count, 0, ("pcolor shouldn't have been "
                                             "called, but was."))
+        plt.close()
 
 
 def test_pcolormesh_partially_masked():
@@ -44,6 +45,7 @@ def test_pcolormesh_partially_masked():
         ax.pcolormesh(np.linspace(-90, 90, 40), np.linspace(0, 360, 30), data)
         assert_equal(pcolor.call_count, 1, ("pcolor should have been "
                                             "called exactly once."))
+        plt.close()
 
 
 if __name__ == '__main__':

--- a/lib/cartopy/tests/mpl/test_set_extent.py
+++ b/lib/cartopy/tests/mpl/test_set_extent.py
@@ -147,6 +147,7 @@ def test_view_lim_autoscaling():
     expected_non_tight = np.array([[86, 52.45], [86.8, 52.9]])
     assert_array_almost_equal(ax.viewLim.frozen().get_points(),
                               expected_non_tight)
+    plt.close()
 
 
 def test_view_lim_default_global():
@@ -159,6 +160,7 @@ def test_view_lim_default_global():
     expected = np.array([[-180, -90], [180, 90]])
     assert_array_almost_equal(ax.viewLim.frozen().get_points(),
                               expected)
+    plt.close()
 
 
 if __name__ == '__main__':

--- a/lib/cartopy/tests/mpl/test_ticks.py
+++ b/lib/cartopy/tests/mpl/test_ticks.py
@@ -77,6 +77,7 @@ def test_set_xticks_non_cylindrical():
         ax.set_xticks([-180, -90, 0, 90, 180], crs=ccrs.Geodetic())
     with nose.tools.assert_raises(RuntimeError):
         ax.set_xticks([-135, -45, 45, 135], minor=True, crs=ccrs.Geodetic())
+    plt.close()
 
 
 @ImageTesting(['yticks_no_transform'], tolerance=0.125)
@@ -108,6 +109,7 @@ def test_set_yticks_non_cylindrical():
         ax.set_yticks([-60, -30, 0, 30, 60], crs=ccrs.Geodetic())
     with nose.tools.assert_raises(RuntimeError):
         ax.set_yticks([-75, -45, 15, 45, 75], minor=True, crs=ccrs.Geodetic())
+    plt.close()
 
 
 @ImageTesting(['xyticks'], tolerance=0.17)


### PR DESCRIPTION
Unclosed figures cause warnings on subsequent tests.
