### PR TITLE
Added MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+include *.md
+include CHANGES
+include COPYING*
+include INSTALL
+include README.rst
+include requirements/*.txt
+include lib/cartopy/data/*
+include lib/cartopy/io/srtm.json
+recursive-include lib *.py
+recursive-include lib *.pyx *.pxd *.h


### PR DESCRIPTION
Not sure if a `MANIFEST.in` is desirable here, so feel free to close this PR if it is not.

I had to use the workflow `python setup.py sdist` and then install the tarball today and I noticed that `requirements/` was not a part of the source distribution.

PS: It would be nice to provide `.c` files for non-Cython install too.  I can look into that if there is an interest.