### PR TITLE
test added to show faulty proj4 params

### DIFF
--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -157,8 +157,8 @@ class TestCRS(unittest.TestCase):
                                            src_crs=src_proj)
 
         # Solutions derived by proj4 direct.
-        solx = np.array([-6082344.5, -6098151.15, -6224699.15])
-        soly = np.array([83740.44, -1.49, 24268.47])
+        solx = np.array([83740.44, -1.49, 24268.47])
+        soly = np.array([-6082344.5, -6098151.15, -6224699.15])
 
         assert_arr_almost_eq(res[..., 0], solx)
         assert_arr_almost_eq(res[..., 1], soly)

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -147,6 +147,22 @@ class TestCRS(unittest.TestCase):
         assert_arr_almost_eq(unrotated_lon, solx)
         assert_arr_almost_eq(unrotated_lat, soly)
 
+    def test_transform_points_2D(self):
+        rlons = [142.49996948, 164.99995422, 112.99996948]
+        rlats = [-72.48229747, -72.9603603, -77.406934]
+
+        src_proj = ccrs.PlateCarree()
+        target_proj = ccrs.Orthographic()
+        res = target_proj.transform_points(x=rlons, y=rlats,
+                                           src_crs=src_proj)
+
+        # Solutions derived by proj4 direct.
+        solx = np.array([-6082344.5, -6098151.15, -6224699.15])
+        soly = np.array([83740.44, -1.49, 24268.47])
+
+        assert_arr_almost_eq(res[..., 0], solx)
+        assert_arr_almost_eq(res[..., 1], soly)
+
     def test_transform_points_xyz(self):
         # Test geodetic transforms when using z value
         rx = np.array([2574.32516e3])

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2016, Met Office
+# (C) British Crown Copyright 2011 - 2017, Met Office
 #
 # This file is part of cartopy.
 #

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -157,8 +157,8 @@ class TestCRS(unittest.TestCase):
                                            src_crs=src_proj)
 
         # Solutions derived by proj4 direct.
-        solx = np.array([83740.44, -1.49, 24268.47])
-        soly = np.array([-6082344.5, -6098151.15, -6224699.15])
+        solx = np.array([-6082344.5, -6098151.15, -6224699.15])
+        soly = np.array([83740.44, -1.49, 24268.47])
 
         assert_arr_almost_eq(res[..., 0], solx)
         assert_arr_almost_eq(res[..., 1], soly)

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -148,8 +148,8 @@ class TestCRS(unittest.TestCase):
         assert_arr_almost_eq(unrotated_lat, soly)
 
     def test_transform_points_2D(self):
-        rlons = [142.49996948, 164.99995422, 112.99996948]
-        rlats = [-72.48229747, -72.9603603, -77.406934]
+        rlons = np.array([142.49996948, 164.99995422, 112.99996948])
+        rlats = np.array([-72.48229747, -72.9603603, -77.406934])
 
         src_proj = ccrs.PlateCarree()
         target_proj = ccrs.Orthographic()

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -148,8 +148,8 @@ class TestCRS(unittest.TestCase):
         assert_arr_almost_eq(unrotated_lat, soly)
 
     def test_transform_points_2D(self):
-        rlons = np.array([142.49996948, 164.99995422, 112.99996948])
-        rlats = np.array([-72.48229747, -72.9603603, -77.406934])
+        rlons = np.array([-72.48229747, -72.9603603, -77.406934])
+        rlats = np.array([142.49996948, 164.99995422, 112.99996948])
 
         src_proj = ccrs.PlateCarree()
         target_proj = ccrs.Orthographic()


### PR DESCRIPTION
For several projections, the call to proj4 in cartopy geoaxes.py transform_points uses params which are out of bounds.  This causes proj4 to return null coordinates and hence not be able to produce a plot, although no error is shown to the user.

This test should fail because it uses an example of the invalid coordinates which are passed to proj4.