### PR TITLE
Restore functionality to image transforms

### DIFF
--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -285,7 +285,15 @@ def regrid(array, source_x_coords, source_y_coords, source_cs, target_proj,
                                            target_x_points.flatten(),
                                            target_y_points.flatten())
 
-    kdtree = scipy.spatial.cKDTree(xyz, balanced_tree=False)
+    # Versions of scipy >= v0.16 added the balanced_tree argument,
+    # hence the handling of the specific exception. 
+    try:
+      kdtree = scipy.spatial.cKDTree(xyz, balanced_tree=False)
+    except TypeError as err:
+      if err.message[-14:-1] == 'balanced_tree':
+        kdtree = scipy.spatial.cKDTree(xyz)        
+      else: raise
+    
     distances, indices = kdtree.query(target_xyz, k=1)
     mask = np.isinf(distances)
 

--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -288,11 +288,11 @@ def regrid(array, source_x_coords, source_y_coords, source_cs, target_proj,
     # Versions of scipy >= v0.16 added the balanced_tree argument,
     # hence the handling of the specific exception. 
     try:
-      kdtree = scipy.spatial.cKDTree(xyz, balanced_tree=False)
+        kdtree = scipy.spatial.cKDTree(xyz, balanced_tree=False)
     except TypeError as err:
-      if err.message[-14:-1] == 'balanced_tree':
-        kdtree = scipy.spatial.cKDTree(xyz)        
-      else: raise
+        if err.message[-14:-1] == 'balanced_tree':
+            kdtree = scipy.spatial.cKDTree(xyz)        
+        else: raise
     
     distances, indices = kdtree.query(target_xyz, k=1)
     mask = np.isinf(distances)

--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -289,7 +289,7 @@ def regrid(array, source_x_coords, source_y_coords, source_cs, target_proj,
     # which caused the KDTree to hang with this input.
     try:
         kdtree = scipy.spatial.cKDTree(xyz, balanced_tree=False)
-    except:
+    except TypeError:
         kdtree = scipy.spatial.cKDTree(xyz)
 
     distances, indices = kdtree.query(target_xyz, k=1)

--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -285,7 +285,7 @@ def regrid(array, source_x_coords, source_y_coords, source_cs, target_proj,
                                            target_x_points.flatten(),
                                            target_y_points.flatten())
 
-    kdtree = scipy.spatial.cKDTree(xyz)
+    kdtree = scipy.spatial.cKDTree(xyz, balanced_tree=False)
     distances, indices = kdtree.query(target_xyz, k=1)
     mask = np.isinf(distances)
 

--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -286,14 +286,12 @@ def regrid(array, source_x_coords, source_y_coords, source_cs, target_proj,
                                            target_y_points.flatten())
 
     # Versions of scipy >= v0.16 added the balanced_tree argument,
-    # hence the handling of the specific exception. 
+    # which caused the KDTree to hang with this input.
     try:
         kdtree = scipy.spatial.cKDTree(xyz, balanced_tree=False)
-    except TypeError as err:
-        if err.message[-14:-1] == 'balanced_tree':
-            kdtree = scipy.spatial.cKDTree(xyz)        
-        else: raise
-    
+    except:
+        kdtree = scipy.spatial.cKDTree(xyz)
+
     distances, indices = kdtree.query(target_xyz, k=1)
     mask = np.isinf(distances)
 


### PR DESCRIPTION
After changes in SciPy 0.16.x scipy.spatial.cKDTree now hangs during projection of images (see http://stackoverflow.com/questions/31819778/scipy-spatial-ckdtree-running-slowly and http://stackoverflow.com/questions/35637801/cartopy-hanging-during-transform/37532594#37532594).
This edit returns the application of scipy.spatial.cKDTree to its previous functionality.