### PR TITLE
TST: Fix caching test error messages.

### DIFF
--- a/lib/cartopy/tests/mpl/test_caching.py
+++ b/lib/cartopy/tests/mpl/test_caching.py
@@ -132,9 +132,9 @@ def test_shapefile_transform_cache():
     # Without caching the count would have been
     # n_calls * n_geom, but should now be just n_geom.
     assert counter.count == n_geom, ('The given geometry was transformed too '
-                                     'many times (expected: %s; got %s) - the'
+                                     'many times (expected: {}; got {}) - the'
                                      ' caching is not working.'
-                                     ''.format(n_geom, n_geom, counter.count))
+                                     ''.format(n_geom, counter.count))
 
     # Check the cache has an entry for each geometry.
     assert len(FeatureArtist._geom_key_to_geometry_cache) == n_geom
@@ -171,9 +171,9 @@ def test_contourf_transform_path_counting():
 
     # Before the performance enhancement, the count would have been 2 * n_geom,
     # but should now be just n_geom.
-    msg = ('The given geometry was transformed too many times (expected: %s; '
-           'got %s) - the caching is not working.'
-           '' % (n_geom, path_to_geos_counter.count))
+    msg = ('The given geometry was transformed too many times (expected: {}; '
+           'got {}) - the caching is not working.'
+           '').format(n_geom, path_to_geos_counter.count)
     assert path_to_geos_counter.count == n_geom, msg
 
     # Check the cache has an entry for each geometry.


### PR DESCRIPTION
The strings use %-markers, but calls .format() on the string.