### PR TITLE
Changed natural earth URL 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 
   # Create the basic testing environment
   # ------------------------------------
-  - conda config --set always_yes yes --set changeps1 no
+  - conda config --set always_yes yes --set changeps1 no --set show_channel_urls yes
   - conda update conda
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
 
   # Customise the testing environment
   # ---------------------------------
-  - conda config --add channels rsignell
+  - conda config --add channels scitools
   - conda install numpy=1.7.1 matplotlib=1.3.1 scipy=0.12.0
   - conda install cython
   # The conda "pillow" build is broken, so we use "imaging" instead.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ install:
   # Install miniconda
   # -----------------
   - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
-      wget http://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+      wget http://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh -O miniconda.sh;
     else
-      wget http://repo.continuum.io/miniconda/Miniconda3-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+      wget http://repo.continuum.io/miniconda/Miniconda3-3.7.0-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -274,14 +274,10 @@ class NEShpDownloader(Downloader):
     FORMAT_KEYS = ('config', 'resolution', 'category', 'name')
 
     # Define the NaturalEarth URL template. The natural earth website
-    # returns a 302 status if accessing directly, so we could use the naciscdn
+    # returns a 302 status if accessing directly, so we use the naciscdn
     # URL directly.
     _NE_URL_TEMPLATE = ('http://naciscdn.org/naturalearth/{resolution}'
                         '/{category}/ne_{resolution}_{name}.zip')
-    # But in preference we use the latest files from the Github repo instead.
-    _NE_URL_TEMPLATE = ('https://github.com/nvkelso/natural-earth-vector/'
-                        'raw/master/zips/{resolution}_{category}/'
-                        'ne_{resolution}_{name}.zip')
 
     def __init__(self,
                  url_template=_NE_URL_TEMPLATE,


### PR DESCRIPTION
This PR changes the Natural Earth URL to use naciscdn.org rather than github. See latest comments on #487. The github location (https://github.com/nvkelso/natural-earth-vector) has removed the zip files in line with guidance from github on large binaries.

This PR also has a separate commit to fix the conda update issue by using the latest miniconda version (3.7.0)

This targets v0.11.x