### PR TITLE
OWSLib Python 3 compatibility

### DIFF
--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -170,7 +170,7 @@ class WMSRasterSource(RasterSource):
 
         """
         contents = self.service.contents
-        for proj, srs in _CRS_TO_OGC_SRS.iteritems():
+        for proj, srs in six.iteritems(_CRS_TO_OGC_SRS):
             missing = any(srs not in contents[layer].crsOptions for
                           layer in self.layers)
             if not missing:
@@ -629,7 +629,7 @@ class WFSGeometrySource(object):
                              'geometries are in multiple SRSs, when only one '
                              'was expected.')
         else:
-            srs, geoms = geoms_by_srs.items()[0]
+            srs, geoms = list(geoms_by_srs.items())[0]
             # Attempt to verify the SRS associated with the geometries (if any)
             # matches the specified projection.
             if srs is not None:

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -389,13 +389,10 @@ class WMTSRasterSource(RasterSource):
 
         # Find which tile matrix has the appropriate resolution.
         max_scale = max_pixel_span * meters_per_unit / METERS_PER_PIXEL
-        ok_tile_matrices = filter(lambda tm: tm.scaledenominator <= max_scale,
-                                  tile_matrices)
-        if ok_tile_matrices:
-            tile_matrix = ok_tile_matrices[0]
-        else:
-            tile_matrix = tile_matrices[-1]
-        return tile_matrix
+        for tm in tile_matrices:
+            if tm.scaledenominator <= max_scale:
+                return tm
+        return tile_matrices[-1]
 
     def _tile_span(self, tile_matrix, meters_per_unit):
         pixel_span = tile_matrix.scaledenominator * (

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -585,13 +585,13 @@ class WFSGeometrySource(object):
                 default_urn = default_urn.pop()
                 default_srs = default_urn.id
 
-            if unicode(default_urn) not in _URN_TO_CRS:
+            if six.text_type(default_urn) not in _URN_TO_CRS:
                 raise ValueError('Unknown mapping from SRS/CRS_URN {!r} to '
                                  'cartopy projection.'.format(default_urn))
 
             self._default_urn = default_urn
 
-        return _URN_TO_CRS[unicode(self._default_urn)]
+        return _URN_TO_CRS[six.text_type(self._default_urn)]
 
     def fetch_geometries(self, projection, extent):
         """

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -30,6 +30,8 @@ this way can be found at :ref:`examples-wmts`.
 
 from __future__ import (absolute_import, division, print_function)
 
+import six
+
 import collections
 import io
 import math
@@ -130,10 +132,10 @@ class WMSRasterSource(RasterSource):
         if WebMapService is None:
             raise ImportError(_OWSLIB_REQUIRED)
 
-        if isinstance(service, basestring):
+        if isinstance(service, six.string_types):
             service = WebMapService(service)
 
-        if isinstance(layers, basestring):
+        if isinstance(layers, six.string_types):
             layers = [layers]
 
         if getmap_extra_kwargs is None:
@@ -547,10 +549,10 @@ class WFSGeometrySource(object):
         if WebFeatureService is None:
             raise ImportError(_OWSLIB_REQUIRED)
 
-        if isinstance(service, basestring):
+        if isinstance(service, six.string_types):
             service = WebFeatureService(service)
 
-        if isinstance(features, basestring):
+        if isinstance(features, six.string_types):
             features = [features]
 
         if getfeature_extra_kwargs is None:


### PR DESCRIPTION
Now that OWSLib has Python 3 support, it seems that there were still a few kinks to work out with its support here. Unfortunately, there is not yet any conda Python 3 package, so you'll just have to take my word for it that it works. (Plus one needs geopython/OWSLib#251 first.)