### PR TITLE
Support `sweep` parameter for Geostationary projection

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1608,11 +1608,14 @@ class InterruptedGoodeHomolosine(Projection):
 class _Satellite(Projection):
     def __init__(self, projection, satellite_height=35785831,
                  central_longitude=0.0, central_latitude=0.0,
-                 false_easting=0, false_northing=0, globe=None):
+                 false_easting=0, false_northing=0, globe=None,
+                 sweep_axis=None):
         proj4_params = [('proj', projection), ('lon_0', central_longitude),
                         ('lat_0', central_latitude), ('h', satellite_height),
                         ('x_0', false_easting), ('y_0', false_northing),
                         ('units', 'm')]
+        if sweep_axis:
+            proj4_params.append(('sweep', sweep_axis))
         super(_Satellite, self).__init__(proj4_params, globe=globe)
 
         # TODO: Let the globe return the semimajor axis always.
@@ -1652,7 +1655,8 @@ class Geostationary(_Satellite):
 
     """
     def __init__(self, central_longitude=0.0, satellite_height=35785831,
-                 false_easting=0, false_northing=0, globe=None):
+                 false_easting=0, false_northing=0, globe=None,
+                 sweep_axis='y'):
         super(Geostationary, self).__init__(
             projection='geos',
             satellite_height=satellite_height,
@@ -1660,7 +1664,8 @@ class Geostationary(_Satellite):
             central_latitude=0.0,
             false_easting=false_easting,
             false_northing=false_northing,
-            globe=globe)
+            globe=globe,
+            sweep_axis=sweep_axis)
 
 
 class NearsidePerspective(_Satellite):

--- a/lib/cartopy/tests/crs/test_geostationary.py
+++ b/lib/cartopy/tests/crs/test_geostationary.py
@@ -36,12 +36,19 @@ class GeostationaryTestsMixin(object):
     test_class = ccrs.Geostationary
     expected_proj_name = 'geos'
 
+    def adjust_expected_params(self, expected):
+        # Only for Geostationary do we expect the sweep parameter
+        if self.expected_proj_name == 'geos':
+            expected.insert(-3, 'sweep=y')
+
     def test_default(self):
         geos = self.test_class()
         expected = ['+ellps=WGS84', 'h=35785831', 'lat_0=0.0', 'lon_0=0.0',
                     'no_defs',
                     'proj={}'.format(self.expected_proj_name),
                     'units=m', 'x_0=0', 'y_0=0']
+        self.adjust_expected_params(expected)
+
         check_proj4_params(geos, expected)
 
         assert_almost_equal(geos.boundary.bounds,
@@ -58,6 +65,8 @@ class GeostationaryTestsMixin(object):
                     'no_defs',
                     'proj={}'.format(self.expected_proj_name),
                     'units=m', 'x_0=0', 'y_0=0']
+        self.adjust_expected_params(expected)
+
         check_proj4_params(geos, expected)
 
         assert_almost_equal(geos.boundary.bounds,
@@ -72,6 +81,8 @@ class GeostationaryTestsMixin(object):
                     'proj={}'.format(self.expected_proj_name),
                     'units=m', 'x_0=5000000',
                     'y_0=-125000']
+        self.adjust_expected_params(expected)
+
         check_proj4_params(geos, expected)
 
         assert_almost_equal(geos.boundary.bounds,
@@ -81,4 +92,16 @@ class GeostationaryTestsMixin(object):
 
 
 class TestGeostationary(GeostationaryTestsMixin, object):
-    pass
+    def test_sweep(self):
+        geos = ccrs.Geostationary(sweep_axis='x')
+        expected = ['+ellps=WGS84', 'h=35785831', 'lat_0=0.0', 'lon_0=0.0',
+                    'no_defs', 'proj=geos', 'sweep=x',
+                    'units=m', 'x_0=0', 'y_0=0']
+
+        check_proj4_params(geos, expected)
+
+        pt = geos.transform_point(-60, 25, ccrs.PlateCarree())
+
+        assert_almost_equal(pt,
+                            (-4529521.6442, 2437479.4195),
+                            decimal=4)


### PR DESCRIPTION
Proj.4 (added in 4.8) has a `sweep` parameter that designates which axis is fixed and which is scanning, which impacts the formula for the projection. (See [here](https://github.com/OSGeo/proj.4/wiki/Geostationary) for more info.)

I've added this parameter to the `Geostationary` and `_Satellite` projections. Owing to the Euro roots of the project, I made 'y' the default to match Meteosat. The upshot of this change is that GOES-16 data (making use of the `sweep_angle_axis` attribute) goes from:

<img width="195" alt="screen shot 2017-06-22 at 9 02 46 pm" src="https://user-images.githubusercontent.com/221526/27465708-79a935de-5792-11e7-852d-1a0e0e70f676.png">

to:

<img width="200" alt="screen shot 2017-06-22 at 9 03 33 pm" src="https://user-images.githubusercontent.com/221526/27465723-89746cfe-5792-11e7-8044-520320747899.png">
