### PR TITLE
numpy 1.10+ linspace nan fix

### DIFF
--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -81,6 +81,14 @@ def mesh_projection(projection, nx, ny,
     y, ystep = np.linspace(y_lower, y_upper, ny, retstep=True,
                            endpoint=False)
 
+    # Deal with single point corner case and the difference
+    # between np.linspace v1.9 and v1.10+ retstep nan result.
+    if nx == 1 and np.isnan(xstep):
+        xstep = x_upper - x_lower
+
+    if ny == 1 and np.isnan(ystep):
+        ystep = y_upper - y_lower
+
     # Offset the sample points to be within the extent range.
     x += 0.5 * xstep
     y += 0.5 * ystep


### PR DESCRIPTION
This PR smooths over a corner case exception that can be raised within `img_transform.mesh_projection` for a **single point** that requires to be projected and using numpy **v1.10+**.

In this case, for numpy **v1.9** we have:
```python
>>> import numpy as np
>>> np.__version__
'1.9.3'
>>> np.linspace(-1, 1, 1, retstep=True, endpoint=False)
(array([-1.]), 2.0)
>>> 
```
and for numpy **v1.10+** we have:
```python
>>> import numpy as np
>>> np.__version__
'1.10.4'
>>> np.linspace(-1, 1, 1, retstep=True, endpoint=False)
(array([-1.]), nan)
>>> 
```