### PR TITLE
Add example of using set_boundary with a star.

### DIFF
--- a/lib/cartopy/examples/star_shaped_boundary.py
+++ b/lib/cartopy/examples/star_shaped_boundary.py
@@ -1,0 +1,36 @@
+"""
+Modifying the boundary/neatline of a map in cartopy
+---------------------------------------------------
+
+This example demonstrates how to modify the boundary/neatline
+of an axes. We construct a star with coordinates in a Plate Carree
+coordinate system, and use the star as the outline of the map.
+
+Notice how changing the projection of the map represents a *projected*
+star shaped boundary.
+
+"""
+__tags__ = ['Miscellanea']
+import matplotlib.path as mpath
+import matplotlib.pyplot as plt
+
+import cartopy.crs as ccrs
+
+
+def main():
+    ax = plt.axes([0, 0, 1, 1], projection=ccrs.PlateCarree())
+    ax.coastlines()
+
+    # Construct a star in longitudes and latitudes.
+    star_path = mpath.Path.unit_regular_star(5, 0.5)
+    star_path = mpath.Path(star_path.vertices.copy() * 80,
+                           star_path.codes.copy())
+
+    # Use the star as the boundary.
+    ax.set_boundary(star_path, transform=ccrs.PlateCarree())
+
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -957,6 +957,10 @@ class GeoAxes(matplotlib.axes.Axes):
         """
         if transform is None:
             transform = self.transData
+
+        if isinstance(transform, cartopy.crs.CRS):
+            transform = transform._as_mpl_transform(self)
+
         if self.background_patch is None:
             background = matplotlib.patches.PathPatch(path, edgecolor='none',
                                                       facecolor='white',


### PR DESCRIPTION
Hope you don't find it creepy @digitalvapor, but I took your changes and made use of the new ``set_boundary`` method.

Produces:

![figure_1](https://cloud.githubusercontent.com/assets/810663/6270618/f42ffd60-b852-11e4-93d8-d6e97e2b0620.png)


I'll merge this if the tests pass.