### PR TITLE
Add _repr_html_ to Projection class

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -156,6 +156,13 @@ class Projection(six.with_metaclass(ABCMeta, CRS)):
             minlon += epsilon
         return minlon, maxlon
 
+    def _repr_html_(self):
+        import matplotlib.pyplot as plt
+        ax = plt.axes(projection=self)
+        ax.set_global()
+        ax.coastlines('110m')
+        plt.show()
+
     def _as_mpl_axes(self):
         import cartopy.mpl.geoaxes as geoaxes
         return geoaxes.GeoAxes, {'map_projection': self}

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -157,11 +157,29 @@ class Projection(six.with_metaclass(ABCMeta, CRS)):
         return minlon, maxlon
 
     def _repr_html_(self):
+        """
+        Make a visual representation of the projection and return it as an
+        html element.
+
+        """
+        # Imports.
+        import base64
+        from io import BytesIO
         import matplotlib.pyplot as plt
+        # Produce a visual repr of the Projection instance.
         ax = plt.axes(projection=self)
         ax.set_global()
         ax.coastlines('110m')
-        plt.show()
+        # "Save" to a bytestring.
+        fmt = 'png'
+        buf = BytesIO()
+        plt.savefig(buf, format=fmt)
+        plt.close()
+        buf.seek(0)  # "Rewind" the buffer to the start.
+        img_str = base64.b64encode(buf.getvalue()).decode()
+        # Produce html output.
+        html = '<img src="data:image/{fmt};base64,{img_str}" />'
+        return html.format(fmt=fmt, img_str=img_str)
 
     def _as_mpl_axes(self):
         import cartopy.mpl.geoaxes as geoaxes


### PR DESCRIPTION
Provides a visual repr (!) of any cartopy `Projection` subclass in jupyter notebook.

For example:

<img width="1109" alt="screen shot 2017-11-14 at 14 12 05" src="https://user-images.githubusercontent.com/3473068/32784148-ed4fbcea-c945-11e7-906f-83eeebd67728.png">

Also works interactively:

<img width="1102" alt="screen shot 2017-11-14 at 14 15 50" src="https://user-images.githubusercontent.com/3473068/32784313-643cf502-c946-11e7-82d9-11237feb5aed.png">