### PR TITLE
doc: Update projection list generator

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -37,6 +37,7 @@ help:
 	@echo "  changes    to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
+	@echo "  projection to automatically create list of available CRS projections"
 
 clean:
 	-rm -rf $(BUILDDIR)/*
@@ -152,3 +153,6 @@ doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
+
+projection:
+	python make_projection.py

--- a/docs/make_projection.py
+++ b/docs/make_projection.py
@@ -42,6 +42,7 @@ def projection_rst(projection_cls):
 SPECIAL_CASES = {
     ccrs.PlateCarree: [{}, {'central_longitude': 180}],
     ccrs.RotatedPole: [{'pole_longitude': 177.5, 'pole_latitude': 37.5}],
+    ccrs.UTM: [{'zone': 30}],
 }
 
 
@@ -52,11 +53,11 @@ COASTLINE_RESOLUTION = {ccrs.OSNI: '10m',
 PRJ_SORT_ORDER = {'PlateCarree': 1, 'Mercator': 2, 'Mollweide': 2, 'Robinson': 2,
                   'TransverseMercator': 2, 'LambertCylindrical': 2,
                   'LambertConformal': 2, 'Stereographic': 2, 'Miller': 2,
-                  'Orthographic': 2, 'InterruptedGoodeHomolosine': 3,
+                  'Orthographic': 2, 'UTM': 2, 'InterruptedGoodeHomolosine': 3,
                   'RotatedPole': 3, 'OSGB': 4}
 
 
-groups = [('cylindrical', [ccrs.PlateCarree, ccrs.Mercator, ccrs.TransverseMercator,
+groups = [('cylindrical', [ccrs.PlateCarree, ccrs.Mercator, ccrs.TransverseMercator, ccrs.UTM,
                            ccrs.OSGB, ccrs.LambertCylindrical, ccrs.Miller, ccrs.RotatedPole]),
           ('pseudo-cylindrical', [ccrs.Mollweide, ccrs.Robinson]),
 #          ('conic', [ccrs.aed]),

--- a/docs/make_projection.py
+++ b/docs/make_projection.py
@@ -39,9 +39,10 @@ def projection_rst(projection_cls):
     print(name)
 
 
-SPECIAL_CASES = {ccrs.PlateCarree: ['PlateCarree()', 'PlateCarree(central_longitude=180)'],
-                 ccrs.RotatedPole: ['RotatedPole(pole_longitude=177.5, pole_latitude=37.5)'],
-                 }
+SPECIAL_CASES = {
+    ccrs.PlateCarree: [{}, {'central_longitude': 180}],
+    ccrs.RotatedPole: [{'pole_longitude': 177.5, 'pole_latitude': 37.5}],
+}
 
 
 COASTLINE_RESOLUTION = {ccrs.OSNI: '10m',
@@ -81,28 +82,22 @@ if __name__ == '__main__':
     prj_class_sorter = lambda cls: (PRJ_SORT_ORDER.get(cls.__name__, []), cls.__name__)
     for prj in sorted(find_projections(), key=prj_class_sorter):
         name = prj.__name__
-#        print prj in SPECIAL_CASES, prj in all_projections_in_groups, prj
-
-        # put the class documentation on the left, and a sidebar on the right.
-
-        aspect = (np.diff(prj().x_limits) / np.diff(prj().y_limits))[0]
-        width = 3 * aspect
-        if width == int(width):
-            width = int(width)
 
         table.write(name + '\n')
         table.write('-' * len(name) + '\n\n')
 
         table.write('.. autoclass:: cartopy.crs.%s\n' % name)
 
-#        table.write('Ipsum lorum....')
+        for instance_args in SPECIAL_CASES.get(prj, [{}]):
+            prj_inst = prj(**instance_args)
+            aspect = (np.diff(prj_inst.x_limits) / np.diff(prj_inst.y_limits))[0]
+            width = 3 * aspect
+            if width == int(width):
+                width = int(width)
 
-#        table.write("""\n\n
-#
-#.. sidebar:: Example
-#""")
-
-        for instance_creation_code in SPECIAL_CASES.get(prj, ['%s()' % name]):
+            instance_params = ', '.join('{}={}'.format(k, v)
+                                        for k, v in instance_args.items())
+            instance_creation_code = '{}({})'.format(name, instance_params)
             code = """
 .. plot::
 

--- a/docs/make_projection.py
+++ b/docs/make_projection.py
@@ -25,20 +25,6 @@ import numpy as np
 import cartopy.crs as ccrs
 
 
-def find_projections():
-    for obj_name, o in vars(ccrs).copy().items():
-#        o = getattr(ccrs, obj_name)
-        if (isinstance(o, type) and issubclass(o, ccrs.Projection) and
-            not obj_name.startswith('_') and obj_name not in ['Projection']):
-
-            # yield the projections
-            yield o
-
-def projection_rst(projection_cls):
-    name = projection_cls.__name__
-    print(name)
-
-
 SPECIAL_CASES = {
     ccrs.PlateCarree: [{}, {'central_longitude': 180}],
     ccrs.RotatedPole: [{'pole_longitude': 177.5, 'pole_latitude': 37.5}],
@@ -50,25 +36,21 @@ COASTLINE_RESOLUTION = {ccrs.OSNI: '10m',
                         ccrs.OSGB: '50m',
                         ccrs.EuroPP: '50m'}
 
-PRJ_SORT_ORDER = {'PlateCarree': 1, 'Mercator': 2, 'Mollweide': 2, 'Robinson': 2,
+PRJ_SORT_ORDER = {'PlateCarree': 1,
+                  'Mercator': 2, 'Mollweide': 2, 'Robinson': 2,
                   'TransverseMercator': 2, 'LambertCylindrical': 2,
                   'LambertConformal': 2, 'Stereographic': 2, 'Miller': 2,
-                  'Orthographic': 2, 'UTM': 2, 'InterruptedGoodeHomolosine': 3,
-                  'RotatedPole': 3, 'OSGB': 4}
+                  'Orthographic': 2, 'UTM': 2,
+                  'InterruptedGoodeHomolosine': 3, 'RotatedPole': 3,
+                  'OSGB': 4}
 
 
-groups = [('cylindrical', [ccrs.PlateCarree, ccrs.Mercator, ccrs.TransverseMercator, ccrs.UTM,
-                           ccrs.OSGB, ccrs.LambertCylindrical, ccrs.Miller, ccrs.RotatedPole]),
-          ('pseudo-cylindrical', [ccrs.Mollweide, ccrs.Robinson]),
-#          ('conic', [ccrs.aed]),
-          ('azimuthal', [ccrs.Stereographic, ccrs.NorthPolarStereo,
-                         ccrs.SouthPolarStereo, ccrs.Gnomonic, ccrs.Orthographic
-                         ]),
-          ('misc', [ccrs.InterruptedGoodeHomolosine]),
-          ]
+def find_projections():
+    for obj_name, o in vars(ccrs).copy().items():
+        if isinstance(o, type) and issubclass(o, ccrs.Projection) and \
+           not obj_name.startswith('_') and obj_name not in ['Projection']:
 
-
-all_projections_in_groups = list(itertools.chain.from_iterable([g[1] for g in groups]))
+            yield o
 
 
 if __name__ == '__main__':
@@ -80,7 +62,8 @@ if __name__ == '__main__':
     table.write('Cartopy projection list\n')
     table.write('=======================\n\n\n')
 
-    prj_class_sorter = lambda cls: (PRJ_SORT_ORDER.get(cls.__name__, []), cls.__name__)
+    prj_class_sorter = lambda cls: (PRJ_SORT_ORDER.get(cls.__name__, []),
+                                    cls.__name__)
     for prj in sorted(find_projections(), key=prj_class_sorter):
         name = prj.__name__
 
@@ -91,7 +74,8 @@ if __name__ == '__main__':
 
         for instance_args in SPECIAL_CASES.get(prj, [{}]):
             prj_inst = prj(**instance_args)
-            aspect = (np.diff(prj_inst.x_limits) / np.diff(prj_inst.y_limits))[0]
+            aspect = (np.diff(prj_inst.x_limits) /
+                      np.diff(prj_inst.y_limits))[0]
             width = 3 * aspect
             if width == int(width):
                 width = int(width)

--- a/docs/source/crs/projections.rst
+++ b/docs/source/crs/projections.rst
@@ -209,7 +209,7 @@ RotatedPole
     import cartopy.crs as ccrs
 
     plt.figure(figsize=(6, 3))
-    ax = plt.axes(projection=ccrs.RotatedPole(pole_longitude=177.5, pole_latitude=37.5))
+    ax = plt.axes(projection=ccrs.RotatedPole(pole_latitude=37.5, pole_longitude=177.5))
     ax.coastlines(resolution='110m')
     ax.gridlines()
 
@@ -240,7 +240,7 @@ EuroPP
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(2.51842105263, 3))
+    plt.figure(figsize=(2.61538461538, 3))
     ax = plt.axes(projection=ccrs.EuroPP())
     ax.coastlines(resolution='50m')
     ax.gridlines()

--- a/docs/source/crs/projections.rst
+++ b/docs/source/crs/projections.rst
@@ -181,6 +181,16 @@ UTM
 
 .. autoclass:: cartopy.crs.UTM
 
+.. plot::
+
+    import matplotlib.pyplot as plt
+    import cartopy.crs as ccrs
+
+    plt.figure(figsize=(0.128571428571, 3))
+    ax = plt.axes(projection=ccrs.UTM(zone=30))
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
+
 
 InterruptedGoodeHomolosine
 --------------------------


### PR DESCRIPTION
This cleans up the projection list generator:
 * Remove a lot of comments and extra code that didn't do anything.
 * Fix calculation of aspect ratio that didn't work when projection constructor had required parameters.
 * Add UTM to the generator setup. It appears that it was added manually (and thus the previous problem was never noticed).