### PR TITLE
Matplotlib update

### DIFF
--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2015, Met Office
+# (C) British Crown Copyright 2011 - 2016, Met Office
 #
 # This file is part of cartopy.
 #
@@ -122,7 +122,7 @@ class FeatureArtist(matplotlib.artist.Artist):
         if not self.get_visible():
             return
 
-        ax = self.get_axes()
+        ax = self.axes
         feature_crs = self._feature.crs
 
         # Get geometries that we need to draw.

--- a/lib/cartopy/mpl/slippy_image_artist.py
+++ b/lib/cartopy/mpl/slippy_image_artist.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of cartopy.
 #
@@ -47,7 +47,7 @@ class SlippyImageArtist(AxesImage):
         if not self.get_visible():
             return
 
-        ax = self.get_axes()
+        ax = self.axes
         window_extent = ax.get_window_extent()
         [x1, y1], [x2, y2] = ax.viewLim.get_points()
         located_images = self.raster_source.fetch_raster(


### PR DESCRIPTION
This updates all test images for matplotlib 1.5.1. Instead of providing multiple copies of images, I've made it possible to vary the tolerance for any versions of matplotlib.

There are still a couple of things that don't work:
 * `cartopy.tests.mpl.test_set_extent.test_view_lim_autoscaling` - This changed in 1.4 and 1.5, but the results do not look reasonable. Some of the difference may be due to #707?
 * `cartopy.tests.mpl.test_mpl_integration.test_pcolormesh_limited_area_wrap` - This one is due to #707, and I'm not totally sure it's intended.
 * `cartopy.tests.mpl.test_set_extent.test_limits_pcolor` - This one is due to #707 as well, but the result also seems a bit weird.
 * `cartopy.tests.mpl.test_mpl_integration.global_contourf_wrap` and `cartopy.mpl.test_mpl_integration.global_pcolor_wrap` - These have some rather large changes; the horizontal axis seems a bit cropped and the vertical axis seems a bit bigger. It seems like it might be a bug somewhere.