### PR TITLE
Add Mapbox tiles retrieval

### DIFF
--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -253,6 +253,42 @@ class StamenTerrain(GoogleTiles):
         return url
 
 
+class MapboxTiles(GoogleTiles):
+    """
+    Implements web tile retrieval from Mapbox.
+
+    For terms of service, see https://www.mapbox.com/tos/.
+
+    """
+    def __init__(self, access_token, map_id):
+        """
+        Set up a new Mapbox tiles instance.
+
+        Access to Mapbox web services requires an access token and a map ID.
+        See https://www.mapbox.com/developers/api/ for details.
+
+        Parameters
+        ----------
+        access_token: str
+            A valid Mapbox API access token.
+        map_id: str
+            A map ID for a publically accessible map. This is the map whose
+            tiles will be retrieved through this process.
+
+        """
+        self.access_token = access_token
+        self.map_id = map_id
+        super(MapboxTiles, self).__init__()
+
+    def _image_url(self, tile):
+        x, y, z = tile
+        url = ('http://api.tiles.mapbox.com/v4/{mapid}/{z}/{x}/{y}.png?'
+               'access_token={token}'.format(z=z, y=y, x=x,
+                                             mapid=self.map_id,
+                                             token=self.access_token))
+        return url
+
+
 class QuadtreeTiles(GoogleTiles):
     """
     Implements web tile retrieval using the Microsoft WTS quadkey coordinate

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -197,6 +197,17 @@ def test_quadtree_wts():
                       KNOWN_EXTENTS[(8, 9, 4)])
 
 
+def test_mapbox_tiles():
+    token = 'foo'
+    map_id = 'bar'
+    tile = [0, 1, 2]
+    exp_url = 'http://api.tiles.mapbox.com/v4/bar/2/0/1.png?access_token=foo'
+
+    mapbox_sample = cimgt.MapboxTiles(token, map_id)
+    url_str = mapbox_sample._image_url(tile)
+    assert_equal(url_str, exp_url)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
Adds a class for retrieving mapbox tiles. 

This class looks a little different to the other tile classes that inherit from `GoogleTiles` because Maptiles' approach to map tile provision is user oriented, so a given user's API access token and an ID for a map that they have created needs to be supplied.
