### PR TITLE
Support Python 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,13 @@ docs/build
 # cartopy build files
 lib/cartopy/trace.cpp
 lib/cartopy/trace.so
+lib/cartopy/trace.*.so
 lib/cartopy/_crs.c
 lib/cartopy/_crs.so
+lib/cartopy/_crs.*.so
 lib/cartopy/geodesic/_geodesic.c
 lib/cartopy/geodesic/_geodesic.so
+lib/cartopy/geodesic/_geodesic.*.so
 docs/build
 lib/cartopy/tests/mpl/output/
 docs/source/cartopy_outline.rst

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 env:
     matrix:
         - PYTHON_VERSION=2.7
-          PACKAGES="numpy=1.7.1 matplotlib=1.3.1 scipy=0.12.0"
+          PACKAGES="numpy=1.7.1 matplotlib=1.3.1 scipy=0.12.0 mock"
         - PYTHON_VERSION=3.4
           PACKAGES="numpy=1.8.2 matplotlib=1.3.1 scipy=0.14.0"
         - NAME="Latest everything."
@@ -11,7 +11,7 @@ env:
           PACKAGES="numpy matplotlib matplotlib-tests scipy"
         - NAME="Latest everything (py2k)."
           PYTHON_VERSION=2
-          PACKAGES="numpy matplotlib matplotlib-tests scipy"
+          PACKAGES="numpy matplotlib matplotlib-tests scipy mock"
 
 
 sudo: false
@@ -42,7 +42,7 @@ install:
   # Customise the testing environment
   # ---------------------------------
   - conda config --add channels scitools
-  - PACKAGES="$PACKAGES cython pillow mock nose pep8 proj4 pyshp shapely six requests pyepsg owslib"
+  - PACKAGES="$PACKAGES cython pillow nose pep8 proj4 pyshp shapely six requests pyepsg owslib"
   - conda install --quiet $PACKAGES
 
   # Conda debug

--- a/lib/cartopy/tests/io/test_ogc_clients.py
+++ b/lib/cartopy/tests/io/test_ogc_clients.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2015, Met Office
+# (C) British Crown Copyright 2011 - 2016, Met Office
 #
 # This file is part of cartopy.
 #
@@ -29,7 +29,10 @@ except ImportError:
     WebMapTileService = None
 import unittest
 import cartopy.crs as ccrs
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import numpy as np
 
 

--- a/lib/cartopy/tests/mpl/__init__.py
+++ b/lib/cartopy/tests/mpl/__init__.py
@@ -17,6 +17,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+import base64
 import os
 import glob
 import shutil
@@ -262,7 +263,7 @@ def failed_images_html():
 
     def image_as_base64(fname):
         with open(fname, "rb") as fh:
-            return fh.read().encode("base64").replace("\n", "")
+            return base64.b64encode(fh.read()).decode("ascii")
 
     html = ['<!DOCTYPE html>', '<html>', '<body>']
 

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -21,7 +21,10 @@ import matplotlib as mpl
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from nose.tools import assert_raises
 import numpy as np
 

--- a/lib/cartopy/tests/mpl/test_pseudo_color.py
+++ b/lib/cartopy/tests/mpl/test_pseudo_color.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2014, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of cartopy.
 #
@@ -18,7 +18,10 @@
 from __future__ import (absolute_import, division, print_function)
 
 import matplotlib.pyplot as plt
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from nose.tools import assert_equal
 import numpy as np
 

--- a/lib/cartopy/tests/mpl/test_ticker.py
+++ b/lib/cartopy/tests/mpl/test_ticker.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2015, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of cartopy.
 #
@@ -17,7 +17,10 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from nose.tools import assert_equal
 try:
     from nose.tools import assert_raises_regex

--- a/setup.py
+++ b/setup.py
@@ -409,6 +409,7 @@ setup(
             'Programming Language :: Python :: 3',
             'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
             'Topic :: Scientific/Engineering',
             'Topic :: Scientific/Engineering :: GIS',
             'Topic :: Scientific/Engineering :: Visualization',


### PR DESCRIPTION
Moving `mock` imports around to the standard library, and some other test framework consolidation, but nothing major.

This might still fail due to the bump of matplotlib required with Python 3.5.