### PR TITLE
Fix license typo

### DIFF
--- a/docs/source/copyright.rst
+++ b/docs/source/copyright.rst
@@ -7,14 +7,14 @@ Cartopy copyright, licensing and contributors
 Cartopy code
 ------------
 
-All Iris source code, unless explicitly stated, is |copy| ``British Crown copyright, 2014`` and 
+All Cartopy source code, unless explicitly stated, is |copy| ``British Crown copyright, 2015`` and
 is licensed under the **GNU Lesser General Public License** as published by the
 Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 You should find all source files with the following header:
 
 .. admonition:: Code License
 
-    |copy| British Crown Copyright 2011 - 2014, Met Office
+    |copy| British Crown Copyright 2011 - 2015, Met Office
     
     This file is part of cartopy.
     
@@ -40,7 +40,7 @@ are licensed under the UK's Open Government Licence:
 
 .. admonition:: Documentation, example and data license
  
-    |copy| British Crown copyright, 2014.
+    |copy| British Crown copyright, 2015.
     
     You may use and re-use the information featured on this website (not including logos) free of 
     charge in any format or medium, under the terms of the 

--- a/docs/source/copyright.rst
+++ b/docs/source/copyright.rst
@@ -7,47 +7,48 @@ Cartopy copyright, licensing and contributors
 Cartopy code
 ------------
 
-All Cartopy source code, unless explicitly stated, is |copy| ``British Crown copyright, 2015`` and
-is licensed under the **GNU Lesser General Public License** as published by the
-Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-You should find all source files with the following header:
+All Cartopy source code, unless explicitly stated, is |copy| ``British Crown
+copyright, 2015`` and is licensed under the **GNU Lesser General Public
+License** as published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version. You should find all source
+files with the following header:
 
 .. admonition:: Code License
 
     |copy| British Crown Copyright 2011 - 2015, Met Office
-    
+
     This file is part of cartopy.
-    
+
     Cartopy is free software: you can redistribute it and/or modify it under
     the terms of the GNU Lesser General Public License as published by the
     Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-    
+
     Cartopy is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-    
+
     You should have received a copy of the GNU Lesser General Public License
-    along with cartopy.  If not, see `<http://www.gnu.org/licenses/>`_. 
+    along with cartopy.  If not, see `<http://www.gnu.org/licenses/>`_.
 
 
 Cartopy documentation and examples
 ----------------------------------
 
-All documentation, examples and sample data found on this website and in source repository 
-are licensed under the UK's Open Government Licence:
+All documentation, examples and sample data found on this website and in source
+repository are licensed under the UK's Open Government Licence:
 
 .. admonition:: Documentation, example and data license
- 
-    |copy| British Crown copyright, 2015.
-    
-    You may use and re-use the information featured on this website (not including logos) free of 
-    charge in any format or medium, under the terms of the 
-    `Open Government Licence <http://reference.data.gov.uk/id/open-government-licence>`_. 
-    We encourage users to establish hypertext links to this website.
-    
-    Any email enquiries regarding the use and re-use of this information resource should be 
-    sent to: psi@nationalarchives.gsi.gov.uk.
 
+    |copy| British Crown copyright, 2015.
+
+    You may use and re-use the information featured on this website (not
+    including logos) free of charge in any format or medium, under the terms of
+    the `Open Government Licence
+    <http://reference.data.gov.uk/id/open-government-licence>`_. We encourage
+    users to establish hypertext links to this website.
+
+    Any email enquiries regarding the use and re-use of this information
+    resource should be sent to: psi@nationalarchives.gsi.gov.uk.
 


### PR DESCRIPTION
`docs/source/copyright.rst` says _Iris_, not Cartopy. Also, update the dates and word wrapping while I'm there.