### PR TITLE
Download data and tiles over https where available.

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -27,6 +27,10 @@ Features
   provides SRTM at a higher resolution of 1 arc-second, which may be accessed
   via :class:`cartopy.io.srtm.SRTM1Source`.
 
+* All downloaders will use secure connections where available. Note that not
+  every service supports this method, and so will use insecure HTTP connections
+  instead. (See :pull:`736` for full list.)
+
 Incompatible changes
 --------------------
 * :meth:`cartopy.crs.CRS.transform_point` now issues NaNs when invalid transforms are identified.

--- a/lib/cartopy/examples/eccentric_ellipse.py
+++ b/lib/cartopy/examples/eccentric_ellipse.py
@@ -40,7 +40,7 @@ def vesta_image():
         the ``img_proj`` coordinate system.
 
     """
-    url = 'http://www.nasa.gov/sites/default/files/pia17037.jpg'
+    url = 'https://www.nasa.gov/sites/default/files/pia17037.jpg'
     img_handle = BytesIO(urlopen(url).read())
     raw_image = Image.open(img_handle)
     # The image is extremely high-resolution, which takes a long time to

--- a/lib/cartopy/examples/wmts.py
+++ b/lib/cartopy/examples/wmts.py
@@ -21,7 +21,7 @@ import matplotlib.pyplot as plt
 
 
 def main():
-    url = 'http://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi'
+    url = 'https://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi'
     layer = 'VIIRS_CityLights_2012'
 
     ax = plt.axes(projection=ccrs.PlateCarree())

--- a/lib/cartopy/io/__init__.py
+++ b/lib/cartopy/io/__init__.py
@@ -289,14 +289,14 @@ class Downloader(object):
 
         >>> from cartopy.io import Downloader
         >>>
-        >>> dnldr = Downloader('http://example.com/{name}', './{name}.txt')
+        >>> dnldr = Downloader('https://example.com/{name}', './{name}.txt')
         >>> config = {('level_1', 'level_2'): dnldr}
         >>> d1 = Downloader.from_config(('level_1', 'level_2', 'level_3'),
         ...                             config_dict=config)
         >>> print(d1.url_template)
-        http://example.com/{name}
+        https://example.com/{name}
         >>> print(d1.url({'name': 'item_name'}))
-        http://example.com/item_name
+        https://example.com/item_name
 
         """
         spec_depth = len(specification)

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -173,7 +173,7 @@ class GoogleTiles(object):
             "satellite": "s",
             "terrain": "t",
             "only_streets": "h"}
-        url = ('http://mts0.google.com/vt/lyrs={style}@177000000&hl=en&'
+        url = ('https://mts0.google.com/vt/lyrs={style}@177000000&hl=en&'
                'src=api&x={tile_x}&y={tile_y}&z={tile_z}&s=G'.format(
                    style=style_dict[self.style],
                    tile_x=tile[0],
@@ -224,7 +224,7 @@ class OSM(GoogleTiles):
     # http://developer.mapquest.com/web/products/open/map for terms of use
     def _image_url(self, tile):
         x, y, z = tile
-        url = 'http://a.tile.openstreetmap.org/%s/%s/%s.png' % (z, x, y)
+        url = 'https://a.tile.openstreetmap.org/%s/%s/%s.png' % (z, x, y)
         return url
 
 
@@ -282,7 +282,7 @@ class MapboxTiles(GoogleTiles):
 
     def _image_url(self, tile):
         x, y, z = tile
-        url = ('http://api.tiles.mapbox.com/v4/{mapid}/{z}/{x}/{y}.png?'
+        url = ('https://api.tiles.mapbox.com/v4/{mapid}/{z}/{x}/{y}.png?'
                'access_token={token}'.format(z=z, y=y, x=x,
                                              mapid=self.map_id,
                                              token=self.access_token))

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -390,7 +390,7 @@ class GSHHSShpDownloader(Downloader):
     """
     FORMAT_KEYS = ('config', 'scale', 'level')
 
-    _GSHHS_URL_TEMPLATE = ('http://www.ngdc.noaa.gov/mgg/shorelines/data/'
+    _GSHHS_URL_TEMPLATE = ('https://www.ngdc.noaa.gov/mgg/shorelines/data/'
                            'gshhs/oldversions/version2.2.0/'
                            'GSHHS_shp_2.2.0.zip')
 

--- a/lib/cartopy/tests/io/test_downloaders.py
+++ b/lib/cartopy/tests/io/test_downloaders.py
@@ -32,7 +32,7 @@ from cartopy.tests.mpl.test_caching import CallCounter
 
 
 def test_Downloader_data():
-    di = cio.Downloader('http://testing.com/{category}/{name}.zip',
+    di = cio.Downloader('https://testing.com/{category}/{name}.zip',
                         os.path.join('{data_dir}', '{category}',
                                      'shape.shp'),
                         '/project/foobar/{category}/sample.shp')
@@ -42,7 +42,7 @@ def test_Downloader_data():
                         'data_dir': os.path.join('/wibble', 'foo', 'bar')}
 
     assert_equal(di.url(replacement_dict),
-                 'http://testing.com/example/test.zip')
+                 'https://testing.com/example/test.zip')
 
     assert_equal(di.target_path(replacement_dict),
                  os.path.join('/wibble', 'foo', 'bar', 'example', 'shape.shp')
@@ -87,7 +87,7 @@ def download_to_temp():
 
 
 def test_from_config():
-    generic_url = 'http://example.com/generic_ne/{name}.zip'
+    generic_url = 'https://example.com/generic_ne/{name}.zip'
 
     land_downloader = cio.Downloader(generic_url, '', '')
     generic_ne_downloader = cio.Downloader(generic_url, '', '')
@@ -107,7 +107,7 @@ def test_from_config():
 
         # check the resulting download item produces a sensible url.
         assert_equal(r.url({'name': 'ocean'}),
-                     'http://example.com/generic_ne/ocean.zip')
+                     'https://example.com/generic_ne/ocean.zip')
 
         downloaders = cio.config['downloaders']
 
@@ -119,7 +119,7 @@ def test_downloading_simple_ascii():
     # downloads a file from the Google APIs. (very high uptime and file will
     # always be there - if this goes down, most of the internet would break!)
     # to test the downloading mechanisms.
-    file_url = 'http://ajax.googleapis.com/ajax/libs/jquery/1.8.2/{name}.js'
+    file_url = 'https://ajax.googleapis.com/ajax/libs/jquery/1.8.2/{name}.js'
 
     format_dict = {'name': 'jquery'}
 

--- a/lib/cartopy/tests/io/test_ogc_clients.py
+++ b/lib/cartopy/tests/io/test_ogc_clients.py
@@ -135,7 +135,7 @@ class test_WMSRasterSource(unittest.TestCase):
 
 @unittest.skipIf(not _OWSLIB_AVAILABLE, 'OWSLib is unavailable.')
 class test_WMTSRasterSource(unittest.TestCase):
-    URI = 'http://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi'
+    URI = 'https://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi'
     layer_name = 'VIIRS_CityLights_2012'
     projection = ccrs.PlateCarree()
 
@@ -175,7 +175,7 @@ class test_WMTSRasterSource(unittest.TestCase):
 
 @unittest.skipIf(not _OWSLIB_AVAILABLE, 'OWSLib is unavailable.')
 class test_WFSGeometrySource(unittest.TestCase):
-    URI = 'http://nsidc.org/cgi-bin/atlas_south?service=WFS'
+    URI = 'https://nsidc.org/cgi-bin/atlas_south?service=WFS'
     typename = 'land_excluding_antarctica'
     native_projection = ccrs.Stereographic(central_latitude=-90,
                                            true_scale_latitude=-71)

--- a/lib/cartopy/tests/mpl/test_caching.py
+++ b/lib/cartopy/tests/mpl/test_caching.py
@@ -194,7 +194,7 @@ def test_wmts_tile_caching():
     image_cache.clear()
     assert len(image_cache) == 0
 
-    url = 'http://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi'
+    url = 'https://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi'
     wmts = WebMapTileService(url)
     layer_name = 'MODIS_Terra_CorrectedReflectance_TrueColor'
 

--- a/lib/cartopy/tests/mpl/test_features.py
+++ b/lib/cartopy/tests/mpl/test_features.py
@@ -69,7 +69,7 @@ def test_gshhs():
 @ImageTesting(['wfs'])
 def test_wfs():
     ax = plt.axes(projection=ccrs.OSGB())
-    url = 'http://nsidc.org/cgi-bin/atlas_south?service=WFS'
+    url = 'https://nsidc.org/cgi-bin/atlas_south?service=WFS'
     typename = 'land_excluding_antarctica'
     feature = cfeature.WFSFeature(url, typename,
                                   edgecolor='red')

--- a/lib/cartopy/tests/mpl/test_web_services.py
+++ b/lib/cartopy/tests/mpl/test_web_services.py
@@ -30,7 +30,7 @@ from cartopy.io.ogc_clients import _OWSLIB_AVAILABLE
 @ImageTesting(['wmts'])
 def test_wmts():
     ax = plt.axes(projection=ccrs.PlateCarree())
-    url = 'http://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi'
+    url = 'https://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi'
     # Use a layer which doesn't change over time.
     ax.add_wmts(url, 'MODIS_Water_Mask')
 

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -44,7 +44,7 @@ KNOWN_EXTENTS = {(0, 0, 0): (-20037508.342789244, 20037508.342789244,
 
 
 def GOOGLE_IMAGE_URL_REPLACEMENT(self, tile):
-    url = ('http://chart.apis.google.com/chart?chst=d_text_outline&'
+    url = ('https://chart.googleapis.com/chart?chst=d_text_outline&'
            'chs=256x256&chf=bg,s,00000055&chld=FFFFFF|16|h|000000|b||||'
            'Google:%20%20(' + str(tile[0]) + ',' + str(tile[1]) + ')'
            '|Zoom%20' + str(tile[2]) + '||||||______________________'
@@ -59,7 +59,7 @@ def test_google_tile_styles():
     This is essentially just assures information is properly propagated through
     the class structure.
     """
-    reference_url = ("http://mts0.google.com/vt/lyrs={style}@177000000&hl=en"
+    reference_url = ("https://mts0.google.com/vt/lyrs={style}@177000000&hl=en"
                      "&src=api&x=1&y=2&z=3&s=G")
     tile = ["1", "2", "3"]
 
@@ -201,7 +201,7 @@ def test_mapbox_tiles():
     token = 'foo'
     map_id = 'bar'
     tile = [0, 1, 2]
-    exp_url = 'http://api.tiles.mapbox.com/v4/bar/2/0/1.png?access_token=foo'
+    exp_url = 'https://api.tiles.mapbox.com/v4/bar/2/0/1.png?access_token=foo'
 
     mapbox_sample = cimgt.MapboxTiles(token, map_id)
     url_str = mapbox_sample._image_url(tile)


### PR DESCRIPTION
Use https for:
 * Google tiles
 * Some NASA references
 * OpenStreetMap
 * MapBox
 * All example & test URLs

What's left is:
 * Anything from osgeo; their certificate is for *.osgeo.org only and none of the subdomains where the tiles are served.
 * SRTM
 * MapQuest; maybe a new API works over https, but I'm not sure and don't really want to dive into it.
 * The Stamen terrain tiles
 * NaturalEarth
 * VirtualEarth

BTW, it's rather disappointing that even the MetOffice still isn't available over https.