### PR TITLE
Add .pyd files (build products on Windows) to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,15 @@ docs/build
 lib/cartopy/trace.cpp
 lib/cartopy/trace.so
 lib/cartopy/trace.*.so
+lib/cartopy/trace.pyd
 lib/cartopy/_crs.c
 lib/cartopy/_crs.so
 lib/cartopy/_crs.*.so
+lib/cartopy/_crs.pyd
 lib/cartopy/geodesic/_geodesic.c
 lib/cartopy/geodesic/_geodesic.so
 lib/cartopy/geodesic/_geodesic.*.so
+lib/cartopy/geodesic/_geodesic.pyd
 docs/build
 lib/cartopy/tests/mpl/output/
 docs/source/cartopy_outline.rst

--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -32,6 +32,7 @@ the package wouldn't be as rich or diverse as it is today:
  * Daniel Atton Beckmann
  * Joseph Hogg
  * Zachary Tessler
+ * Daniel Eriksson
 
 
 Thank you!


### PR DESCRIPTION
Lately I've been struggling with figuring out how to build cartopy on Windows. It's been somewhat problematic so if anyone has any advice I'd be all ears. Specifically I've had to modify `setup.py` by hand to get the geos and proj.4 dependencies to work.

Anyway, one of the easier issues I encountered was that .pyd files started cluttering my git after build. These are build products on Windows so I decided to add them to .gitignore.