### PR TITLE
Bump version for post-release development

### DIFF
--- a/lib/cartopy/__init__.py
+++ b/lib/cartopy/__init__.py
@@ -17,7 +17,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-__version__ = '0.15.1'
+__version__ = '0.15.2dev0'
 __document_these__ = ['config']
 
 # Enable shapely performance enhancements


### PR DESCRIPTION
In a similar vein to #763 this bumps the version number to be 0.15.2dev0 (or should it be 0.15.2dev????)