### PR TITLE
Set matplotlib backend when testing

### DIFF
--- a/lib/cartopy/tests/__init__.py
+++ b/lib/cartopy/tests/__init__.py
@@ -23,9 +23,6 @@ import tempfile
 import shutil
 import types
 
-import matplotlib.patches as mpatches
-import matplotlib.pyplot as plt
-
 
 @contextlib.contextmanager
 def temp_dir(suffix=None):
@@ -49,58 +46,3 @@ def not_a_nose_fixture(function):
             return
         return function(app)
     return setup
-
-
-def show(projection, geometry):
-    if geometry.type == 'MultiPolygon' and 1:
-        multi_polygon = geometry
-        for polygon in multi_polygon:
-            import cartopy.mpl.patch as patch
-            paths = patch.geos_to_path(polygon)
-            for pth in paths:
-                patch = mpatches.PathPatch(pth, edgecolor='none',
-                                           lw=0, alpha=0.2)
-                plt.gca().add_patch(patch)
-            line_string = polygon.exterior
-            plt.plot(*list(zip(*line_string.coords)),
-                     marker='+', linestyle='-')
-    elif geometry.type == 'MultiPolygon':
-        multi_polygon = geometry
-        for polygon in multi_polygon:
-            line_string = polygon.exterior
-            plt.plot(*list(zip(*line_string.coords)),
-                     marker='+', linestyle='-')
-
-    elif geometry.type == 'MultiLineString':
-        multi_line_string = geometry
-        for line_string in multi_line_string:
-            plt.plot(*list(zip(*line_string.coords)),
-                     marker='+', linestyle='-')
-
-    elif geometry.type == 'LinearRing':
-        plt.plot(*list(zip(*geometry.coords)), marker='+', linestyle='-')
-
-    if 1:
-        # Whole map domain
-        plt.autoscale()
-    elif 0:
-        # The left-hand triangle
-        plt.xlim(-1.65e7, -1.2e7)
-        plt.ylim(0.3e7, 0.65e7)
-    elif 0:
-        # The tip of the left-hand triangle
-        plt.xlim(-1.65e7, -1.55e7)
-        plt.ylim(0.3e7, 0.4e7)
-    elif 1:
-        # The very tip of the left-hand triangle
-        plt.xlim(-1.632e7, -1.622e7)
-        plt.ylim(0.327e7, 0.337e7)
-    elif 1:
-        # The tip of the right-hand triangle
-        plt.xlim(1.55e7, 1.65e7)
-        plt.ylim(0.3e7, 0.4e7)
-
-    plt.plot(*list(zip(*projection.boundary.coords)), marker='o',
-             scalex=False, scaley=False, zorder=-1)
-
-    plt.show()

--- a/lib/cartopy/tests/mpl/__init__.py
+++ b/lib/cartopy/tests/mpl/__init__.py
@@ -22,7 +22,8 @@ import glob
 import shutil
 import warnings
 
-
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
 import matplotlib.testing.compare as mcompare
 import matplotlib._pylab_helpers as pyplot_helpers
 
@@ -270,3 +271,58 @@ def failed_images_html():
 
     html.extend(['</body>', '</html>'])
     return '\n'.join(html)
+
+
+def show(projection, geometry):
+    if geometry.type == 'MultiPolygon' and 1:
+        multi_polygon = geometry
+        for polygon in multi_polygon:
+            import cartopy.mpl.patch as patch
+            paths = patch.geos_to_path(polygon)
+            for pth in paths:
+                patch = mpatches.PathPatch(pth, edgecolor='none',
+                                           lw=0, alpha=0.2)
+                plt.gca().add_patch(patch)
+            line_string = polygon.exterior
+            plt.plot(*list(zip(*line_string.coords)),
+                     marker='+', linestyle='-')
+    elif geometry.type == 'MultiPolygon':
+        multi_polygon = geometry
+        for polygon in multi_polygon:
+            line_string = polygon.exterior
+            plt.plot(*list(zip(*line_string.coords)),
+                     marker='+', linestyle='-')
+
+    elif geometry.type == 'MultiLineString':
+        multi_line_string = geometry
+        for line_string in multi_line_string:
+            plt.plot(*list(zip(*line_string.coords)),
+                     marker='+', linestyle='-')
+
+    elif geometry.type == 'LinearRing':
+        plt.plot(*list(zip(*geometry.coords)), marker='+', linestyle='-')
+
+    if 1:
+        # Whole map domain
+        plt.autoscale()
+    elif 0:
+        # The left-hand triangle
+        plt.xlim(-1.65e7, -1.2e7)
+        plt.ylim(0.3e7, 0.65e7)
+    elif 0:
+        # The tip of the left-hand triangle
+        plt.xlim(-1.65e7, -1.55e7)
+        plt.ylim(0.3e7, 0.4e7)
+    elif 1:
+        # The very tip of the left-hand triangle
+        plt.xlim(-1.632e7, -1.622e7)
+        plt.ylim(0.327e7, 0.337e7)
+    elif 1:
+        # The tip of the right-hand triangle
+        plt.xlim(1.55e7, 1.65e7)
+        plt.ylim(0.3e7, 0.4e7)
+
+    plt.plot(*list(zip(*projection.boundary.coords)), marker='o',
+             scalex=False, scaley=False, zorder=-1)
+
+    plt.show()

--- a/lib/cartopy/tests/mpl/__init__.py
+++ b/lib/cartopy/tests/mpl/__init__.py
@@ -196,6 +196,9 @@ class ImageTesting(object):
         mod_name = mod_name.rsplit('.', 1)[-1]
 
         def wrapped(*args, **kwargs):
+            orig_backend = plt.get_backend()
+            plt.switch_backend('agg')
+
             if pyplot_helpers.Gcf.figs:
                 warnings.warn('Figures existed before running the %s %s test.'
                               ' All figures should be closed after they run. '
@@ -213,6 +216,7 @@ class ImageTesting(object):
             finally:
                 for figure in figures:
                     pyplot_helpers.Gcf.destroy_fig(figure)
+                plt.switch_backend(orig_backend)
             return r
 
         # nose needs the function's name to be in the form "test_*" to
@@ -274,6 +278,9 @@ def failed_images_html():
 
 
 def show(projection, geometry):
+    orig_backend = matplotlib.get_backend()
+    plt.switch_backend('tkagg')
+
     if geometry.type == 'MultiPolygon' and 1:
         multi_polygon = geometry
         for polygon in multi_polygon:
@@ -326,3 +333,4 @@ def show(projection, geometry):
              scalex=False, scaley=False, zorder=-1)
 
     plt.show()
+    plt.switch_backend(orig_backend)

--- a/lib/cartopy/tests/test_line_string.py
+++ b/lib/cartopy/tests/test_line_string.py
@@ -63,7 +63,7 @@ class TestLineString(unittest.TestCase):
         for coords, pieces in tests:
             line_string = geometry.LineString(coords)
             multi_line_string = projection.project_geometry(line_string)
-            # from cartopy.tests import show
+            # from cartopy.tests.mpl import show
             # show(projection, multi_line_string)
             self.assertEqual(len(multi_line_string), pieces)
 
@@ -71,7 +71,7 @@ class TestLineString(unittest.TestCase):
         projection = ccrs.Robinson(170.5)
         line_string = geometry.LineString([(-10, 30), (10, 60)])
         multi_line_string = projection.project_geometry(line_string)
-        from cartopy.tests import show
+        # from cartopy.tests.mpl import show
         # show(projection, multi_line_string)
         self.assertEqual(len(multi_line_string), 2)
 
@@ -199,7 +199,7 @@ class TestBisect(unittest.TestCase):
         projection = ccrs.TransverseMercator(central_longitude=-90)
         line_string = geometry.LineString([(-10, 30), (10, 50)])
         multi_line_string = projection.project_geometry(line_string)
-        from cartopy.tests import show
+        # from cartopy.tests.mpl import show
         # show(projection, multi_line_string)
         self.assertEqual(len(multi_line_string), 1)
         for line_string in multi_line_string:
@@ -213,7 +213,7 @@ class TestMisc(unittest.TestCase):
         projection = ccrs.TransverseMercator(central_longitude=-90)
         line_string = geometry.LineString([(10, 50), (-10, 30)])
         multi_line_string = projection.project_geometry(line_string)
-        from cartopy.tests import show
+        # from cartopy.tests.mpl import show
         # show(projection, multi_line_string)
         for line_string in multi_line_string:
             for coord in line_string.coords:

--- a/lib/cartopy/tests/test_linear_ring.py
+++ b/lib/cartopy/tests/test_linear_ring.py
@@ -34,7 +34,7 @@ class TestBoundary(unittest.TestCase):
                                                    (10, 50)])
         projection = ccrs.Robinson(170.5)
         multi_line_string = projection.project_geometry(linear_ring)
-        from cartopy.tests import show
+        # from cartopy.tests.mpl import show
         # show(projection, multi_line_string)
 
         # The original ring should have been split into multiple pieces.
@@ -97,7 +97,7 @@ class TestMisc(unittest.TestCase):
                                                    (10, 60),
                                                    (10, 50)])
         multi_line_string = projection.project_geometry(linear_ring)
-        # from cartopy.tests import show
+        # from cartopy.tests.mpl import show
         # show(projection, multi_line_string)
         # XXX not a test...
 
@@ -114,7 +114,7 @@ class TestMisc(unittest.TestCase):
         # there should be one, and only one, returned line:
         assert isinstance(multi_line_string, geometry.polygon.LinearRing)
 
-        # from cartopy.tests import show
+        # from cartopy.tests.mpl import show
         # show(projection, multi_line_string)
 
     def test_three_points(self):

--- a/lib/cartopy/tests/test_polygon.py
+++ b/lib/cartopy/tests/test_polygon.py
@@ -162,7 +162,7 @@ class TestQuality(unittest.TestCase):
             (175.0, -57.19913331),
         ])
         self.multi_polygon = projection.project_geometry(polygon)
-        # from cartopy.tests import show
+        # from cartopy.tests.mpl import show
         # show(projection, self.multi_polygon)
 
     def test_split(self):


### PR DESCRIPTION
The matplotlib backend is not explicitly set when testing, so tests require the user to mess with the default backend settings to run them. Otherwise, figures may pop up or end up in some other format or something depending on the user's settings.