### PR TITLE
Return the correct type for QuadMesh data limits.

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1297,7 +1297,7 @@ class GeoAxes(matplotlib.axes.Axes):
         maxy = np.amax(Y)
 
         corners = (minx, miny), (maxx, maxy)
-        collection._corners = corners
+        collection._corners = mtransforms.Bbox(corners)
         collection.get_datalim = lambda transData: collection._corners
 
         self.update_datalim(corners)

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1297,8 +1297,13 @@ class GeoAxes(matplotlib.axes.Axes):
         maxy = np.amax(Y)
 
         corners = (minx, miny), (maxx, maxy)
+        ########################
+        # PATCH
+        # XXX Non-standard matplotlib thing.
         collection._corners = mtransforms.Bbox(corners)
         collection.get_datalim = lambda transData: collection._corners
+        # END OF PATCH
+        ##############
 
         self.update_datalim(corners)
         self.add_collection(collection)


### PR DESCRIPTION
Matplotlib expects a Bbox, not a tuple of extents. This PR implements the fix suggested by @philippjfr in #745. I'm not sure about a test as I don't know how to trigger it other than saving with tight `bbox_inches`, though maybe that would be fine if to an `io.BytesIO`.

@pelson Since Cartopy 0.14 is totally broken in the notebook, I think we should merge and release 0.14.1 ASAP.

Fixes #745.