### PR TITLE
Prevent memory leak in CRS objects

### DIFF
--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -131,6 +131,12 @@ cdef class CRS:
     Defines a Coordinate Reference System using proj.4.
 
     """
+    def __cinit__(self):
+        self.proj4 = NULL
+
+    def __dealloc__(self):
+        pj_free(self.proj4)
+
     def __init__(self, proj4_params, globe=None):
         """
         Parameters
@@ -162,7 +168,8 @@ cdef class CRS:
                 init_items.append('+{}'.format(k))
         self.proj4_init = ' '.join(init_items) + ' +no_defs'
         proj4_init_bytes = six.b(self.proj4_init)
-        self.proj4 = pj_init_plus(proj4_init_bytes)
+        if self.proj4 is NULL:
+            self.proj4 = pj_init_plus(proj4_init_bytes)
         if not self.proj4:
             raise Proj4Error()
 

--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -135,7 +135,7 @@ cdef class CRS:
         self.proj4 = NULL
 
     def __dealloc__(self):
-        if self.proj4 is not NULL:
+        if self.proj4 != NULL:
             pj_free(self.proj4)
 
     def __init__(self, proj4_params, globe=None):
@@ -169,7 +169,7 @@ cdef class CRS:
                 init_items.append('+{}'.format(k))
         self.proj4_init = ' '.join(init_items) + ' +no_defs'
         proj4_init_bytes = six.b(self.proj4_init)
-        if self.proj4 is not NULL:
+        if self.proj4 != NULL:
             pj_free(self.proj4)
         self.proj4 = pj_init_plus(proj4_init_bytes)
         if not self.proj4:

--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -135,7 +135,8 @@ cdef class CRS:
         self.proj4 = NULL
 
     def __dealloc__(self):
-        pj_free(self.proj4)
+        if self.proj4 is not NULL:
+            pj_free(self.proj4)
 
     def __init__(self, proj4_params, globe=None):
         """
@@ -168,8 +169,9 @@ cdef class CRS:
                 init_items.append('+{}'.format(k))
         self.proj4_init = ' '.join(init_items) + ' +no_defs'
         proj4_init_bytes = six.b(self.proj4_init)
-        if self.proj4 is NULL:
-            self.proj4 = pj_init_plus(proj4_init_bytes)
+        if self.proj4 is not NULL:
+            pj_free(self.proj4)
+        self.proj4 = pj_init_plus(proj4_init_bytes)
         if not self.proj4:
             raise Proj4Error()
 


### PR DESCRIPTION
Cartopy CRS objects don't free the proj4 object they own. This PR fixes that.