### PR TITLE
Updated copyright on cartopy webpages

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -42,7 +42,7 @@ border="0" alt="Cartopy" style="margin-left: -60px;"/>
     <div class="footer">
     <p style="text-align: left; float: left; margin: 0px; padding: 0 0 0 5px;">Documentation licensed under the <a href="http://reference.data.gov.uk/id/open-government-licence" rel="license">Open Government Licence</a></p>
     {%- if show_copyright %}
-        &copy; <a href="{{ pathto('copyright') }}">British Crown Copyright</a> 2011 - 2013, Met Office
+        &copy; <a href="{{ pathto('copyright') }}">British Crown Copyright</a> 2011 - 2014, Met Office
     {%- endif %}
     {%- if last_updated %}
       {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2013, Met Office
+# (C) British Crown Copyright 2011 - 2014, Met Office
 #
 # This file is part of cartopy.
 #

--- a/docs/source/copyright.rst
+++ b/docs/source/copyright.rst
@@ -7,14 +7,14 @@ Cartopy copyright, licensing and contributors
 Cartopy code
 ------------
 
-All Iris source code, unless explicitly stated, is |copy| ``British Crown copyright, 2012`` and 
+All Iris source code, unless explicitly stated, is |copy| ``British Crown copyright, 2014`` and 
 is licensed under the **GNU Lesser General Public License** as published by the
 Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 You should find all source files with the following header:
 
 .. admonition:: Code License
 
-    |copy| British Crown Copyright 2011 - 2012, Met Office
+    |copy| British Crown Copyright 2011 - 2014, Met Office
     
     This file is part of cartopy.
     
@@ -40,7 +40,7 @@ are licensed under the UK's Open Government Licence:
 
 .. admonition:: Documentation, example and data license
  
-    |copy| British Crown copyright, 2012.
+    |copy| British Crown copyright, 2014.
     
     You may use and re-use the information featured on this website (not including logos) free of 
     charge in any format or medium, under the terms of the 


### PR DESCRIPTION
The copyright on Cartopy webpages needed updating. 
It should read 2011-2014

I'd also like to point out that the copyrights, as stated at the top of all files, aren't consistent, e.g. 2010-2012 for /lib/cartopy/_crs.pxd 
