### PR TITLE
improved SRTM hillshade to match gdaldem

### DIFF
--- a/lib/cartopy/examples/srtm_shading.py
+++ b/lib/cartopy/examples/srtm_shading.py
@@ -20,8 +20,11 @@ def shade(located_elevations):
     give a realistic 3d appearance.
 
     """
-    new_img = srtm.add_shading(located_elevations.image,
-                               azimuth=135, altitude=15)
+    new_img = srtm.add_shading(located_elevations,
+                               azimuth=135, 
+							   altitude=15,
+							   scale=111120,
+							   z=1)
     return LocatedImage(new_img, located_elevations.extent)
 
 

--- a/lib/cartopy/examples/srtm_shading.py
+++ b/lib/cartopy/examples/srtm_shading.py
@@ -23,8 +23,8 @@ def shade(located_elevations):
     new_img = srtm.add_shading(located_elevations,
                                azimuth=135,
                                altitude=15,
-                               scale=111120,
-                               z=1)
+                               hscale=111120,
+                               zscale=1)
     return LocatedImage(new_img, located_elevations.extent)
 
 

--- a/lib/cartopy/examples/srtm_shading.py
+++ b/lib/cartopy/examples/srtm_shading.py
@@ -21,10 +21,10 @@ def shade(located_elevations):
 
     """
     new_img = srtm.add_shading(located_elevations,
-                               azimuth=135, 
-							   altitude=15,
-							   scale=111120,
-							   z=1)
+                               azimuth=135,
+                               altitude=15,
+                               scale=111120,
+                               z=1)
     return LocatedImage(new_img, located_elevations.extent)
 
 
@@ -37,7 +37,7 @@ def plot(Source, name):
     shaded_srtm = PostprocessedRasterSource(Source(), shade)
 
     # Add the shaded SRTM source to our map with a grayscale colormap.
-    ax.add_raster(shaded_srtm, cmap='Greys')
+    ax.add_raster(shaded_srtm, cmap='gray')
 
     # This data is high resolution, so pick a small area which has some
     # interesting orography.

--- a/lib/cartopy/io/srtm.py
+++ b/lib/cartopy/io/srtm.py
@@ -66,8 +66,12 @@ class _SRTMSource(RasterSource):
         """
         if resolution == 3:
             self._shape = (1201, 1201)
+            self.xres = 0.000833333333333
+            self.yres = 0.000833333333333
         elif resolution == 1:
             self._shape = (3601, 3601)
+            self.xres = 0.000277777777778
+            self.yres = 0.000277777777778
         else:
             raise ValueError(
                 'Resolution is an unexpected value ({}).'.format(resolution))
@@ -246,29 +250,61 @@ def srtm(lon, lat):
     return SRTM3Source().single_tile(lon, lat)
 
 
-def add_shading(elevation, azimuth, altitude):
+def add_shading(located_image, azimuth=315, altitude=45, scale=111120, z=1):
     """Adds shading to SRTM elevation data, using azimuth and altitude
-    of the sun.
+    of the sun. Function assumes x,y,z in same units, but automatically
+	downloaded SRTM in [lat,lon,meters]. Therefore default scale is 111120,
+	which is good for equatorial regions, and adequate elsewhere. Azimuth
+	degrees clockwise from North. Altitude is angle above horizon. 
+	Function modeled after:
+	http://geospatialpython.com/2013/12/python-and-elevation-data-creating.html
 
-    :type elevation: numpy.ndarray
-    :param elevation: SRTM elevation data (in meters)
+    :type located_image: LocatedImage instance
+    :param located_image: SRTM elevation data (in meters)
     :type azimuth: float
     :param azimuth: azimuth of the Sun (in degrees)
     :type altitude: float
     :param altitude: altitude of the Sun (in degrees)
+	:type scale: float
+	:param scale: ratio of vertical units to horizontal (111120 m/degree)
+	:type z: float
+	:param z: vertical exaggeration multiplier (1= no exaggeration)
 
     :rtype: numpy.ndarray
-    :return: shaded SRTM relief map.
-    """
+    :return: shaded SRTM relief map"""
+    elevation = located_image.image
+
+    xres = ((located_image.extent[1] - located_image.extent[0]) / 
+             elevation.shape[1])
+    yres = ((located_image.extent[3] - located_image.extent[2]) / 
+             elevation.shape[0])
+    
     azimuth = np.deg2rad(azimuth)
     altitude = np.deg2rad(altitude)
-    x, y = np.gradient(elevation)
-    slope = np.pi/2. - np.arctan(np.sqrt(x*x + y*y))
-    # -x here because of pixel orders in the SRTM tile
-    aspect = np.arctan2(-x, y)
-    shaded = np.sin(altitude) * np.sin(slope)\
-        + np.cos(altitude) * np.cos(slope)\
-        * np.cos((azimuth - np.pi/2.) - aspect)
+    
+    window = []
+    for row in range(3):
+        for col in range(3):
+            window.append(elevation[row:(row + elevation.shape[0] - 2), 
+                            col:(col + elevation.shape[1] - 2)])
+    
+    # Process each cell (average gradients)
+    x = ( ((z * window[0] + z * window[3] + z * window[3] + z * window[6]) - 
+           (z * window[2] + z * window[5] + z * window[5] + z * window[8])) / 
+           (8.0 * xres * scale) )
+    	
+    y = ( ((z * window[6] + z * window[7] + z * window[7] + z * window[8]) - 
+            (z * window[0] + z * window[1] + z * window[1] + z * window[2])) / 
+            (8.0 * yres * scale) )
+    					  
+    # Calculate reflectivity / hillshade
+    slope = np.pi/2 - np.arctan(np.hypot(x,y))
+    aspect = np.arctan2(x, y)
+    shaded = ( np.sin(altitude) * np.sin(slope) + np.cos(altitude) * 
+                np.cos(slope) * np.cos((azimuth - np.pi/2) - aspect) )
+    #shaded = (shaded*127).astype('int8') 
+    #shaded = (shaded*255).astype('int16')
+    	
     return shaded
 
 

--- a/lib/cartopy/io/srtm.py
+++ b/lib/cartopy/io/srtm.py
@@ -44,6 +44,7 @@ class _SRTMSource(RasterSource):
     interface <raster-source-interface>`.
 
     """
+
     def __init__(self, resolution, downloader, max_nx, max_ny):
         """
         Parameters
@@ -188,6 +189,7 @@ class SRTM3Source(_SRTMSource):
     interface <raster-source-interface>`.
 
     """
+
     def __init__(self, downloader=None, max_nx=3, max_ny=3):
         """
         Parameters
@@ -215,6 +217,7 @@ class SRTM1Source(_SRTMSource):
     interface <raster-source-interface>`.
 
     """
+
     def __init__(self, downloader=None, max_nx=3, max_ny=3):
         """
         Parameters
@@ -246,18 +249,19 @@ def srtm(lon, lat):
     return SRTM3Source().single_tile(lon, lat)
 
 
-def add_shading(located_image, azimuth=315, altitude=45, hscale=111120, zscale=1):
+def add_shading(located_image, azimuth=315, altitude=45, hscale=111120,
+                zscale=1):
     """Adds shading to SRTM elevation data, using azimuth and altitude
-    of the sun. 
-    
-    Function assumes x,y,z in units of downloaded SRTM [degree,degree,meters], 
-    so default horizontal scale is 111120, which is good for equatorial regions, 
-    and adequate elsewhere. 
-    
+    of the sun.
+
+    Function assumes x,y,z in units of downloaded SRTM [degree,degree,meters],
+    so default horizontal scale is 111120, which is good for equatorial
+    regions, and adequate elsewhere.
+
     Azimuth degrees clockwise from North. Altitude is angle above horizon.
-    
-    Function modeled after GDAL script (gdaldem hillshade)
-    http://geospatialpython.com/2013/12/python-and-elevation-data-creating.html
+
+    Function modeled after GDAL script (gdaldem hillshade):
+    geospatialpython.com/2013/12/python-and-elevation-data-creating.html
 
     :type located_image: LocatedImage instance
     :param located_image: SRTM elevation data (in meters)
@@ -276,9 +280,9 @@ def add_shading(located_image, azimuth=315, altitude=45, hscale=111120, zscale=1
     elevation = located_image.image
 
     xres = ((located_image.extent[1] - located_image.extent[0]) /
-             elevation.shape[1])
+            elevation.shape[1])
     yres = ((located_image.extent[3] - located_image.extent[2]) /
-             elevation.shape[0])
+            elevation.shape[0])
 
     azimuth = np.deg2rad(azimuth)
     altitude = np.deg2rad(altitude)
@@ -287,23 +291,25 @@ def add_shading(located_image, azimuth=315, altitude=45, hscale=111120, zscale=1
     for row in range(3):
         for col in range(3):
             window.append(elevation[row:(row + elevation.shape[0] - 2),
-                            col:(col + elevation.shape[1] - 2)])
+                                    col:(col + elevation.shape[1] - 2)])
 
     # Process each cell (average gradients)
-    x = ( ((zscale * window[0] + zscale * window[3] + zscale * window[3] + 
-            zscale * window[6]) - (zscale * window[2] + zscale * window[5] + 
-            zscale * window[5] + zscale * window[8])) / (8.0 * xres * hscale) )
+    x = (((zscale * window[0] + zscale * window[3] + zscale * window[3] +
+           zscale * window[6]) - (zscale * window[2] + zscale * window[5] +
+                                  zscale * window[5] + zscale * window[8])) /
+         (8.0 * xres * hscale))
 
-    y = ( ((zscale * window[6] + zscale * window[7] + zscale * window[7] + 
-            zscale * window[8]) - (zscale * window[0] + zscale * window[1] + 
-            zscale * window[1] + zscale * window[2])) / (8.0 * yres * hscale) )
+    y = (((zscale * window[6] + zscale * window[7] + zscale * window[7] +
+           zscale * window[8]) - (zscale * window[0] + zscale * window[1] +
+                                  zscale * window[1] + zscale * window[2])) /
+         (8.0 * yres * hscale))
 
     # Calculate reflectivity / hillshade
-    slope = np.pi/2 - np.arctan(np.hypot(x,y))
+    slope = np.pi / 2 - np.arctan(np.hypot(x, y))
     aspect = np.arctan2(x, y)
-    shaded = ( np.sin(altitude) * np.sin(slope) + np.cos(altitude) *
-                np.cos(slope) * np.cos((azimuth - np.pi/2) - aspect) )
-    shaded = (shaded*255).astype('int16')
+    shaded = (np.sin(altitude) * np.sin(slope) + np.cos(altitude) *
+              np.cos(slope) * np.cos((azimuth - np.pi / 2) - aspect))
+    shaded = (shaded * 255).astype('int16')
 
     return shaded
 
@@ -433,6 +439,7 @@ class SRTMDownloader(Downloader):
     available to download.
 
     """
+
     def __init__(self,
                  target_path_template,
                  pre_downloaded_path_template='',


### PR DESCRIPTION
I've modified the srtm.add_shading() function to produce more realistic shading for files with units of (degrees, degrees, meters). A more detailed explanation is here #752 

Note that the srtm_shading.py example is changed slightly since the new shading requires the physical units of the input array (xres=yres=0.000833333 for SRTM3). My solution was to pass the located_elevation object instead of just the array. Maybe there is a better way though...

This would be me first contribution to cartopy, so I sent off the CLA form today.
