### PR TITLE
Transform points bugfix

### DIFF
--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -83,7 +83,8 @@ class Globe(object):
     def __init__(self, datum=None, ellipse='WGS84',
                  semimajor_axis=None, semiminor_axis=None,
                  flattening=None, inverse_flattening=None,
-                 towgs84=None, nadgrids=None):
+                 towgs84=None, nadgrids=None, central_longitude=None,
+                 central_latitude=None):
         """
         Keywords:
 
@@ -103,6 +104,10 @@ class Globe(object):
             
             * nadgrids - Passed through to the Proj4 definition.
 
+            * central_longitude - Passed through to the Proj4 definition.
+
+            * central_latitude - Passed through to the Proj4 definition.
+
         """
         self.datum = datum
         self.ellipse = ellipse
@@ -112,6 +117,8 @@ class Globe(object):
         self.inverse_flattening = inverse_flattening
         self.towgs84 = towgs84
         self.nadgrids = nadgrids
+        self.central_longitude = central_longitude
+        self.central_latitude = central_latitude
 
     def to_proj4_params(self):
         """
@@ -123,7 +130,8 @@ class Globe(object):
                         ['a', self.semimajor_axis], ['b', self.semiminor_axis],
                         ['f', self.flattening], ['rf', self.inverse_flattening],
                         ['towgs84', self.towgs84], ['nadgrids', self.nadgrids],
-                        ['lon_0', self.lon_0], ['lat_0', self.lat_0])
+                        ['lon_0', self.central_longitude],
+                        ['lat_0', self.central_latitude])
         return OrderedDict((k, v) for k, v in proj4_params if v is not None)
 
 

--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -83,8 +83,7 @@ class Globe(object):
     def __init__(self, datum=None, ellipse='WGS84',
                  semimajor_axis=None, semiminor_axis=None,
                  flattening=None, inverse_flattening=None,
-                 towgs84=None, nadgrids=None, central_longitude=None,
-                 central_latitude=None):
+                 towgs84=None, nadgrids=None):
         """
         Keywords:
 

--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -104,10 +104,6 @@ class Globe(object):
             
             * nadgrids - Passed through to the Proj4 definition.
 
-            * central_longitude - Passed through to the Proj4 definition.
-
-            * central_latitude - Passed through to the Proj4 definition.
-
         """
         self.datum = datum
         self.ellipse = ellipse
@@ -117,8 +113,6 @@ class Globe(object):
         self.inverse_flattening = inverse_flattening
         self.towgs84 = towgs84
         self.nadgrids = nadgrids
-        self.central_longitude = central_longitude
-        self.central_latitude = central_latitude
 
     def to_proj4_params(self):
         """
@@ -129,9 +123,7 @@ class Globe(object):
         proj4_params = (['datum', self.datum], ['ellps', self.ellipse],
                         ['a', self.semimajor_axis], ['b', self.semiminor_axis],
                         ['f', self.flattening], ['rf', self.inverse_flattening],
-                        ['towgs84', self.towgs84], ['nadgrids', self.nadgrids],
-                        ['lon_0', self.central_longitude],
-                        ['lat_0', self.central_latitude])
+                        ['towgs84', self.towgs84], ['nadgrids', self.nadgrids])
         return OrderedDict((k, v) for k, v in proj4_params if v is not None)
 
 

--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -122,7 +122,8 @@ class Globe(object):
         proj4_params = (['datum', self.datum], ['ellps', self.ellipse],
                         ['a', self.semimajor_axis], ['b', self.semiminor_axis],
                         ['f', self.flattening], ['rf', self.inverse_flattening],
-                        ['towgs84', self.towgs84], ['nadgrids', self.nadgrids])
+                        ['towgs84', self.towgs84], ['nadgrids', self.nadgrids],
+                        ['lon_0', self.lon_0], ['lat_0', self.lat_0])
         return OrderedDict((k, v) for k, v in proj4_params if v is not None)
 
 

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -118,14 +118,18 @@ class InterProjectionTransform(mtransforms.Transform):
         prj = self.target_projection
         # TODO: Catch projections which cause out of bounds problem in proj4
         # TODO: Reset lon_0 for these projections in proj4 params
-        limited_projections = [ccrs.Orthographic(), ccrs.]
-        if isinstance(xy, np.ndarray):
-            return prj.transform_points(self.source_projection,
-                                        xy[:, 0], xy[:, 1])[:, 0:2]
-        else:
-            x, y = xy
-            x, y = prj.transform_point(x, y, self.source_projection)
-            return x, y
+        limited_projections = [ccrs.Orthographic(), ccrs.TransverseMercator(),
+                               ccrs.Geostationary(), ccrs.Gnomonic()]
+        bad_projections = [ccrs.OSGB(), ccrs.EuroPP()]
+        if self.target_projection in limited_projections:
+
+            if isinstance(xy, np.ndarray):
+                return prj.transform_points(self.source_projection,
+                                            xy[:, 0], xy[:, 1])[:, 0:2]
+            else:
+                x, y = xy
+                x, y = prj.transform_point(x, y, self.source_projection)
+                return x, y
 
     def transform_path_non_affine(self, src_path):
         """

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -117,12 +117,14 @@ class InterProjectionTransform(mtransforms.Transform):
         """
         prj = self.target_projection
         # TODO: Catch projections which cause out of bounds problem in proj4
-        # TODO: Reset lon_0 for these projections in proj4 params
+        # TODO: Reset lon_0 and lat_0 for these projections in proj4 params
         limited_projections = [ccrs.Orthographic(), ccrs.TransverseMercator(),
                                ccrs.Geostationary(), ccrs.Gnomonic()]
         bad_projections = [ccrs.OSGB(), ccrs.EuroPP()]
         if self.target_projection in limited_projections:
-
+            lon_0 = xy[len(xy[:, 0])/2, 0]
+            lat_0 = xy[len(xy[:, 1])/2, 1]
+            self.target_projection = target_projection()
             if isinstance(xy, np.ndarray):
                 return prj.transform_points(self.source_projection,
                                             xy[:, 0], xy[:, 1])[:, 0:2]

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -134,8 +134,14 @@ class InterProjectionTransform(mtransforms.Transform):
             points = prj.transform_points(self.source_projection,
                                         xy[:, 0], xy[:, 1])[:, 0:2]
             if np.inf in points:
-                raise ValueError('proj4 error has occurred, points have not '
-                                 'been transformed correctly. Sorry.')
+                # raise ValueError('proj4 error has occurred, points have not '
+                #                  'been transformed correctly. Sorry.')
+                badness = np.where(points==np.inf)
+                mask = np.zeros(points.shape)
+                for (i, j) in (zip(badness[0], badness[1])):
+                    mask[i, j] = 1
+                points = np.ma.array(points, mask=mask)
+            return points
         else:
             x, y = xy
             x, y = prj.transform_point(x, y, self.source_projection)

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -116,6 +116,8 @@ class InterProjectionTransform(mtransforms.Transform):
 
         """
         prj = self.target_projection
+        if prj == self.source_projection:
+            return xy
         if isinstance(xy, np.ndarray):
             points = prj.transform_points(self.source_projection,
                                           xy[:, 0], xy[:, 1])[:, 0:2]

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -116,6 +116,9 @@ class InterProjectionTransform(mtransforms.Transform):
 
         """
         prj = self.target_projection
+        # TODO: Catch projections which cause out of bounds problem in proj4
+        # TODO: Reset lon_0 for these projections in proj4 params
+        limited_projections = [ccrs.Orthographic(), ccrs.]
         if isinstance(xy, np.ndarray):
             return prj.transform_points(self.source_projection,
                                         xy[:, 0], xy[:, 1])[:, 0:2]

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2016, Met Office
+# (C) British Crown Copyright 2011 - 2017, Met Office
 #
 # This file is part of cartopy.
 #

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -116,27 +116,11 @@ class InterProjectionTransform(mtransforms.Transform):
 
         """
         prj = self.target_projection
-        # TODO: Catch projections which cause out of bounds problem in proj4
-        # TODO: Reset lon_0 and lat_0 for these projections in proj4 params
-
-        # lon_0 = (np.max(xy[:, 0]) - np.min(xy[:, 0]))/2
-        # lat_0 = (np.max(xy[:, 1]) - np.min(xy[:, 1]))/2
-        #
-        # if isinstance(prj, ccrs.Orthographic) or \
-        #         isinstance(prj, ccrs.TransverseMercator):
-        #     prj.globe.central_longitude = lon_0
-        #     prj.globe.central_latitude = lat_0
-        # elif isinstance(prj, ccrs.Geostationary):
-        #     prj.globe.central_longitude = lon_0
-        # elif isinstance(prj, ccrs.Gnomonic):
-        #     prj.globe.central_latitude = lat_0
         if isinstance(xy, np.ndarray):
             points = prj.transform_points(self.source_projection,
-                                        xy[:, 0], xy[:, 1])[:, 0:2]
+                                          xy[:, 0], xy[:, 1])[:, 0:2]
             if np.inf in points:
-                # raise ValueError('proj4 error has occurred, points have not '
-                #                  'been transformed correctly. Sorry.')
-                badness = np.where(points==np.inf)
+                badness = np.where(points == np.inf)
                 mask = np.zeros(points.shape)
                 for (i, j) in (zip(badness[0], badness[1])):
                     mask[i, j] = 1


### PR DESCRIPTION
Had noticed an issue (https://github.com/SciTools/cartopy/issues/832) in which contour plots were sometimes not being drawn because the proj4 points transform returned a list of points containing np.infs.  The infs were then being turned into nans and causing the plot to just give up and not bother at all, with not even a warning.

The fix I am proposing for this is to simply mask all the values which contain an np.inf.  It seems to work, and it's better than deleting them.  

I am not entirely happy with this solution, as it doesn't actually tell proj4 how to transform the points properly, but that seems much more difficult to achieve because the call to proj4 gets all its parameters from the crs instance, which is initiated at the very beginning of the process and can't be retrospectively changed apparently.

I would quite happily work on this at a later date, but I would need a more experienced pair of eyes I think.