### PR TITLE
Add Sinusoidal projection

### DIFF
--- a/docs/make_projection.py
+++ b/docs/make_projection.py
@@ -42,7 +42,7 @@ PRJ_SORT_ORDER = {'PlateCarree': 1,
                   'TransverseMercator': 2, 'LambertCylindrical': 2,
                   'LambertConformal': 2, 'Stereographic': 2, 'Miller': 2,
                   'Orthographic': 2, 'UTM': 2, 'AlbersEqualArea': 2,
-                  'AzimuthalEquidistant': 2,
+                  'AzimuthalEquidistant': 2, 'Sinusoidal': 2,
                   'InterruptedGoodeHomolosine': 3, 'RotatedPole': 3,
                   'OSGB': 4}
 

--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -31,6 +31,7 @@ the package wouldn't be as rich or diverse as it is today:
  * Laura Dreyer
  * Daniel Atton Beckmann
  * Joseph Hogg
+ * Zachary Tessler
 
 
 Thank you!

--- a/docs/source/crs/projections.rst
+++ b/docs/source/crs/projections.rst
@@ -42,7 +42,7 @@ AlbersEqualArea
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(5.12985642927, 3))
+    plt.figure(figsize=(5.129856429268199, 3))
     ax = plt.axes(projection=ccrs.AlbersEqualArea())
     ax.coastlines(resolution='110m')
     ax.gridlines()
@@ -74,7 +74,7 @@ LambertConformal
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(4.28969332205, 3))
+    plt.figure(figsize=(4.28969332204859, 3))
     ax = plt.axes(projection=ccrs.LambertConformal())
     ax.coastlines(resolution='110m')
     ax.gridlines()
@@ -90,7 +90,7 @@ LambertCylindrical
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(9.42477796077, 3))
+    plt.figure(figsize=(9.42477796076938, 3))
     ax = plt.axes(projection=ccrs.LambertCylindrical())
     ax.coastlines(resolution='110m')
     ax.gridlines()
@@ -106,7 +106,7 @@ Mercator
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(3.50907018473, 3))
+    plt.figure(figsize=(3.5090701847348473, 3))
     ax = plt.axes(projection=ccrs.Mercator())
     ax.coastlines(resolution='110m')
     ax.gridlines()
@@ -122,7 +122,7 @@ Miller
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(4.09152901955, 3))
+    plt.figure(figsize=(4.091529019548417, 3))
     ax = plt.axes(projection=ccrs.Miller())
     ax.coastlines(resolution='110m')
     ax.gridlines()
@@ -170,8 +170,24 @@ Robinson
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(5.91496652704, 3))
+    plt.figure(figsize=(5.914966076674721, 3))
     ax = plt.axes(projection=ccrs.Robinson())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
+
+
+Sinusoidal
+----------
+
+.. autoclass:: cartopy.crs.Sinusoidal
+
+.. plot::
+
+    import matplotlib.pyplot as plt
+    import cartopy.crs as ccrs
+
+    plt.figure(figsize=(6.0100710855457855, 3))
+    ax = plt.axes(projection=ccrs.Sinusoidal())
     ax.coastlines(resolution='110m')
     ax.gridlines()
 
@@ -218,7 +234,7 @@ UTM
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(0.128571428571, 3))
+    plt.figure(figsize=(0.12857142857142856, 3))
     ax = plt.axes(projection=ccrs.UTM(zone=30))
     ax.coastlines(resolution='110m')
     ax.gridlines()
@@ -234,7 +250,7 @@ InterruptedGoodeHomolosine
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(6.92280629527, 3))
+    plt.figure(figsize=(6.922806295266478, 3))
     ax = plt.axes(projection=ccrs.InterruptedGoodeHomolosine())
     ax.coastlines(resolution='110m')
     ax.gridlines()
@@ -251,7 +267,7 @@ RotatedPole
     import cartopy.crs as ccrs
 
     plt.figure(figsize=(6, 3))
-    ax = plt.axes(projection=ccrs.RotatedPole(pole_latitude=37.5, pole_longitude=177.5))
+    ax = plt.axes(projection=ccrs.RotatedPole(pole_longitude=177.5, pole_latitude=37.5))
     ax.coastlines(resolution='110m')
     ax.gridlines()
 
@@ -266,7 +282,7 @@ OSGB
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(1.61538461538, 3))
+    plt.figure(figsize=(1.6153846153846154, 3))
     ax = plt.axes(projection=ccrs.OSGB())
     ax.coastlines(resolution='50m')
     ax.gridlines()
@@ -282,7 +298,7 @@ EuroPP
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(2.61538461538, 3))
+    plt.figure(figsize=(2.6153846153846154, 3))
     ax = plt.axes(projection=ccrs.EuroPP())
     ax.coastlines(resolution='50m')
     ax.gridlines()
@@ -330,7 +346,7 @@ LambertAzimuthalEqualArea
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(3.00670336247, 3))
+    plt.figure(figsize=(3.0065680601446605, 3))
     ax = plt.axes(projection=ccrs.LambertAzimuthalEqualArea())
     ax.coastlines(resolution='110m')
     ax.gridlines()
@@ -362,7 +378,7 @@ OSNI
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(2.43233741378, 3))
+    plt.figure(figsize=(2.4323374137753486, 3))
     ax = plt.axes(projection=ccrs.OSNI())
     ax.coastlines(resolution='10m')
     ax.gridlines()

--- a/lib/cartopy/tests/crs/test_sinusoidal.py
+++ b/lib/cartopy/tests/crs/test_sinusoidal.py
@@ -1,0 +1,87 @@
+# (C) British Crown Copyright 2016, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+
+import unittest
+
+import numpy as np
+from numpy.testing import assert_almost_equal
+from nose.tools import assert_equal
+
+import cartopy.crs as ccrs
+
+
+class TestSinusoidal(unittest.TestCase):
+    def test_default(self):
+        crs = ccrs.Sinusoidal()
+        expected = ('+ellps=WGS84 +proj=sinu +lon_0=0.0 '
+                    '+x_0=0.0 +y_0=0.0 +no_defs')
+        assert_equal(crs.proj4_init, expected)
+
+        assert_almost_equal(np.array(crs.x_limits),
+                            [-20037508.3428, 20037508.3428],
+                            decimal=4)
+        assert_almost_equal(np.array(crs.y_limits),
+                            [-10001965.7293, 10001965.7293],
+                            decimal=4)
+
+    def test_eccentric_globe(self):
+        globe = ccrs.Globe(semimajor_axis=1000, semiminor_axis=500,
+                           ellipse=None)
+        crs = ccrs.Sinusoidal(globe=globe)
+        expected = ('+a=1000 +b=500 +proj=sinu +lon_0=0.0 +x_0=0.0 '
+                    '+y_0=0.0 +no_defs')
+        assert_equal(crs.proj4_init, expected)
+
+        assert_almost_equal(np.array(crs.x_limits),
+                            [-3141.59, 3141.59], decimal=2)
+        assert_almost_equal(np.array(crs.y_limits),
+                            [-1216.60, 1216.60], decimal=2)
+
+    def test_offset(self):
+        crs = ccrs.Sinusoidal()
+        crs_offset = ccrs.Sinusoidal(false_easting=1234,
+                                     false_northing=-4321)
+        expected = ('+ellps=WGS84 +proj=sinu +lon_0=0.0 +x_0=1234 '
+                    '+y_0=-4321 +no_defs')
+        assert_equal(crs_offset.proj4_init, expected)
+        assert_equal(tuple(np.array(crs.x_limits) + 1234),
+                     crs_offset.x_limits)
+        assert_equal(tuple(np.array(crs.y_limits) - 4321),
+                     crs_offset.y_limits)
+
+    def test_MODIS(self):
+        # Testpoints verified with MODLAND Tile Calculator
+        # http://landweb.nascom.nasa.gov/cgi-bin/developer/tilemap.cgi
+        # Settings: Sinusoidal, Global map coordinates, Forward mapping
+        crs = ccrs.MODIS
+        lons = np.array([-180, -50, 40, 180])
+        lats = np.array([-89.999, 30, 20, 89.999])
+        expected_x = np.array([-349.33, -4814886.99,
+                               4179566.79, 349.33])
+        expected_y = np.array([-10007443.48, 3335851.56,
+                               2223901.04, 10007443.48])
+        assert_almost_equal(crs.transform_points(crs.as_geodetic(),
+                                                 lons, lats),
+                            np.c_[expected_x, expected_y, [0, 0, 0, 0]],
+                            decimal=2)
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
The sinusoidal projection is needed for working with MODIS data in its original projection, this resolves #650.  Open pull request #659 provides similar functionality, though appears abandoned.  I've added an instance of the Sinusoidal class for working with MODIS data, which uses a spherical globe, similar to the GOOGLE_MERCATOR instance in crs.py.  Guidance on setting self._threshold would be appreciated, I'm currently using the heuristic in https://github.com/SciTools/cartopy/blob/master/lib/cartopy/crs.py#L199.

The only issue I've found is that stock_img() has problems at the poles, the image is not being clipped correctly and is drawn outside the projection boundary.  I'm not sure if this is indicative of a problem with the projection itself or is a bug in stock_img, as this projection is the first with non-smooth pole boundaries.