### PR TITLE
Fix Mercator central longitude kwarg

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -949,6 +949,7 @@ class Mercator(Projection):
                       If omitted, a default globe is created.
 
         """
+        central_longitude %= 360
         proj4_params = [('proj', 'merc'),
                         ('lon_0', central_longitude),
                         ('k', 1),
@@ -956,8 +957,10 @@ class Mercator(Projection):
         super(Mercator, self).__init__(proj4_params, globe=globe)
 
         # Calculate limits.
+        west = central_longitude - 180.
+        east = central_longitude + 180.
         limits = self.transform_points(Geodetic(),
-                                       np.array([-180., 180.]),
+                                       np.array([west, east]),
                                        np.array([min_latitude, max_latitude]))
         self._xlimits = tuple(limits[..., 0])
         self._ylimits = tuple(limits[..., 1])

--- a/lib/cartopy/tests/crs/test_mercator.py
+++ b/lib/cartopy/tests/crs/test_mercator.py
@@ -61,6 +61,23 @@ def test_equality():
     assert_equal(hash(crs), hash(crs2))
 
 
+def test_central_longitude():
+    cl = 10.0
+    crs = ccrs.Mercator(central_longitude=cl)
+    proj4_str = ('+ellps=WGS84 +proj=merc +lon_0={} +k=1 '
+                 '+units=m +no_defs'.format(cl))
+    assert_equal(crs.proj4_init, proj4_str)
+
+    assert_almost_equal(crs.boundary.bounds,
+                        [-20037508, -15496570, 20037508, 18764656], decimal=0)
+
+
+def test_large_central_longitude():
+    crs = ccrs.Mercator(central_longitude=540.)
+    crs2 = ccrs.Mercator(central_longitude=180.)
+    assert_equal(crs, crs2)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
Fixes a bug in `cartopy.crs.Mercator` where setting a central longitude not equal to zero causes a draw error.

Fixes #624.