### PR TITLE
Add WMTS kwargs to add_wmts() method

### DIFF
--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -34,6 +34,7 @@ the package wouldn't be as rich or diverse as it is today:
  * Louis Tiao
  * Zachary Tessler
  * Daniel Eriksson
+ * Crispian Batstone
 
 
 Thank you!

--- a/lib/cartopy/examples/geostationary.py
+++ b/lib/cartopy/examples/geostationary.py
@@ -5,10 +5,10 @@ Reprojecting images from a Geostationary projection
 This example demonstrates Cartopy's ability to project images into the desired
 projection on-the-fly. The image itself is retrieved from a URL and is loaded
 directly into memory without storing it intermediately into a file. It
-represents pre-processed data from Moderate-Resolution Imaging
-Spectroradiometer (MODIS) which has been put into an image in the data's
-native Geostationary coordinate system - it is then projected by cartopy
-into a global Miller map.
+represents pre-processed data from the Spinning Enhanced Visible and Infrared
+Imager onboard Meteosat Second Generation, which has been put into an image in
+the data's native Geostationary coordinate system - it is then projected by
+cartopy into a global Miller map.
 
 """
 __tags__ = ["Scalar data"]
@@ -24,7 +24,7 @@ import matplotlib.pyplot as plt
 
 def geos_image():
     """
-    Return a specific MODIS image by retrieving it from a github gist URL.
+    Return a specific SEVIRI image by retrieving it from a github gist URL.
 
     Returns
     -------

--- a/lib/cartopy/examples/wmts_time.py
+++ b/lib/cartopy/examples/wmts_time.py
@@ -1,0 +1,55 @@
+__tags__ = ['Web services']
+"""
+Web Map Tile Service time dimension demonstration
+-------------------------------------------------
+
+This example further demonstrates WMTS support within cartopy. Optional
+keyword arguments can be supplied to the OGC WMTS 'gettile' method. This
+allows for the specification of the 'time' dimension for a WMTS layer
+which supports it.
+
+The example shows satellite imagery retrieved from NASA's Global Imagery
+Browse Services for 5th Feb 2016. A true color MODIS image is shown on
+the left, with the MODIS false color 'snow RGB' shown on the right.
+
+"""
+import matplotlib.pyplot as plt
+import matplotlib.patheffects as PathEffects
+import cartopy.crs as ccrs
+from owslib.wmts import WebMapTileService
+
+
+def main():
+    # URL of NASA GIBS
+    URL = 'http://gibs.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi'
+    wmts = WebMapTileService(URL)
+
+    # Layers for MODIS true color and snow RGB
+    layers = ['MODIS_Terra_CorrectedReflectance_TrueColor',
+              'MODIS_Terra_CorrectedReflectance_Bands367']
+
+    date_str = '2016-02-05'
+
+    # Plot setup
+    plot_CRS = ccrs.Mercator()
+    geodetic_CRS = ccrs.Geodetic()
+    x0, y0 = plot_CRS.transform_point(4.6, 43.1, geodetic_CRS)
+    x1, y1 = plot_CRS.transform_point(11.0, 47.4, geodetic_CRS)
+    ysize = 8
+    xsize = 2 * ysize * (x1 - x0) / (y1 - y0)
+    fig = plt.figure(figsize=(xsize, ysize), dpi=100)
+
+    for layer, offset in zip(layers, [0, 0.5]):
+        ax = plt.axes([offset, 0, 0.5, 1], projection=plot_CRS)
+        ax.set_xlim((x0, x1))
+        ax.set_ylim((y0, y1))
+        ax.add_wmts(wmts, layer, wmts_kwargs={'time': date_str})
+        txt = plt.text(4.7, 43.2, wmts[layer].title, fontsize=18,
+                       color='wheat', transform=geodetic_CRS)
+        txt.set_path_effects([PathEffects.withStroke(linewidth=5,
+                                                     foreground='black')])
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/cartopy/examples/wmts_time.py
+++ b/lib/cartopy/examples/wmts_time.py
@@ -25,7 +25,7 @@ def main():
     wmts = WebMapTileService(URL)
 
     # Layers for MODIS true color and snow RGB
-    layers = ['MODIS_Terra_CorrectedReflectance_TrueColor',
+    layers = ['MODIS_Terra_SurfaceReflectance_Bands143',
               'MODIS_Terra_CorrectedReflectance_Bands367']
 
     date_str = '2016-02-05'

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -76,6 +76,8 @@ METERS_PER_UNIT = {
     'urn:ogc:def:crs:EPSG::27700': 1,
     'urn:ogc:def:crs:EPSG::900913': 1,
     'urn:ogc:def:crs:OGC:1.3:CRS84': _WGS84_METERS_PER_UNIT,
+    'urn:ogc:def:crs:EPSG::3031': 1,
+    'urn:ogc:def:crs:EPSG::3413': 1
 }
 
 _URN_TO_CRS = collections.OrderedDict([
@@ -84,7 +86,10 @@ _URN_TO_CRS = collections.OrderedDict([
     ('urn:ogc:def:crs:EPSG::900913', ccrs.GOOGLE_MERCATOR),
     ('urn:ogc:def:crs:EPSG::27700', ccrs.OSGB()),
     ('urn:ogc:def:crs:EPSG::3031', ccrs.Stereographic(central_latitude=-90,
-                                                      true_scale_latitude=-71))
+                                                      true_scale_latitude=-71)),
+    ('urn:ogc:def:crs:EPSG::3413', ccrs.Stereographic(central_longitude=-45,
+                                                      central_latitude=90,
+                                                      true_scale_latitude=70))
 ])
 
 # XML namespace definitions
@@ -340,13 +345,19 @@ class WMTSRasterSource(RasterSource):
 
     """
 
-    def __init__(self, wmts, layer_name):
+    def __init__(self, wmts, layer_name, gettile_extra_kwargs=None):
         """
         Args:
 
             * wmts - The URL of the WMTS, or an
                      owslib.wmts.WebMapTileService instance.
             * layer_name - The name of the layer to use.
+
+        Kwargs:
+
+            * gettile_extra_kwargs : dict or None
+                Extra keywords (e.g. time) to pass through to the
+                service's gettile method.
 
         """
         if WebMapService is None:
@@ -368,6 +379,9 @@ class WMTSRasterSource(RasterSource):
 
         #: The layer to fetch.
         self.layer = layer
+
+        #: Extra kwargs passed through to the service's gettile request.
+        self.gettile_extra_kwargs = gettile_extra_kwargs
 
         self._matrix_set_name_map = {}
 
@@ -587,7 +601,8 @@ class WMTSRasterSource(RasterSource):
                             layer=layer.id,
                             tilematrixset=matrix_set_name,
                             tilematrix=tile_matrix_id,
-                            row=row, column=col)
+                            row=row, column=col,
+                            **self.gettile_extra_kwargs)
                     except owslib.util.ServiceException as exception:
                         if ('TileOutOfRange' in exception.message and
                                 ignore_out_of_range):

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -85,11 +85,13 @@ _URN_TO_CRS = collections.OrderedDict([
     ('urn:ogc:def:crs:EPSG::4326', ccrs.PlateCarree()),
     ('urn:ogc:def:crs:EPSG::900913', ccrs.GOOGLE_MERCATOR),
     ('urn:ogc:def:crs:EPSG::27700', ccrs.OSGB()),
-    ('urn:ogc:def:crs:EPSG::3031', ccrs.Stereographic(central_latitude=-90,
-                                                      true_scale_latitude=-71)),
-    ('urn:ogc:def:crs:EPSG::3413', ccrs.Stereographic(central_longitude=-45,
-                                                      central_latitude=90,
-                                                      true_scale_latitude=70))
+    ('urn:ogc:def:crs:EPSG::3031', ccrs.Stereographic(
+        central_latitude=-90,
+        true_scale_latitude=-71)),
+    ('urn:ogc:def:crs:EPSG::3413', ccrs.Stereographic(
+        central_longitude=-45,
+        central_latitude=90,
+        true_scale_latitude=70))
 ])
 
 # XML namespace definitions
@@ -381,6 +383,8 @@ class WMTSRasterSource(RasterSource):
         self.layer = layer
 
         #: Extra kwargs passed through to the service's gettile request.
+        if gettile_extra_kwargs is None:
+            gettile_extra_kwargs = {}
         self.gettile_extra_kwargs = gettile_extra_kwargs
 
         self._matrix_set_name_map = {}

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1645,7 +1645,7 @@ class GeoAxes(matplotlib.axes.Axes):
             sp = matplotlib.axes.Axes.streamplot(self, x, y, u, v, **kwargs)
         return sp
 
-    def add_wmts(self, wmts, layer_name, **kwargs):
+    def add_wmts(self, wmts, layer_name, wmts_kwargs=None, **kwargs):
         """
         Add the specified WMTS layer to the axes.
 
@@ -1657,13 +1657,20 @@ class GeoAxes(matplotlib.axes.Axes):
                      owslib.wmts.WebMapTileService instance.
             * layer_name - The name of the layer to use.
 
+        Kwargs:
+        
+            * wmts_kwargs - dict or None. Passed through to the
+                :class:`~cartopy.io.ogc_clients.WMTSRasterSource`
+                constructor's ``gettile_extra_kwargs`` (e.g. time).
+
         All other keywords are passed through to the construction of the
         image artist. See :meth:`~matplotlib.axes.Axes.imshow()` for
         more details.
 
         """
         from cartopy.io.ogc_clients import WMTSRasterSource
-        wmts = WMTSRasterSource(wmts, layer_name)
+        wmts = WMTSRasterSource(wmts, layer_name,
+                                gettile_extra_kwargs=wmts_kwargs)
         return self.add_raster(wmts, **kwargs)
 
     def add_wms(self, wms, layers, wms_kwargs=None, **kwargs):

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1658,7 +1658,7 @@ class GeoAxes(matplotlib.axes.Axes):
             * layer_name - The name of the layer to use.
 
         Kwargs:
-        
+
             * wmts_kwargs - dict or None. Passed through to the
                 :class:`~cartopy.io.ogc_clients.WMTSRasterSource`
                 constructor's ``gettile_extra_kwargs`` (e.g. time).

--- a/requirements/ows.txt
+++ b/requirements/ows.txt
@@ -1,2 +1,2 @@
-OWSLib>=0.8.7
+OWSLib>=0.8.11
 pillow>=1.7.8


### PR DESCRIPTION
Following the structure of the add_wms() method, I've added 'gettile_extra_kwargs' to the add_wmts() call, which allows one to pass arguments to the owslib.wmts.gettile() method. This is useful as it allows the specification of the 'time' dimension when requesting WMTS layers that support it.

I've added an example to demonstrate the functionality.

A couple more minor changes:

* Added support for EPSG 3413 (WGS 84 / NSIDC Sea Ice Polar Stereographic North) for 'add_wmts()'
* Corrected comments in the geostationary image example

Cheers