### PR TITLE
removed import of missing PROJ4_VERSION

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -33,7 +33,7 @@ import shapely.geometry as sgeom
 from shapely.prepared import prep
 import six
 
-from cartopy._crs import CRS, Geocentric, Geodetic, Globe, PROJ4_VERSION
+from cartopy._crs import CRS, Geocentric, Geodetic, Globe
 import cartopy.trace
 
 


### PR DESCRIPTION
I don't know when this changed, but today I fetched upstream master to cut a branch, and all of a sudden I got import errors because PROJ4_VERSION is not now living in '_crs.pyx'.

I just removed the import, and that worked for me.  Not tested this extensively yet.