### PR TITLE
changed natural earth URL

### DIFF
--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -277,14 +277,10 @@ class NEShpDownloader(Downloader):
     FORMAT_KEYS = ('config', 'resolution', 'category', 'name')
 
     # Define the NaturalEarth URL template. The natural earth website
-    # returns a 302 status if accessing directly, so we could use the naciscdn
+    # returns a 302 status if accessing directly, so we use the naciscdn
     # URL directly.
     _NE_URL_TEMPLATE = ('http://naciscdn.org/naturalearth/{resolution}'
                         '/{category}/ne_{resolution}_{name}.zip')
-    # But in preference we use the latest files from the Github repo instead.
-    _NE_URL_TEMPLATE = ('https://github.com/nvkelso/natural-earth-vector/'
-                        'raw/master/zips/{resolution}_{category}/'
-                        'ne_{resolution}_{name}.zip')
 
     def __init__(self,
                  url_template=_NE_URL_TEMPLATE,


### PR DESCRIPTION
See latest comments on #487. The github location (https://github.com/nvkelso/natural-earth-vector) has removed the zip files. It's not clear if this was intentional. Their PR goes back to the naciscdn.org URL.

This is targeting master - it should probably target 0.11.x