### PR TITLE
Add support for SRTM with 1 arc-second resolution.

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -14,11 +14,13 @@ Features
   :meth:`cartopy.mpl.geoaxes.GeoAxes.tissot` which draws Tissot's indicatrices on the axes.
 
 * The SRTM3 data source has been changed to the `LP DAAC Data Pool
-  <https://lpdaac.usgs.gov/data_access/data_pool>`. The Data Pool is more
+  <https://lpdaac.usgs.gov/data_access/data_pool>`_. The Data Pool is more
   consistent, fixing several missing tiles, and the data is void-filled.
   Consequently, the :func:`cartopy.srtm.fill_gaps` function has been deprecated
   as it has no purpose. The :ref:`SRTM example<examples-srtm_shading>` has also
-  been updated to skip the void-filling step.
+  been updated to skip the void-filling step. Additionally, this data source
+  provides SRTM at a higher resolution of 1 arc-second, which may be accessed
+  via :class:`cartopy.io.srtm.SRTM1Source`.
 
 
 

--- a/lib/cartopy/examples/srtm_shading.py
+++ b/lib/cartopy/examples/srtm_shading.py
@@ -11,7 +11,7 @@ from cartopy.io import srtm
 import matplotlib.pyplot as plt
 
 from cartopy.io import PostprocessedRasterSource, LocatedImage
-from cartopy.io.srtm import SRTM3Source
+from cartopy.io.srtm import SRTM3Source, SRTM1Source
 
 
 def shade(located_elevations):
@@ -25,12 +25,13 @@ def shade(located_elevations):
     return LocatedImage(new_img, located_elevations.extent)
 
 
-def main():
+def plot(Source, name):
+    plt.figure()
     ax = plt.axes(projection=ccrs.PlateCarree())
 
-    # Define a raster source which uses the SRTM3 data and applies the
+    # Define a raster source which uses the SRTM data and applies the
     # shade function when the data is retrieved.
-    shaded_srtm = PostprocessedRasterSource(SRTM3Source(), shade)
+    shaded_srtm = PostprocessedRasterSource(Source(), shade)
 
     # Add the shaded SRTM source to our map with a grayscale colormap.
     ax.add_raster(shaded_srtm, cmap='Greys')
@@ -39,11 +40,16 @@ def main():
     # interesting orography.
     ax.set_extent([12, 13, 47, 48])
 
-    plt.title("SRTM Shaded Relief Map")
+    plt.title(name + " Shaded Relief Map")
 
     gl = ax.gridlines(draw_labels=True)
     gl.xlabels_top = False
     gl.ylabels_left = False
+
+
+def main():
+    plot(SRTM3Source, 'SRTM3')
+    plot(SRTM1Source, 'SRTM1')
 
     plt.show()
 


### PR DESCRIPTION
The LP DAAC provides SRTM at 3 and 1 arc-second resolution. This PR adds support for the 1 arc-second dataset.