### PR TITLE
BUG: Fix incorrect ellipse boundary for Geostationary

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1619,8 +1619,8 @@ class _Satellite(Projection):
         a = np.float(self.globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS)
         b = np.float(self.globe.semiminor_axis or a)
         h = np.float(satellite_height)
-        max_x = h * math.atan(a / (a + h))
-        max_y = h * math.atan(b / (b + h))
+        max_x = h * np.arcsin(a / (a + h))
+        max_y = h * np.arcsin(b / (a + h))
 
         coords = _ellipse_boundary(max_x, max_y,
                                    false_easting, false_northing, 61)

--- a/lib/cartopy/tests/crs/test_geostationary.py
+++ b/lib/cartopy/tests/crs/test_geostationary.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2016, Met Office
+# (C) British Crown Copyright 2013 - 2017, Met Office
 #
 # This file is part of cartopy.
 #
@@ -48,8 +48,8 @@ class GeostationaryTestsMixin(object):
         check_proj4_params(geos, expected)
 
         assert_almost_equal(geos.boundary.bounds,
-                            (-5372584.78443894, -5372584.78443894,
-                             5372584.78443894, 5372584.78443894),
+                            (-5434177.81588539, -5434177.81588539,
+                             5434177.81588539, 5434177.81588539),
                             decimal=4)
 
     def test_eccentric_globe(self):
@@ -64,7 +64,7 @@ class GeostationaryTestsMixin(object):
         check_proj4_params(geos, expected)
 
         assert_almost_equal(geos.boundary.bounds,
-                            (-8257.4338, -4532.9943, 8257.4338, 4532.9943),
+                            (-8372.4040, -4171.5043, 8372.4040, 4171.5043),
                             decimal=4)
 
     def test_eastings(self):
@@ -78,8 +78,8 @@ class GeostationaryTestsMixin(object):
         check_proj4_params(geos, expected)
 
         assert_almost_equal(geos.boundary.bounds,
-                            (-372584.78443894, -5497584.78443894,
-                             10372584.78443894, 5247584.78443894),
+                            (-434177.81588539, -5559177.81588539,
+                             10434177.81588539, 5309177.81588539),
                             decimal=4)
 
 

--- a/lib/cartopy/tests/crs/test_nearside_perspective.py
+++ b/lib/cartopy/tests/crs/test_nearside_perspective.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016, Met Office
+# (C) British Crown Copyright 2016 - 2017, Met Office
 #
 # This file is part of cartopy.
 #
@@ -50,8 +50,8 @@ class TestOwnSpecifics(unittest.TestCase):
         check_proj4_params(geos, expected)
 
         assert_almost_equal(geos.boundary.bounds,
-                            (-5372584.78443894, -5372584.78443894,
-                             5372584.78443894, 5372584.78443894),
+                            (-5434177.81588539, -5434177.81588539,
+                             5434177.81588539, 5434177.81588539),
                             decimal=4)
 
 


### PR DESCRIPTION
Need to calculate boundary out to where the satellite viewing angle is
tangent to the spheroid (not out to +/- 90 latitude and longitude). Also
should always use `a + h` in the denominator, since this needs to be total
distance of the satellite above the earth center point.

Also go ahead and use numpy math functions since values are converted to
numpy floats.