### PR TITLE
Limit libpng version installed on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,24 +32,25 @@ install:
   # ---------------------------------
   - conda config --add channels scitools
   - if [[ "$TRAVIS_PYTHON_VERSION" == 3.4 ]]; then
-      conda install numpy=1.8.2 matplotlib=1.3.1 scipy=0.14.0 libpng=1.5.*;
+      PACKAGES="numpy=1.8.2 matplotlib=1.3.1 scipy=0.14.0 libpng=1.5.*";
     else
-      conda install numpy=1.7.1 matplotlib=1.3.1 scipy=0.12.0 libpng=1.5.*;
+      PACKAGES="numpy=1.7.1 matplotlib=1.3.1 scipy=0.12.0 libpng=1.5.*";
     fi
-  - conda install cython
-  - conda install pillow
-  - conda install mock
-  - conda install nose
+  - PACKAGES="$PACKAGES cython"
+  - PACKAGES="$PACKAGES pillow"
+  - PACKAGES="$PACKAGES mock"
+  - PACKAGES="$PACKAGES nose"
   - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
-      conda install owslib;
+      PACKAGES="$PACKAGES owslib";
     fi
-  - conda install pep8=1.5.7
-  - conda install proj4=4.8   # Until we've updated the tests for 4.9.
-  - conda install pyshp
-  - conda install shapely
-  - conda install six
-  - conda install requests
-  - conda install pyepsg
+  - PACKAGES="$PACKAGES pep8=1.5.7"
+  - PACKAGES="$PACKAGES proj4=4.8"   # Until we've updated the tests for 4.9.
+  - PACKAGES="$PACKAGES pyshp"
+  - PACKAGES="$PACKAGES shapely"
+  - PACKAGES="$PACKAGES six"
+  - PACKAGES="$PACKAGES requests"
+  - PACKAGES="$PACKAGES pyepsg"
+  - conda install $PACKAGES
 
   # Conda debug
   # -----------

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ install:
   # ---------------------------------
   - conda config --add channels scitools
   - if [[ "$TRAVIS_PYTHON_VERSION" == 3.4 ]]; then
-      conda install numpy=1.8.2 matplotlib=1.3.1 scipy=0.14.0;
+      conda install numpy=1.8.2 matplotlib=1.3.1 scipy=0.14.0 libpng=1.5.*;
     else
-      conda install numpy=1.7.1 matplotlib=1.3.1 scipy=0.12.0;
+      conda install numpy=1.7.1 matplotlib=1.3.1 scipy=0.12.0 libpng=1.5.*;
     fi
   - conda install cython
   - conda install pillow


### PR DESCRIPTION
The matplotlib conda packages requires libpng15.so, but does not limit dependencies so that a new version is not installed.

This should reduce the number of build failures, though I'm not sure if they'll all go away.