### PR TITLE
Add keywords to control gridline locations.

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2014, Met Office
+# (C) British Crown Copyright 2011 - 2015, Met Office
 #
 # This file is part of cartopy.
 #
@@ -35,6 +35,7 @@ from matplotlib.image import imread
 import matplotlib.transforms as mtransforms
 import matplotlib.patches as mpatches
 import matplotlib.path as mpath
+import matplotlib.ticker as mticker
 import numpy as np
 import numpy.ma as ma
 import shapely.geometry as sgeom
@@ -857,7 +858,8 @@ class GeoAxes(matplotlib.axes.Axes):
 #            result.set_clip_path(self.outline_patch)
         return result
 
-    def gridlines(self, crs=None, draw_labels=False, **kwargs):
+    def gridlines(self, crs=None, draw_labels=False, xlocs=None,
+                  ylocs=None, **kwargs):
         """
         Automatically adds gridlines to the axes, in the given coordinate
         system, at draw time.
@@ -872,6 +874,20 @@ class GeoAxes(matplotlib.axes.Axes):
         * draw_labels
             Label gridlines like axis ticks, around the edge.
 
+        * xlocs
+            An iterable of gridline locations or a
+            :class:`matplotlib.ticker.Locator` instance which will be used to
+            determine the locations of the gridlines in the x-coordinate of
+            the given CRS. Defaults to None, which implies automatic locating
+            of the gridlines.
+
+        * ylocs
+            An iterable of gridline locations or a
+            :class:`matplotlib.ticker.Locator` instance which will be used to
+            determine the locations of the gridlines in the y-coordinate of
+            the given CRS. Defaults to None, which implies automatic locating
+            of the gridlines.
+
         Returns:
 
             A :class:`cartopy.mpl.gridliner.Gridliner` instance.
@@ -883,8 +899,13 @@ class GeoAxes(matplotlib.axes.Axes):
         if crs is None:
             crs = ccrs.PlateCarree()
         from cartopy.mpl.gridliner import Gridliner
+        if xlocs is not None and not isinstance(xlocs, mticker.Locator):
+            xlocs = mticker.FixedLocator(xlocs)
+        if ylocs is not None and not isinstance(ylocs, mticker.Locator):
+            ylocs = mticker.FixedLocator(ylocs)
         gl = Gridliner(
-            self, crs=crs, draw_labels=draw_labels, collection_kwargs=kwargs)
+            self, crs=crs, draw_labels=draw_labels, xlocator=xlocs,
+            ylocator=ylocs, collection_kwargs=kwargs)
         self._gridliners.append(gl)
         return gl
 

--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2014, Met Office
+# (C) British Crown Copyright 2011 - 2015, Met Office
 #
 # This file is part of cartopy.
 #
@@ -95,7 +95,8 @@ class Gridliner(object):
     # maybe even a plain old mpl axes) and it will call the "_draw_gridliner"
     # method on draw. This will enable automatic gridline resolution
     # determination on zoom/pan.
-    def __init__(self, axes, crs, draw_labels=False, collection_kwargs=None):
+    def __init__(self, axes, crs, draw_labels=False, xlocator=None,
+                 ylocator=None, collection_kwargs=None):
         """
         Object used by :meth:`cartopy.mpl.geoaxes.GeoAxes.gridlines`
         to add gridlines and tick labels to a map.
@@ -113,6 +114,18 @@ class Gridliner(object):
             Toggle whether to draw labels. For finer control, attributes of
             :class:`Gridliner` may be modified individually.
 
+        * xlocator
+            A :class:`matplotlib.ticker.Locator` instance which will be used
+            to determine the locations of the gridlines in the x-coordinate of
+            the given CRS. Defaults to None, which implies automatic locating
+            of the gridlines.
+
+        * ylocator
+            A :class:`matplotlib.ticker.Locator` instance which will be used
+            to determine the locations of the gridlines in the y-coordinate of
+            the given CRS. Defaults to None, which implies automatic locating
+            of the gridlines.
+
         * collection_kwargs
             Dictionary controlling line properties, passed to
             :class:`matplotlib.collections.Collection`.
@@ -122,11 +135,11 @@ class Gridliner(object):
 
         #: The :class:`~matplotlib.ticker.Locator` to use for the x
         #: gridlines and labels.
-        self.xlocator = degree_locator
+        self.xlocator = xlocator or degree_locator
 
         #: The :class:`~matplotlib.ticker.Locator` to use for the y
         #: gridlines and labels.
-        self.ylocator = degree_locator
+        self.ylocator = ylocator or degree_locator
 
         #: The :class:`~matplotlib.ticker.Formatter` to use for the x labels.
         self.xformatter = mticker.ScalarFormatter()

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2014, Met Office
+# (C) British Crown Copyright 2011 - 2015, Met Office
 #
 # This file is part of cartopy.
 #
@@ -20,10 +20,13 @@ from __future__ import (absolute_import, division, print_function)
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
+import mock
 from nose.tools import assert_raises
+import numpy as np
 
 import cartopy.crs as ccrs
 from cartopy.tests.mpl import ImageTesting
+from cartopy.mpl.geoaxes import GeoAxes
 from cartopy.mpl.gridliner import LATITUDE_FORMATTER, LONGITUDE_FORMATTER
 
 
@@ -83,6 +86,17 @@ def test_gridliner():
     delta = 1.5e-2
     plt.subplots_adjust(left=0 + delta, right=1 - delta,
                         top=1 - delta, bottom=0 + delta)
+
+
+def test_gridliner_specified_lines():
+    xs = [0, 60, 120, 180, 240, 360]
+    ys = [-90, -60, -30, 0, 30, 60, 90]
+    ax = mock.Mock(_gridliners=[], spec=GeoAxes)
+    gl = GeoAxes.gridlines(ax, xlocs=xs, ylocs=ys)
+    assert isinstance(gl.xlocator, mticker.FixedLocator)
+    assert isinstance(gl.ylocator, mticker.FixedLocator)
+    assert gl.xlocator.tick_values(None, None).tolist() == xs
+    assert gl.ylocator.tick_values(None, None).tolist() == ys
 
 
 # The tolerance on this test is particularly high because of the high number


### PR DESCRIPTION
This PR allows users to provide locator classes to the `GeoAxes.gridlines()` method to specify the locations gridlines should be drawn at.

Uses an image test, not sure if it is a good idea to add another image test, suggestions welcome.