### PR TITLE
doc: Remove over-wide paragraphs.

### DIFF
--- a/docs/source/_static/layout.css
+++ b/docs/source/_static/layout.css
@@ -1,5 +1,3 @@
-div.body p { width: 65em; padding-right: 45px; }
-
 .gallery-images img { border: none;}
 .gallery-images p { display: inline;}
 
@@ -8,9 +6,6 @@ div.body p { width: 65em; padding-right: 45px; }
 .highlight {background: none;}
 
 pre {max-width: 70em;}
-div.admonition {width: 65em;}
-div.admonition p {width: 60em;}
-div.admonition p.admonition-title {width: auto;}
 
 div.section dl, div.section ul { max-width: 80em;}
 


### PR DESCRIPTION
These fixed widths overrun into the right sidebar, and in fact appear to be unnecessary.

Removing them goes from this:
![screen shot 2015-03-14 at 19 22 05](https://cloud.githubusercontent.com/assets/302469/6654116/ae476230-ca85-11e4-8732-c2f938eab5dc.png)
to this:
![screen shot 2015-03-14 at 19 22 22](https://cloud.githubusercontent.com/assets/302469/6654117/b1a457ee-ca85-11e4-95ab-bbe36cdb4fc1.png)
(plus it's more responsive, generally.)

Also of note, the link to `MapboxTiles` doesn't work. It appears that `source/index.rst` includes `cartopy/io/img_tiles.rst` in the main toctree, but that file doesn't exist. Was that missing file an oversight? Also, half the links in the Deprecations section of What's New are broken, too.