### PR TITLE
Fix bug in setup.py

### DIFF
--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -31,6 +31,7 @@ the package wouldn't be as rich or diverse as it is today:
  * Laura Dreyer
  * Daniel Atton Beckmann
  * Joseph Hogg
+ * Louis Tiao
  * Zachary Tessler
 
 

--- a/setup.py
+++ b/setup.py
@@ -286,7 +286,9 @@ else:
             proj_includes = proj_includes.decode()
             proj_clibs = proj_clibs.decode()
 
-        proj_includes = proj_includes.split()
+        proj_includes = [proj_include[2:] if proj_include.startswith('-I') else
+                         proj_include for proj_include in proj_includes.split()]      
+
         proj_libraries = []
         proj_library_dirs = []
         for entry in proj_clibs.split():


### PR DESCRIPTION
On Mac OS X 10.11.4, with both Python 2.7.11 and Python 3.5.1, and the requirements installed (Cython 0.23.5, NumPy 1.11.0, geos 3.5.0, proj 4.9.2):

```
$ brew install geos
$ brew install proj
$ mkvirtualenv cartopy
(cartopy)$ pip install cython
(cartopy)$ pip install numpy
```

We get:

```
(cartopy)$ pip install cartopy
    [...]
    clang -fno-strict-aliasing -fno-common -dynamic -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/include -I./lib/cartopy -I-I/usr/local/Cellar/proj/4.9.2/include -I/usr/local/Cellar/geos/3.5.0/include -I/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c lib/cartopy/trace.cpp -o build/temp.macosx-10.11-x86_64-2.7/lib/cartopy/trace.o
    lib/cartopy/trace.cpp:249:10: fatal error: 'proj_api.h' file not found
    #include "proj_api.h"
             ^
    1 error generated.
    error: command 'clang' failed with exit status 1

    ----------------------------------------
```

Note the relevant `--include-dir` (`-I`) flags above:

- `-I/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/include`
- `-I./lib/cartopy`
- `-I-I/usr/local/Cellar/proj/4.9.2/include`
- `-I/usr/local/Cellar/geos/3.5.0/include` 
- `-I/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/include/python2.7`

We see that the directory `/usr/local/Cellar/proj/4.9.2/include` has `-I` prepended twice. 

Also, upon further inspection, `proj_api.h` does in fact exist in that directory:

```
$ ls /usr/local/Cellar/proj/4.9.2/include
geodesic.h              org_proj4_PJ.h          org_proj4_Projections.h proj_api.h              projects.h
```

Looking at [line 260](https://github.com/SciTools/cartopy/blob/cb00b7d2e89aa0982a28e7d7dcd32ee553e42e10/setup.py#L260) of `setup.py` in the latest commit, we have 

``` Python
proj_includes = subprocess.check_output(['pkg-config', '--cflags', 'proj'])
```
Executing the command gives 

```
$ pkg-config --cflags proj
-I/usr/local/Cellar/proj/4.9.2/include
```
And we find that we're able to install `cartopy` with no problems by supplying the following flags to `pip`:

```
$ pip install --global-option=build_ext --global-option=`pkg-config --cflags proj` cartopy
[...]
Installing collected packages: cartopy
  Running setup.py install for cartopy ... done
Successfully installed cartopy-0.13.0
```

It definitely looks like `-I` is being prepended to all elements of `include_dirs` on [line 372](https://github.com/SciTools/cartopy/blob/cb00b7d2e89aa0982a28e7d7dcd32ee553e42e10/setup.py#L372):

```
include_dirs=[include_dir, './lib/cartopy'] + proj_includes + geos_includes,
```
 and a look at the value of `geos_includes` ([line 168](https://github.com/SciTools/cartopy/blob/cb00b7d2e89aa0982a28e7d7dcd32ee553e42e10/setup.py#L168)) would confirm this:
```
>>> import subprocess
>>> geos_includes = subprocess.check_output(['geos-config', '--includes'])
>>> geos_includes.split()
['/usr/local/Cellar/geos/3.5.0/include']
>>> proj_includes = subprocess.check_output(['pkg-config', '--cflags', 'proj'])
>>> proj_includes.split()
['-I/usr/local/Cellar/proj/4.9.2/include']
```
Perhaps this behaviour of `pkg-config` specific to Mac OS X? 

In any case, this PR would catch if the `-I` has been prepended and strip it first.