### PR TITLE
ENH: Support setting lat_ts for Mercator. (Fixes #728)

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -940,7 +940,7 @@ class Mercator(Projection):
 
     def __init__(self, central_longitude=0.0,
                  min_latitude=-80.0, max_latitude=84.0,
-                 globe=None):
+                 globe=None, latitude_true_scale=0.0):
         """
         Kwargs:
 
@@ -951,11 +951,13 @@ class Mercator(Projection):
                              Defaults to 84 degrees.
             * globe - A :class:`cartopy.crs.Globe`.
                       If omitted, a default globe is created.
+            * latitude_true_scale - the latitude where the scale is 1.
+                                    Defaults to 0 degrees.
 
         """
         proj4_params = [('proj', 'merc'),
                         ('lon_0', central_longitude),
-                        ('k', 1),
+                        ('lat_ts', latitude_true_scale),
                         ('units', 'm')]
         super(Mercator, self).__init__(proj4_params, globe=globe)
 

--- a/lib/cartopy/tests/crs/test_mercator.py
+++ b/lib/cartopy/tests/crs/test_mercator.py
@@ -28,8 +28,8 @@ import cartopy.crs as ccrs
 def test_default():
     crs = ccrs.Mercator()
 
-    assert_equal(crs.proj4_init, ('+ellps=WGS84 +proj=merc +lon_0=0.0 +k=1 '
-                                  '+units=m +no_defs'))
+    assert_equal(crs.proj4_init, ('+ellps=WGS84 +proj=merc +lon_0=0.0 '
+                                  '+lat_ts=0.0 +units=m +no_defs'))
     assert_almost_equal(crs.boundary.bounds,
                         [-20037508, -15496571, 20037508, 18764656], decimal=0)
 
@@ -39,7 +39,7 @@ def test_eccentric_globe():
                        ellipse=None)
     crs = ccrs.Mercator(globe=globe, min_latitude=-40, max_latitude=40)
     assert_equal(crs.proj4_init, ('+a=10000 +b=5000 +proj=merc +lon_0=0.0 '
-                                  '+k=1 +units=m +no_defs'))
+                                  '+lat_ts=0.0 +units=m +no_defs'))
 
     assert_almost_equal(crs.boundary.bounds,
                         [-31415.93, -2190.5, 31415.93, 2190.5], decimal=2)
@@ -64,12 +64,23 @@ def test_equality():
 def test_central_longitude():
     cl = 10.0
     crs = ccrs.Mercator(central_longitude=cl)
-    proj4_str = ('+ellps=WGS84 +proj=merc +lon_0={} +k=1 '
+    proj4_str = ('+ellps=WGS84 +proj=merc +lon_0={} +lat_ts=0.0 '
                  '+units=m +no_defs'.format(cl))
     assert_equal(crs.proj4_init, proj4_str)
 
     assert_almost_equal(crs.boundary.bounds,
                         [-20037508, -15496570, 20037508, 18764656], decimal=0)
+
+
+def test_latitude_true_scale():
+    lat_ts = 20.0
+    crs = ccrs.Mercator(latitude_true_scale=lat_ts)
+    proj4_str = ('+ellps=WGS84 +proj=merc +lon_0=0.0 +lat_ts={} '
+                 '+units=m +no_defs'.format(lat_ts))
+    assert_equal(crs.proj4_init, proj4_str)
+
+    assert_almost_equal(crs.boundary.bounds,
+                        [-18836475, -14567718, 18836475, 17639917], decimal=0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I needed this for some GINI satellite imagery over Hawaii. #728 mentions some issues about domain, but I don't see how that's actually relevant to the matter at hand.
