### PR TITLE
Improve error message from setting an invalid extent.

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -585,7 +585,18 @@ class GeoAxes(matplotlib.axes.Axes):
 
         if projected is None:
             projected = self.projection.project_geometry(domain_in_crs, crs)
-        x1, y1, x2, y2 = projected.bounds
+        try:
+            # This might fail with an unhelpful error message ('need more
+            # than 0 values to unpack') if the specified extents fall outside
+            # the projection extents, so try and give a better error message.
+            x1, y1, x2, y2 = projected.bounds
+        except ValueError:
+            msg = ('Failed to determine the required bounds in projection '
+                   'coordinates. Check that the values provided are within '
+                   'the valid range (x_limits=[{xlim[0]}, {xlim[1]}], '
+                   'y_limits=[{ylim[0]}, {ylim[1]}]).')
+            raise ValueError(msg.format(xlim=self.projection.x_limits,
+                                        ylim=self.projection.y_limits))
         self.set_xlim([x1, x2])
         self.set_ylim([y1, y2])
 


### PR DESCRIPTION
If you do try and use `GeoAxes.set_extent` and specify values outside the exent of the axes projection, the method may internally generate an empty geometry with no bounds, which will generate an unhelpful error message to the end-user referring to unpacking a tuple. This PR simply catches this `ValueError` exception and raises a new `ValueError` with a more appropriate error message. See #703 for background.

I'm not sure if this is the best way to approach this, the original issue #703 might be more complex than I have accounted for.

I've targeted v0.13.x, since this could be thought of as a bug fix.