### PR TITLE
Infinite loop workaround

### DIFF
--- a/lib/cartopy/_trace.cpp
+++ b/lib/cartopy/_trace.cpp
@@ -231,6 +231,11 @@ class LineAccumulator
     void add_point_if_empty(const Point &point);
     GEOSGeometry *as_geom(GEOSContextHandle_t handle);
 
+    std::list<Line>::size_type size() const
+    {
+        return m_lines.size();
+    }
+
     private:
     std::list<Line> m_lines;
 };
@@ -558,7 +563,7 @@ void _project_segment(GEOSContextHandle_t handle,
     t_current = 0.0;
     state = get_state(p_current, gp_domain, handle);
 
-    while(t_current < 1.0)
+    while(t_current < 1.0 && lines.size() < 100)
     {
         //std::cerr << "Bisecting" << std::endl;
 #ifdef DEBUG

--- a/lib/cartopy/_trace.cpp
+++ b/lib/cartopy/_trace.cpp
@@ -563,7 +563,7 @@ void _project_segment(GEOSContextHandle_t handle,
     t_current = 0.0;
     state = get_state(p_current, gp_domain, handle);
 
-    while(t_current < 1.0 && lines.size() < 100)
+    while(t_current < 1.0 && lines.size() < 500)
     {
         //std::cerr << "Bisecting" << std::endl;
 #ifdef DEBUG

--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -54,7 +54,8 @@ cdef extern from "_trace.h":
     GEOSGeometry *_project_line_string(GEOSContextHandle_t handle,
                                        GEOSGeometry *g_line_string,
                                        Interpolator *interpolator,
-                                       GEOSGeometry *g_domain, double handle)
+                                       GEOSGeometry *g_domain,
+                                       double threshold)
 
 # XXX What should go here?
 ctypedef long ptr


### PR DESCRIPTION
This is a possibly hacky, but reasonable workaround to the infinite loops in #325 and #389. Essentially, at these "special" points (singularities, I guess?), the line is continually split into smaller lines.

I check the test suite, and overwhelmingly, the number of lines actually required is quite small:
```
$ grep -o 'lines:[0-9]\+' log |sort |uniq -c
 174239 lines:1
  50922 lines:2
  12628 lines:3
   8199 lines:4
   3036 lines:5
    600 lines:6
```
but for the two issues, the lines just grow infinitely.

The workaround here is to simply _give up_ when there are too many lines. Currently, "too many" is set to 100, and it's likely this is more than enough, though I'm sure someone can come up with something that breaks.