### PR TITLE
Use new assert_raises_regex name.

### DIFF
--- a/lib/cartopy/tests/mpl/test_ticker.py
+++ b/lib/cartopy/tests/mpl/test_ticker.py
@@ -18,7 +18,11 @@
 from __future__ import (absolute_import, division, print_function)
 
 from mock import Mock
-from nose.tools import assert_equal, assert_raises_regexp
+from nose.tools import assert_equal
+try:
+    from nose.tools import assert_raises_regex
+except ImportError:
+    from nose.tools import assert_raises_regexp as assert_raises_regex
 from matplotlib.axes import Axes
 
 import cartopy.crs as ccrs
@@ -30,7 +34,7 @@ def test_LatitudeFormatter_bad_axes():
     formatter = LatitudeFormatter()
     formatter.axis = Mock(axes=Mock(Axes, projection=ccrs.PlateCarree()))
     message = 'This formatter can only be used with cartopy axes.'
-    with assert_raises_regexp(TypeError, message):
+    with assert_raises_regex(TypeError, message):
         formatter(0)
 
 
@@ -38,7 +42,7 @@ def test_LatitudeFormatter_bad_projection():
     formatter = LatitudeFormatter()
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=ccrs.Orthographic()))
     message = 'This formatter cannot be used with non-rectangular projections.'
-    with assert_raises_regexp(TypeError, message):
+    with assert_raises_regex(TypeError, message):
         formatter(0)
 
 
@@ -46,7 +50,7 @@ def test_LongitudeFormatter_bad_axes():
     formatter = LongitudeFormatter()
     formatter.axis = Mock(axes=Mock(Axes, projection=ccrs.PlateCarree()))
     message = 'This formatter can only be used with cartopy axes.'
-    with assert_raises_regexp(TypeError, message):
+    with assert_raises_regex(TypeError, message):
         formatter(0)
 
 
@@ -54,7 +58,7 @@ def test_LongitudeFormatter_bad_projection():
     formatter = LongitudeFormatter()
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=ccrs.Orthographic()))
     message = 'This formatter cannot be used with non-rectangular projections.'
-    with assert_raises_regexp(TypeError, message):
+    with assert_raises_regex(TypeError, message):
         formatter(0)
 
 


### PR DESCRIPTION
This name replace the old assert_raises_regexp from Python 2 and prevents warnings when using Python 3.4.