### PR TITLE
Use `shapely.buffer(0)` to attempt fixing invalid geometries

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -561,8 +561,9 @@ class Projection(six.with_metaclass(ABCMeta, CRS)):
             x4 += bx
             y4 += by
             for ring in interior_rings:
-                polygon = sgeom.Polygon(ring)
-                if polygon.is_valid:
+                # Use shapely buffer in an attempt to fix invalid geometries
+                polygon = sgeom.Polygon(ring).buffer(0)
+                if not polygon.is_empty and polygon.is_valid:
                     x1, y1, x2, y2 = polygon.bounds
                     bx = (x2 - x1) * 0.1
                     by = (y2 - y1) * 0.1


### PR DESCRIPTION
This change should be a NOOP if the inbound interior_ring is valid
to begin with, otherwise `buffer(0)` should make an attempt to fix
invalid geometries.  If it fails, then we need an additional check
that the polygon is not empty. fixes #903