### PR TITLE
Update eccentric ellipse example.

### DIFF
--- a/lib/cartopy/examples/eccentric_ellipse.py
+++ b/lib/cartopy/examples/eccentric_ellipse.py
@@ -1,29 +1,72 @@
+"""
+Displaying data on an eccentric ellipse
+---------------------------------------
+
+This example demonstrates plotting data on an eccentric ellipse. The data
+plotted is a topography map of the asteroid Vesta. The map is actually an
+image, which is defined on an equirectangluar projection relative to an
+ellipse with a semi-major axis of 285 km and a semi-minor axis of 229 km.
+The image is reprojected on-the-fly onto a geostationary projection with
+matching eccentricity.
+
+"""
 __tags__ = ['Miscellanea']
-"""
-Eccentric Ellipsoids
---------------------
+try:
+    from urllib2 import urlopen
+except ImportError:
+    from urllib.request import urlopen
+from io import BytesIO
 
-This example demonstrates how :class:`cartopy.crs.Globe` can be used
-to define a highly eccentric elliptical model of a geoid. This globe
-definition is used in defining a Geostationary projection. The projection
-is then visualised with a Natural Earth image and coastlines, which have both
-been reprojected on the fly.
-
-"""
-import matplotlib.pyplot as plt
 import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+import numpy as np
+from PIL import Image
+
+
+def vesta_image():
+    """
+    Return an image of Vesta's topography.
+
+    Image credit: NASA/JPL-Caltech/UCLA/MPS/DLR/IDA/PSI
+
+    Returns
+    -------
+    img : numpy array
+        The pixels of the image in a numpy array.
+    img_proj : cartopy CRS
+        The rectangular coordinate system of the image.
+    img_extent : tuple of floats
+        The extent of the image ``(x0, y0, x1, y1)`` referenced in
+        the ``img_proj`` coordinate system.
+
+    """
+    url = ('http://www.nasa.gov/sites/default/files/pia17037.jpg')
+    img_handle = BytesIO(urlopen(url).read())
+    raw_image = Image.open(img_handle)
+    # The image is extremely high-resolution, which takes a long time to
+    # plot. Sub-sampling reduces the time taken to plot while not
+    # significantly altering the integrity of the result.
+    smaller_image = raw_image.resize([raw_image.size[0] / 10,
+                                      raw_image.size[1] / 10])
+    img = np.asarray(smaller_image)
+    img_proj = ccrs.PlateCarree()
+    img_extent = (-180, 180, 90, -90)
+    return img, img_proj, img_extent
 
 
 def main():
     # We define the semimajor and semiminor axes, but must also tell the
     # globe not to use the WGS84 ellipse, which is its default behaviour.
-    eccentric_globe = ccrs.Globe(semimajor_axis=1000, semiminor_axis=500,
-                                 ellipse=None)
-    geostationary = ccrs.Geostationary(globe=eccentric_globe)
-
-    ax = plt.axes(projection=geostationary)
-    ax.stock_img()
-    ax.coastlines()
+    globe = ccrs.Globe(semimajor_axis=285000., semiminor_axis=229000.,
+                       ellipse=None)
+    projection = ccrs.Geostationary(globe=globe)
+    ax = plt.axes(projection=projection)
+    ax.set_global()
+    img, crs, extent = vesta_image()
+    ax.imshow(img, transform=crs, extent=extent)
+    plt.gcf().text(.075, .012,
+                   "Image credit: NASA/JPL-Caltech/UCLA/MPS/DLR/IDA/PSI",
+                   bbox={'facecolor': 'w', 'edgecolor': 'k'})
     plt.show()
 
 

--- a/lib/cartopy/examples/eccentric_ellipse.py
+++ b/lib/cartopy/examples/eccentric_ellipse.py
@@ -40,7 +40,7 @@ def vesta_image():
         the ``img_proj`` coordinate system.
 
     """
-    url = ('http://www.nasa.gov/sites/default/files/pia17037.jpg')
+    url = 'http://www.nasa.gov/sites/default/files/pia17037.jpg'
     img_handle = BytesIO(urlopen(url).read())
     raw_image = Image.open(img_handle)
     # The image is extremely high-resolution, which takes a long time to
@@ -49,20 +49,20 @@ def vesta_image():
     smaller_image = raw_image.resize([raw_image.size[0] / 10,
                                       raw_image.size[1] / 10])
     img = np.asarray(smaller_image)
-    img_proj = ccrs.PlateCarree()
-    img_extent = (-180, 180, 90, -90)
-    return img, img_proj, img_extent
+    # We define the semimajor and semiminor axes, but must also tell the
+    # globe not to use the WGS84 ellipse, which is its default behaviour.
+    img_globe = ccrs.Globe(semimajor_axis=285000., semiminor_axis=229000.,
+                           ellipse=None)
+    img_proj = ccrs.PlateCarree(globe=img_globe)
+    img_extent = (-895353.906273091, 895353.906273091,
+                  447676.9531365455, -447676.9531365455)
+    return img, img_globe, img_proj, img_extent
 
 
 def main():
-    # We define the semimajor and semiminor axes, but must also tell the
-    # globe not to use the WGS84 ellipse, which is its default behaviour.
-    globe = ccrs.Globe(semimajor_axis=285000., semiminor_axis=229000.,
-                       ellipse=None)
+    img, globe, crs, extent = vesta_image()
     projection = ccrs.Geostationary(globe=globe)
     ax = plt.axes(projection=projection)
-    ax.set_global()
-    img, crs, extent = vesta_image()
     ax.imshow(img, transform=crs, extent=extent)
     plt.gcf().text(.075, .012,
                    "Image credit: NASA/JPL-Caltech/UCLA/MPS/DLR/IDA/PSI",


### PR DESCRIPTION
This PR replaces the existing eccentric ellipse example with a new one that is a bit more physically realistic. It turns out the NASA Dawn mission made a really nice topography map of Vesta (https://en.wikipedia.org/wiki/4_Vesta) which was ~~published~~ updated this month. Vesta has ellipsoid with a semi-major axis of 285 km and a semi-minor axis of 229 km, and plotting this map over an ellipse with these parameters allows you to see this, unlike most realistic ellipsoid shapes for other objects we have nice images/maps for (i.e. Earth, Mars).

I have a few questions about this though, perhaps @pelson or @rhattersley would be able to answer:

1. Is it OK to use this image at all? Currently the example is downloading the image from the NASA website, and I've put an image credit annotation on the plot, which I assume is all OK. However, the image may not persist on the site I retrieved it from (moved, deleted) and I'm not sure if I should worry about that.
2. I'm not actually sure I've done this correctly in cartopy, it feels like I should set the image transform (`img_proj`) with the correct globe as well as the display projection, but when I try this I get an empty plot... what do you think?

The resulting docs page will look like this:

![vesta_example](https://cloud.githubusercontent.com/assets/390602/8953791/faf8a116-35d8-11e5-9127-f356d474394a.png)


