### PR TITLE
Update Proj4 warnings

### DIFF
--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -22,6 +22,7 @@ The CRS class is the base-class for all projections defined in :mod:`cartopy.crs
 """
 
 from collections import OrderedDict
+import re
 import warnings
 
 import numpy as np
@@ -51,6 +52,11 @@ cdef double NAN = float('nan')
 PROJ4_RELEASE = pj_get_release()
 if six.PY3:
     PROJ4_RELEASE = PROJ4_RELEASE.decode()
+_match = re.search(r"\d+\.\d+.\d+", PROJ4_RELEASE)
+if _match is not None:
+    PROJ4_VERSION = tuple(int(v) for v in _match.group().split('.'))
+else:
+    PROJ4_VERSION = ()
 
 
 class Proj4Error(Exception):

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -33,7 +33,7 @@ import shapely.geometry as sgeom
 from shapely.prepared import prep
 import six
 
-from cartopy._crs import CRS, Geocentric, Geodetic, Globe, PROJ4_RELEASE
+from cartopy._crs import CRS, Geocentric, Geodetic, Globe, PROJ4_VERSION
 import cartopy.trace
 
 
@@ -1454,10 +1454,8 @@ class Robinson(_WarpedRectangularProjection):
         # 40 deg N introduced by incomplete fix to issue #113 (see
         # https://trac.osgeo.org/proj/ticket/113).
         import re
-        match = re.search(r"\d+\.\d+", PROJ4_RELEASE)
-        if match is not None:
-            proj4_version = tuple(int(v) for v in match.group().split('.'))
-            if (4, 8) <= proj4_version < (4, 9):
+        if PROJ4_VERSION != ():
+            if (4, 8) <= PROJ4_VERSION < (4, 9):
                 warnings.warn('The Robinson projection in the v4.8.x series '
                               'of Proj.4 contains a discontinuity at '
                               '40 deg latitude. Use this projection with '
@@ -1751,11 +1749,8 @@ class AzimuthalEquidistant(Projection):
         # Warn when using Azimuthal Equidistant with proj4 < 4.9.2 due to
         # incorrect transformation past 90 deg distance (see
         # https://github.com/OSGeo/proj.4/issues/246).
-        import re
-        match = re.search(r"\d+\.\d+.\d+", PROJ4_RELEASE)
-        if match is not None:
-            proj4_version = tuple(int(v) for v in match.group().split('.'))
-            if proj4_version < (4, 9, 2):
+        if PROJ4_VERSION != ():
+            if PROJ4_VERSION < (4, 9, 2):
                 warnings.warn('The Azimuthal Equidistant projection in Proj.4 '
                               'older than 4.9.2 incorrectly transforms points '
                               'farther than 90 deg from the origin. Use this '

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1748,6 +1748,23 @@ class AzimuthalEquidistant(Projection):
                       default globe is created.
 
         """
+        # Warn when using Azimuthal Equidistant with proj4 < 4.9.2 due to
+        # incorrect transformation past 90 deg distance (see
+        # https://github.com/OSGeo/proj.4/issues/246).
+        import re
+        match = re.search(r"\d+\.\d+.\d+", PROJ4_RELEASE)
+        if match is not None:
+            proj4_version = tuple(int(v) for v in match.group().split('.'))
+            if proj4_version < (4, 9, 2):
+                warnings.warn('The Azimuthal Equidistant projection in Proj.4 '
+                              'older than 4.9.2 incorrectly transforms points '
+                              'farther than 90 deg from the origin. Use this '
+                              'projection with caution.')
+        else:
+            warnings.warn('Cannot determine Proj.4 version. The Azimuthal '
+                          'Equidistant projection may be unreliable and '
+                          'should be used with caution.')
+
         proj4_params = [('proj', 'aeqd'), ('lon_0', central_longitude),
                         ('lat_0', central_latitude),
                         ('x_0', false_easting), ('y_0', false_northing)]

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1454,10 +1454,10 @@ class Robinson(_WarpedRectangularProjection):
         # 40 deg N introduced by incomplete fix to issue #113 (see
         # https://trac.osgeo.org/proj/ticket/113).
         import re
-        match = re.search(r"\d\.\d", PROJ4_RELEASE)
+        match = re.search(r"\d+\.\d+", PROJ4_RELEASE)
         if match is not None:
-            proj4_version = float(match.group())
-            if 4.8 <= proj4_version < 4.9:
+            proj4_version = tuple(int(v) for v in match.group().split('.'))
+            if (4, 8) <= proj4_version < (4, 9):
                 warnings.warn('The Robinson projection in the v4.8.x series '
                               'of Proj.4 contains a discontinuity at '
                               '40 deg latitude. Use this projection with '

--- a/lib/cartopy/tests/__init__.py
+++ b/lib/cartopy/tests/__init__.py
@@ -24,15 +24,6 @@ import tempfile
 import shutil
 import types
 
-from cartopy._crs import PROJ4_RELEASE as _PROJ4_RELEASE
-
-
-_match = re.search(r"\d\.\d", _PROJ4_RELEASE)
-if _match is not None:
-    _proj4_version = float(_match.group())
-else:
-    _proj4_version = 0.0
-
 
 @contextlib.contextmanager
 def temp_dir(suffix=None):

--- a/lib/cartopy/tests/crs/test_robinson.py
+++ b/lib/cartopy/tests/crs/test_robinson.py
@@ -33,7 +33,6 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal as assert_arr_almost_eq
 
 import cartopy.crs as ccrs
-from cartopy.tests import _proj4_version
 
 
 _NAN = float('nan')
@@ -41,7 +40,7 @@ _CRS_PC = ccrs.PlateCarree()
 _CRS_ROB = ccrs.Robinson()
 
 # Increase tolerance if using older proj.4 releases
-_TOL = -1 if _proj4_version < 4.9 else 7
+_TOL = -1 if ccrs.PROJ4_VERSION < (4, 9) else 7
 
 
 def test_transform_point():

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -32,7 +32,6 @@ import cartopy.crs as ccrs
 from cartopy.mpl.geoaxes import GeoAxes
 from cartopy.mpl.gridliner import LATITUDE_FORMATTER, LONGITUDE_FORMATTER
 
-from cartopy.tests import _proj4_version
 from cartopy.tests.mpl import ImageTesting
 
 

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -32,11 +32,10 @@ import six
 
 import cartopy.crs as ccrs
 
-from cartopy.tests import _proj4_version
 from cartopy.tests.mpl import ImageTesting
 
 
-_ROB_TOL = 0.5 if _proj4_version < 4.9 else 0.1
+_ROB_TOL = 0.5 if ccrs.PROJ4_VERSION < (4, 9) else 0.1
 
 
 @ImageTesting(['global_contour_wrap'])
@@ -119,7 +118,8 @@ def test_global_scatter_wrap_no_transform():
     plt.scatter(x, y, c=data)
 
 
-@ImageTesting(['global_map'], tolerance=16 if _proj4_version < 4.9 else 0.1)
+@ImageTesting(['global_map'],
+              tolerance=16 if ccrs.PROJ4_VERSION < (4, 9) else 0.1)
 def test_global_map():
     ax = plt.axes(projection=ccrs.Robinson())
 #    ax.coastlines()

--- a/lib/cartopy/tests/mpl/test_shapely_to_mpl.py
+++ b/lib/cartopy/tests/mpl/test_shapely_to_mpl.py
@@ -28,7 +28,6 @@ import shapely.geometry as sgeom
 import cartopy.crs as ccrs
 import cartopy.mpl.patch as cpatch
 
-from cartopy.tests import _proj4_version
 from cartopy.tests.mpl import ImageTesting
 
 


### PR DESCRIPTION
Fix a small problem with the Robinson check that could trigger the warning on multi-digit versions in the future.

Add a warning for Azimuthal Equidistant to indicate the issue with > 90 degree transforms. Closes #568.