### PR TITLE
Update waves.py

### DIFF
--- a/lib/cartopy/examples/waves.py
+++ b/lib/cartopy/examples/waves.py
@@ -13,11 +13,12 @@ def sample_data(shape=(73, 145)):
     lons, lats = np.meshgrid(lons, lats)
     wave = 0.75 * (np.sin(2 * lats) ** 8) * np.cos(4 * lons)
     mean = 0.5 * np.cos(2 * lats) * ((np.sin(2 * lats)) ** 2 + 2)
-
-    lats = np.rad2deg(lats)
-    lons = np.rad2deg(lons)
     data = wave + mean
-
+    
+    lats = np.linspace(90, -90, nlats)
+    lons = np.linspace(-180, 180, nlons)
+    lons, lats = np.meshgrid(lons, lats)
+    
     return lons, lats, data
 
 
@@ -29,7 +30,7 @@ def main():
 
     ax.contourf(lons, lats, data,
                 transform=ccrs.PlateCarree(),
-                cmap='spectral')
+                cmap='nipy_spectral')
     ax.coastlines()
     ax.set_global()
     plt.show()


### PR DESCRIPTION
I'm just transitioning from basemap to cartopy and am working through some examples to understand how things work.

I found this example a little confusing as in the original version the sample data's longitude values ran 0 to 360 from west (left) to east (right), and the latitude values ran -90 to 90 from north (top) to south (bottom), neither of which makes sense to me in terms of actual latitude and longitude values.

I suggested a change which means the sample data's longitude values run -180 to 180 from west to east, and the latitude values run 90 to 90 from north to south, so that they relate to a geographic coordinate system.

I was also getting a Matplotlib Deprecation Warning message that the spectral colormap was deprecated in version 2.0, so I have updated to nipy_spectral instead as per the warning messages instruction.

The final plot looks identical, so i don't think I've changed the intent of the example, but I think this might make it easier for people to understand how to plot gridded data - hope you think it is helpful!