### PR TITLE
Enable Python 3 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,4 +70,4 @@ script:
 
 after_failure:
   - source activate test-environment
-  - python -c "import cartopy.tests.mpl; print cartopy.tests.mpl.failed_images_html()"
+  - python -c "from __future__ import print_function; import cartopy.tests.mpl; print(cartopy.tests.mpl.failed_images_html())"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,8 @@ install:
   - conda install pyshp
   - conda install shapely
   - conda install six
-
   - conda install requests
-  - conda install pip
-  - pip install pyepsg
+  - conda install pyepsg
 
   # Conda debug
   # -----------

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,11 @@ install:
   # Customise the testing environment
   # ---------------------------------
   - conda config --add channels scitools
-  - conda install numpy=1.7.1 matplotlib=1.3.1 scipy=0.12.0
+  - if [[ "$TRAVIS_PYTHON_VERSION" == 3.4 ]]; then
+      conda install numpy=1.8.2 matplotlib=1.3.1 scipy=0.14.0;
+    else
+      conda install numpy=1.7.1 matplotlib=1.3.1 scipy=0.12.0;
+    fi
   - conda install cython
   - conda install pillow
   - conda install mock

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   # to build scipy we cannot use the virtual env of travis. Instead, we
   # use miniconda.
   - 2.7
+  - 3.3
+  - 3.4
 
 install:
   - sudo apt-get update -qq

--- a/lib/cartopy/tests/mpl/test_features.py
+++ b/lib/cartopy/tests/mpl/test_features.py
@@ -17,10 +17,13 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+import unittest
+
 import matplotlib.pyplot as plt
 
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
+from cartopy.io.ogc_clients import _OWSLIB_AVAILABLE
 
 from cartopy.tests.mpl import ImageTesting
 
@@ -62,6 +65,7 @@ def test_gshhs():
                                          facecolor='green'), facecolor='blue')
 
 
+@unittest.skipIf(not _OWSLIB_AVAILABLE, 'OWSLib is unavailable.')
 @ImageTesting(['wfs'])
 def test_wfs():
     ax = plt.axes(projection=ccrs.OSGB())


### PR DESCRIPTION
~~This is not going to work just yet. It's waiting on some changes to the SciTools binstar channel, because everything isn't built for Python 3 there.~~ This should work now! It's also tangentially related to #496, but not required.