### PR TITLE
Remove documentation of 'target_extent' argument to imshow

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -832,10 +832,6 @@ class GeoAxes(matplotlib.axes.Axes):
             The corner coordinates of the image in the form
             ``(left, right, bottom, top)``. The coordinates should be in the
             coordinate system passed to the transform keyword.
-        target_extent : tuple
-            The corner coordinate of the desired image in the form
-            ``(left, right, bottom, top)``. The coordinates should be in the
-            coordinate system passed to the transform keyword.
         origin : {'lower', 'upper'}
             The origin of the vertical pixels. See
             :func:`matplotlib.pyplot.imshow` for further details. Default


### PR DESCRIPTION
This isn't actually an accepted argument by the looks of it