### PR TITLE
Add the docs to the release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,4 @@ include lib/cartopy/data/*
 include lib/cartopy/io/srtm.npz
 recursive-include lib *.py
 recursive-include lib *.pyx *.pxd *.h
+graft docs

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ include lib/cartopy/io/srtm.npz
 recursive-include lib *.py
 recursive-include lib *.pyx *.pxd *.h
 graft docs
+prune docs/build


### PR DESCRIPTION
Enable builds of a corresponding documentation package for `Cartopy` on Linux distributions such as Debian