### PR TITLE
Multiple small optimizations

### DIFF
--- a/lib/cartopy/mpl/patch.py
+++ b/lib/cartopy/mpl/patch.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2016, Met Office
+# (C) British Crown Copyright 2011 - 2017, Met Office
 #
 # This file is part of cartopy.
 #
@@ -63,7 +63,7 @@ def geos_to_path(shape):
         return paths
 
     if isinstance(shape, (sgeom.LineString, sgeom.Point)):
-        return [Path(np.vstack(shape.xy).T)]
+        return [Path(np.column_stack(shape.xy))]
     elif isinstance(shape, sgeom.Polygon):
         def poly_codes(poly):
             codes = np.ones(len(poly.xy[0])) * Path.LINETO


### PR DESCRIPTION
This optimizes a few small bits of repetitive work. Using a test of the following form (generating a bunch of maps on a grid like this is something I do often):
```python
import matplotlib as mpl
mpl.use('Agg')
import matplotlib.pylab as plt
import cartopy.crs as ccrs

transform = ccrs.PlateCarree(central_longitude=0)
fig, axs = plt.subplots(10, 10, figsize=(20, 20), subplot_kw=dict(projection=transform))
for ax in axs.flat:
    ax.coastlines(resolution='110m')
    gridlines = ax.gridlines()

fig.savefig('tmp.png')
```
these changes reduce runtime from 8.32 s (average of 3 runs) to 3.73 s, approximately 2 times faster.