### PR TITLE
BUG: Fix contourf bounds calculation (Fixes #811)

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1147,7 +1147,8 @@ class GeoAxes(matplotlib.axes.Axes):
         # We need to compute the dataLim correctly for contours.
         if matplotlib.__version__ >= '1.4':
             extent = mtransforms.Bbox.union([col.get_datalim(self.transData)
-                                             for col in result.collections])
+                                             for col in result.collections
+                                             if col.get_paths()])
             self.dataLim.update_from_data_xy(extent.get_points())
 
         self.autoscale_view()

--- a/lib/cartopy/tests/mpl/test_contour.py
+++ b/lib/cartopy/tests/mpl/test_contour.py
@@ -1,0 +1,45 @@
+# (C) British Crown Copyright 2016, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+
+import matplotlib.pyplot as plt
+from matplotlib.testing.decorators import cleanup
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+
+import cartopy.crs as ccrs
+
+
+@cleanup
+def test_contour_plot_bounds():
+    x = np.linspace(-2763217.0, 2681906.0, 200)
+    y = np.linspace(-263790.62, 3230840.5, 130)
+    data = np.hypot(*np.meshgrid(x, y)) / 2e5
+
+    proj_lcc = ccrs.LambertConformal(central_longitude=-95,
+                                     central_latitude=25,
+                                     standard_parallels=[25])
+    ax = plt.axes(projection=proj_lcc)
+    ax.contourf(x, y, data, levels=np.arange(0, 40, 1))
+    assert_array_almost_equal(ax.get_extent(),
+                              np.array([x[0], x[-1], y[0], y[-1]]))
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(argv=['-s', '--with-doctest'], exit=False)


### PR DESCRIPTION
Previously, if a path returned from contourf was empty, the calculation
of the bounds would go wrong, resulting in poor bounds (*extremely*
zoomed in view). This would often show when specifying arbitrary contour
levels.