### PR TITLE
shapely version dependency

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
 Cython>=0.15.1
 numpy>=1.6
-shapely>=1.2.14
+shapely>=1.5.6
 pyshp>=1.1.4
 six>=1.3.0


### PR DESCRIPTION
there is a bug in shapely which I experience with 1.3.2, which fails to handle the changes made to cartopy which I highlighted:
https://github.com/SciTools/cartopy/issues/597

I have not found in Shapely's docs where this may have been fixed, but I can see it workign effectively in 1.5.6

I suggest we update the requirements to 1.5.6 for shapely so we don't suffer from this bug any more