### PR TITLE
Fix testing against OWSLib 0.13.0.

### DIFF
--- a/lib/cartopy/tests/io/test_ogc_clients.py
+++ b/lib/cartopy/tests/io/test_ogc_clients.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2016, Met Office
+# (C) British Crown Copyright 2011 - 2017, Met Office
 #
 # This file is part of cartopy.
 #
@@ -48,7 +48,16 @@ class test_WMSRasterSource(unittest.TestCase):
 
     def test_string_service(self):
         source = ogc.WMSRasterSource(self.URI, self.layer)
-        self.assertIsInstance(source.service, WebMapService)
+        if isinstance(WebMapService, type):
+            # OWSLib < 0.13.0
+            self.assertIsInstance(source.service, WebMapService)
+        else:
+            # OWSLib >= 0.13.0: WebMapService is a function that creates
+            # instances of these two classes.
+            from owslib.map.wms111 import WebMapService_1_1_1
+            from owslib.map.wms130 import WebMapService_1_3_0
+            self.assertIsInstance(source.service,
+                                  (WebMapService_1_1_1, WebMapService_1_3_0))
         self.assertIsInstance(source.layers, list)
         self.assertEqual(source.layers, [self.layer])
 


### PR DESCRIPTION
The `WebMapService` is a function in that version, so we can't run `isinstance` against it.

I assume this is not triggered on Travis because we're still using the scitools channel which doesn't have an updated owslib. Would it make sense to switch to conda-forge now?