### PR TITLE
Identified the major difference between the images from v1.3 of matplotlib and v1.4.

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1386,10 +1386,6 @@ class GeoAxes(matplotlib.axes.Axes):
                         # scale the data according to the *original* data
                         pcolor_col.norm.autoscale_None(C)
 
-                        # Update the datalim for this pcolor.
-                        limits = pcolor_col.get_datalim(self.axes.transData)
-                        self.axes.update_datalim(limits)
-
                         # put the pcolor_col on the pcolormesh collection so
                         # that if really necessary, users can do things post
                         # this method
@@ -1422,6 +1418,11 @@ class GeoAxes(matplotlib.axes.Axes):
                              ' consider using PlateCarree/RotatedPole.')
         kwargs.setdefault('transform', t)
         result = matplotlib.axes.Axes.pcolor(self, *args, **kwargs)
+
+        # Update the datalim for this pcolor.
+        limits = result.get_datalim(self.axes.transData)
+        self.axes.update_datalim(limits)
+
         self.autoscale_view()
         return result
 

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2015, Met Office
+# (C) British Crown Copyright 2011 - 2016, Met Office
 #
 # This file is part of cartopy.
 #
@@ -41,7 +41,10 @@ REGIONAL_IMG = os.path.join(config['repo_data_dir'], 'raster', 'sample',
                             'Miriam.A2012270.2050.2km.jpg')
 
 
-@ImageTesting(['web_tiles'], tolerance=0.5)
+# We have an exceptionally large tolerance for the web_tiles test.
+# The basemap changes on a regular basis (for seasons) and we really only
+# care that it is putting images onto the map which are roughly correct.
+@ImageTesting(['web_tiles'], tolerance=2)
 def test_web_tiles():
     extent = [-15, 0.1, 50, 60]
     target_domain = sgeom.Polygon([[extent[0], extent[1]],


### PR DESCRIPTION
Frustratingly, this tiny PR represents a good 3 hour's work. :anguished: 
It makes pcolormesh work nicely across matplotlib v1.3 and v1.5 for all of the cases I've tested.

Ping @QuLogic 