### PR TITLE
Adding .stickler.yml

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,2 @@
+linters:
+  flake8: {  }


### PR DESCRIPTION
Replaces automatic #967 

Because CLA-checker doesn't like that one.