### PR TITLE
Test transform bugfix

### DIFF
--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2016, Met Office
+# (C) British Crown Copyright 2011 - 2017, Met Office
 #
 # This file is part of cartopy.
 #

--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -348,6 +348,15 @@ cdef class CRS:
             result[:, 2] = 0
         else:
             result[:, 2] = z
+        # Catch restricted area CRS instances and reset central lons and lats
+        # This reduces proj4 out-of-bounds errors
+        if self.__class__ in ['Geostationary',
+                              'Gnomonic',
+                              'Orthographic',
+                              'TransverseMercator']:
+            target_lon_0 = (np.max(x) - np.min(x))/2
+            target_lat_0 = (np.max(y) - np.min(y))/2
+            self.proj4_params.update(lon_0=target_lon_0, lat_0=target_lat_0)
 
         # call proj.4. The result array is modified in place.
         status = pj_transform(src_crs.proj4, self.proj4, npts, 3,

--- a/lib/cartopy/tests/mpl/test_coord_transform.py
+++ b/lib/cartopy/tests/mpl/test_coord_transform.py
@@ -1,0 +1,54 @@
+# (C) British Crown Copyright 2017, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+
+import matplotlib.pyplot as plt
+from matplotlib.testing.decorators import cleanup
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+
+import cartopy.crs as ccrs
+
+
+
+# TODO: Decide how I want to test this:
+# Graphics test? (Probably not).
+# Test for nans or infs in transformed arrays? (Maybe too contrived)
+# Some kind of test of the geoaxes (like in test_contour.py) - Check mpl for options
+def test_transform_to_orthographic():
+
+
+
+
+def test_transform_to_transverse_mercator():
+
+
+
+
+def test_transform_to_gnomonic():
+
+
+
+def test_transform_to_geostationary():
+
+
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(argv=['-s', '--with-doctest'], exit=False)

--- a/lib/cartopy/tests/mpl/test_transform_points.py
+++ b/lib/cartopy/tests/mpl/test_transform_points.py
@@ -23,10 +23,7 @@ import unittest
 from nose.tools import assert_true
 
 
-
-
 # TODO: Decide how I want to test this:
-# Graphics test? (Probably not).
 # Test for nans or infs in transformed arrays? (Maybe too contrived)
 # Some kind of test of the geoaxes (like in test_contour.py) - Check mpl for options:
 # contains_point()?
@@ -34,7 +31,7 @@ from nose.tools import assert_true
 # has_data()? (unlikely, but worth a try...)
 
 class TestTransformPoints(unittest.TestCase):
-    def __init__(self):
+    def __init__():
         x = np.linspace(0, 360, 60).astype(np.float32)
         y = np.linspace(-90, 90, 90).astype(np.float32)
 

--- a/lib/cartopy/tests/mpl/test_transform_points.py
+++ b/lib/cartopy/tests/mpl/test_transform_points.py
@@ -36,9 +36,6 @@ class TestTransformPoints:
         target_proj = ccrs.Orthographic()
         proj_xyz = target_proj.transform_points(self.src_proj,
                                                 self.x2d, self.y2d)
-        # target_lon_0 = (np.max(self.x2d) - np.min(self.x2d))/2
-        # target_lat_0 = (np.max(self.y2d) - np.min(self.y2d))/2
-        # target_proj.proj4_params.update(lon_0=target_lon_0, lat_0=target_lat_0)
         assert_true(np.inf not in proj_xyz)
 
     def test_transform_to_transverse_mercator(self):

--- a/lib/cartopy/tests/mpl/test_transform_points.py
+++ b/lib/cartopy/tests/mpl/test_transform_points.py
@@ -23,25 +23,22 @@ import unittest
 from nose.tools import assert_true
 
 
-# TODO: Decide how I want to test this:
-# Test for nans or infs in transformed arrays? (Maybe too contrived)
-# Some kind of test of the geoaxes (like in test_contour.py) - Check mpl for options:
-# contains_point()?
-# get_visible()?
-# has_data()? (unlikely, but worth a try...)
-
 class TestTransformPoints:
     def __init__(self):
-        x = np.linspace(0, 360, 60).astype(np.float32)
-        y = np.linspace(-90, 90, 90).astype(np.float32)
+        x = np.array([-68, 142.5])
+        y = np.array([-72.5, -77.1])
 
         self.x2d, self.y2d = np.meshgrid(x, y)
 
         self.src_proj = ccrs.PlateCarree()
+
     def test_transform_to_orthographic(self):
         target_proj = ccrs.Orthographic()
         proj_xyz = target_proj.transform_points(self.src_proj,
                                                 self.x2d, self.y2d)
+        # target_lon_0 = (np.max(self.x2d) - np.min(self.x2d))/2
+        # target_lat_0 = (np.max(self.y2d) - np.min(self.y2d))/2
+        # target_proj.proj4_params.update(lon_0=target_lon_0, lat_0=target_lat_0)
         assert_true(np.inf not in proj_xyz)
 
     def test_transform_to_transverse_mercator(self):
@@ -61,8 +58,6 @@ class TestTransformPoints:
         proj_xyz = target_proj.transform_points(self.src_proj,
                                                 self.x2d, self.y2d)
         assert_true(np.inf not in proj_xyz)
-
-
 
 
 if __name__ == '__main__':

--- a/lib/cartopy/tests/mpl/test_transform_points.py
+++ b/lib/cartopy/tests/mpl/test_transform_points.py
@@ -30,8 +30,8 @@ from nose.tools import assert_true
 # get_visible()?
 # has_data()? (unlikely, but worth a try...)
 
-class TestTransformPoints(unittest.TestCase):
-    def __init__():
+class TestTransformPoints:
+    def __init__(self):
         x = np.linspace(0, 360, 60).astype(np.float32)
         y = np.linspace(-90, 90, 90).astype(np.float32)
 
@@ -44,16 +44,23 @@ class TestTransformPoints(unittest.TestCase):
                                                 self.x2d, self.y2d)
         assert_true(np.inf not in proj_xyz)
 
-    # def test_transform_to_transverse_mercator():
-    #
-    #
-    #
-    #
-    # def test_transform_to_gnomonic():
-    #
-    #
-    #
-    # def test_transform_to_geostationary():
+    def test_transform_to_transverse_mercator(self):
+        target_proj = ccrs.TransverseMercator()
+        proj_xyz = target_proj.transform_points(self.src_proj,
+                                                self.x2d, self.y2d)
+        assert_true(np.inf not in proj_xyz)
+
+    def test_transform_to_gnomonic(self):
+        target_proj = ccrs.Gnomonic()
+        proj_xyz = target_proj.transform_points(self.src_proj,
+                                                self.x2d, self.y2d)
+        assert_true(np.inf not in proj_xyz)
+
+    def test_transform_to_geostationary(self):
+        target_proj = ccrs.Geostationary()
+        proj_xyz = target_proj.transform_points(self.src_proj,
+                                                self.x2d, self.y2d)
+        assert_true(np.inf not in proj_xyz)
 
 
 

--- a/lib/cartopy/tests/mpl/test_transform_points.py
+++ b/lib/cartopy/tests/mpl/test_transform_points.py
@@ -17,34 +17,46 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import cleanup
-import numpy as np
-from numpy.testing import assert_array_almost_equal
-
 import cartopy.crs as ccrs
+import numpy as np
+import unittest
+from nose.tools import assert_true
+
 
 
 
 # TODO: Decide how I want to test this:
 # Graphics test? (Probably not).
 # Test for nans or infs in transformed arrays? (Maybe too contrived)
-# Some kind of test of the geoaxes (like in test_contour.py) - Check mpl for options
-def test_transform_to_orthographic():
+# Some kind of test of the geoaxes (like in test_contour.py) - Check mpl for options:
+# contains_point()?
+# get_visible()?
+# has_data()? (unlikely, but worth a try...)
 
+class TestTransformPoints(unittest.TestCase):
+    def __init__(self):
+        x = np.linspace(0, 360, 60).astype(np.float32)
+        y = np.linspace(-90, 90, 90).astype(np.float32)
 
+        self.x2d, self.y2d = np.meshgrid(x, y)
 
+        self.src_proj = ccrs.PlateCarree()
+    def test_transform_to_orthographic(self):
+        target_proj = ccrs.Orthographic()
+        proj_xyz = target_proj.transform_points(self.src_proj,
+                                                self.x2d, self.y2d)
+        assert_true(np.inf not in proj_xyz)
 
-def test_transform_to_transverse_mercator():
-
-
-
-
-def test_transform_to_gnomonic():
-
-
-
-def test_transform_to_geostationary():
+    # def test_transform_to_transverse_mercator():
+    #
+    #
+    #
+    #
+    # def test_transform_to_gnomonic():
+    #
+    #
+    #
+    # def test_transform_to_geostationary():
 
 
 


### PR DESCRIPTION
This is a test to show that current points transform operations do not work with the proj4 API.  All these tests fail, due to proj4 returning invalid coordinates (np.infs).  This happens when proj4 deems a transform to be out of bounds of the target CRS.

