### PR TITLE
Use Bitstream Vera Sans instead of non-free Arial.

### DIFF
--- a/lib/cartopy/examples/favicon.py
+++ b/lib/cartopy/examples/favicon.py
@@ -31,12 +31,12 @@ def main():
     on_draw()
 
     # Generate a matplotlib path representing the character "C".
-    fp = FontProperties(family='Arial', weight='bold')
+    fp = FontProperties(family='Bitstream Vera Sans', weight='bold')
     logo_path = matplotlib.textpath.TextPath((-4.5e7, -3.7e7),
                                              'C', size=1, prop=fp)
 
     # Scale the letter up to an appropriate X and Y scale.
-    logo_path._vertices *= np.array([123500000, 103250000])
+    logo_path._vertices *= np.array([103250000, 103250000])
 
     # Add the path as a patch, drawing black outlines around the text.
     patch = matplotlib.patches.PathPatch(logo_path, facecolor='white',

--- a/lib/cartopy/examples/logo.py
+++ b/lib/cartopy/examples/logo.py
@@ -15,11 +15,11 @@ def main():
     ax.gridlines()
 
     # generate a matplotlib path representing the word "cartopy"
-    fp = FontProperties(family='Arial', weight='bold')
+    fp = FontProperties(family='Bitstream Vera Sans', weight='bold')
     logo_path = matplotlib.textpath.TextPath((-175, -35), 'cartopy',
                                              size=1, prop=fp)
     # scale the letters up to sensible longitude and latitude sizes
-    logo_path._vertices *= np.array([95, 160])
+    logo_path._vertices *= np.array([80, 160])
 
     # add a background image
     im = ax.stock_img()


### PR DESCRIPTION
I'm not sure if there's some sort of Visual Identity you're using that made you specifically choose Arial, but it's a non-free font and not generally (though of course widely) available. Bitstream Vera Sans on the other hand is distributed with matplotlib and thus pretty much guaranteed to be installed.

Subjectively, I think the favicon suffers a _little_ bit as the letter has a shorter arc.
![favicon](https://cloud.githubusercontent.com/assets/302469/6430175/d37ba408-bfcc-11e4-9fc5-932110815c55.png)

On the other hand, I find the logo is improved slightly in that the angled sections are more consistent, e.g., on the "r" and "t" the slant is such that there is no overlap.
![logo](https://cloud.githubusercontent.com/assets/302469/6430176/e278cb70-bfcc-11e4-9663-ca947c3be351.png)