### PR TITLE
Add whats new for 0.15.0 release

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -330,10 +330,7 @@ What's new in cartopy 0.11
 * Thomas Lecocq added functionality to :mod:`cartopy.io.srtm` allowing
   intelligent filling of missing elevation data, as well as a function to
   compute elevation shading for relief style mapping. An example has been added
-  which uses both of these functions to produce a grayscale shaded relief map:
-
-.. plot:: examples/srtm_shading.py
-   :width: 300pt
+  which uses both of these functions to produce a grayscale shaded relief map
 
 * Lion Krischer extended the capability of
   :class:`~cartopy.io.img_tiles.GoogleTiles` to allow support for **street**,

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -1,3 +1,54 @@
+What's New in cartopy 0.15
+==========================
+
+:Release: 0.15.0
+:Date: 1st February 2017
+
+Features
+--------
+
+* The :class:`cartopy.crs.Mercator` class now allows a ``latitude_true_scale``
+  to be specified. 
+
+* A ``tiles`` url can now be passed directly to the
+  :class:`cartopy.io.img_tiles.GoogleTiles` class. 
+
+* The :meth:`~cartopy.mpl.geoaxes.GeoAxes.background_img` method has been
+  added. 
+
+* The Web Map Tile Service (WMTS) interface has been extended so that WMTS
+  layers can be added to geoaxes in different projections.
+
+* The :class:`~cartopy.crs.NearsidePerspective` projection has been added. 
+
+* Optional kwargs can now be supplied to the 
+  :meth:`~cartopy.mpl.geoaxes.GeoAxes.add_wmts` method, which will be passed to
+  the OGC WMTS ``gettile`` method. 
+
+* New additions to the gallery:
+
+ |image_axes_grid|_
+
+    .. |image_axes_grid| image:: examples/axes_grid_basic_00_00.png
+
+    .. _image_axes_grid: examples/axes_grid_basic.html
+
+ |image_reprojected_wmts|_
+
+    .. |image_reprojected_wmts| image:: examples/reprojected_wmts_00_00.png
+
+    .. _image_reprojected_wmts: examples/reprojected_wmts.html
+
+ |image_wmts_time|_
+
+    .. |image_wmts_time| image:: examples/wmts_time_00_00.png
+
+    .. _image_wmts_time: examples/wmts_time.html
+
+
+-----------
+
+
 What's New in cartopy 0.14
 ==========================
 
@@ -49,6 +100,7 @@ Features
 
     .. _image_aurora: examples/aurora_forecast.html
 
+
 Incompatible changes
 --------------------
 * :meth:`cartopy.crs.CRS.transform_point` now issues NaNs when invalid transforms are identified.
@@ -57,6 +109,10 @@ Incompatible changes
 Deprecations
 ------------
 * :data:`cartopy.crs.GOOGLE_MERCATOR` has been moved to :data:`cartopy.crs.Mercator.GOOGLE`.
+
+
+-----------
+
 
 
 What's new in cartopy 0.13
@@ -88,6 +144,9 @@ Features
     .. |image_eccentric_ellipse| image:: examples/eccentric_ellipse_00_00.png
 
     .. _image_eccentric_ellipse: examples/eccentric_ellipse.html
+
+
+-----------
 
 
 

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -14,7 +14,9 @@ Features
   :class:`cartopy.io.img_tiles.GoogleTiles` class. 
 
 * The :meth:`~cartopy.mpl.geoaxes.GeoAxes.background_img` method has been
-  added. 
+  added. This allows users to add a background image to the map, from a
+  selection of pre-prepared images held in a directory specified by the
+  CARTOPY_USER_BACKGROUNDS environment variable. 
 
 * The Web Map Tile Service (WMTS) interface has been extended so that WMTS
   layers can be added to geoaxes in different projections.


### PR DESCRIPTION
The Cartopy v0.15.0 release needs a whats new.

I did notice that "bugs fixed" haven't been included in any of the previous entries (which would explain why there aren't entries for the v0.14.1, v0.14.2 and v0.14.3 releases), so I followed suit. But I can add the bug fix entries if necessary (there were only 3).

