### PR TITLE
fresh addition of savefig link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It features:
 
  * object oriented projection definitions
  * point, line, polygon and image transformations between projections
- * integration to expose advanced mapping in matplotlib with a simple and intuitive interface
+ * integration to expose advanced mapping in Matplotlib with a simple and intuitive interface
  * powerful vector data handling by integrating shapefile reading with Shapely capabilities 
 
 Licence

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ It features:
 
 * object oriented projection definitions
 * point, line, polygon and image transformations between projections
-* integration to expose advanced mapping in matplotlib with a simple and intuitive interface
+* integration to expose advanced mapping in Matplotlib with a simple and intuitive interface
 * powerful vector data handling by integrating shapefile reading with Shapely capabilities 
 
 Documentation can be found at http://scitools.org.uk/cartopy/docs/latest/.

--- a/docs/source/citation.rst
+++ b/docs/source/citation.rst
@@ -13,7 +13,7 @@ For example::
 
  @manual{Cartopy,
  author = {{Met Office}},
- title = {Cartopy: a cartographic python library with a matplotlib interface},
+ title = {Cartopy: a cartographic python library with a Matplotlib interface},
  year = {2010 - 2015},
  address = {Exeter, Devon },
  url = {http://scitools.org.uk/cartopy}

--- a/docs/source/developer_interfaces.rst
+++ b/docs/source/developer_interfaces.rst
@@ -51,7 +51,7 @@ matplotlib interface the
 :class:`cartopy.mpl.slippy_image_artist.SlippyImageArtist`
 class feeds the appropriate information to the
 :class:`~cartopy.io.RasterSource` and visualises it on a map.
-The orchestration in matplotlib is made more convenient
+The orchestration in Matplotlib is made more convenient
 to the user of a :class:`~cartopy.mpl.geoaxes.GeoAxes` through the
 :class:`~cartopy.mpl.geoaxes.GeoAxes.add_raster` method. Anything which exposes
 the ``validate_projection`` and ``fetch_raster`` methods in the form described

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,13 +12,13 @@ Introduction
 Cartopy is a Python package designed to make drawing maps for data analysis and visualisation as easy as possible.
 
 Cartopy makes use of the powerful PROJ.4, numpy and shapely libraries and has a simple and intuitive
-drawing interface to matplotlib for creating publication quality maps.
+drawing interface to Matplotlib for creating publication quality maps.
 
 Some of the key features of cartopy are:
 
  * object oriented projection definitions
  * point, line, vector, polygon and image transformations between projections
- * integration to expose advanced mapping in matplotlib with a simple and intuitive interface
+ * integration to expose advanced mapping in Matplotlib with a simple and intuitive interface
  * powerful vector data handling by integrating shapefile reading with Shapely capabilities
 
 Cartopy is licensed under `GNU Lesser General Public License <https://www.gnu.org/licenses/lgpl.html>`_

--- a/docs/source/matplotlib/feature_interface.rst
+++ b/docs/source/matplotlib/feature_interface.rst
@@ -68,7 +68,7 @@ For a full list of names in this dictionary:
 ------------
 
 
-Example of using the Feature class with the matplotlib interface
+Example of using the Feature class with the Matplotlib interface
 ----------------------------------------------------------------
 
 .. figure:: ../gallery/lines_and_polygons/images/sphx_glr_feature_creation_001.png

--- a/docs/source/matplotlib/geoaxes.rst
+++ b/docs/source/matplotlib/geoaxes.rst
@@ -1,12 +1,12 @@
-Cartopy matplotlib integration reference document
+Cartopy Matplotlib integration reference document
 =================================================
 
-The primary class for integrating cartopy into matplotlib is the GeoAxes, which is a subclass of
-a normal matplotlib Axes. The GeoAxes class adds extra functionality to an axes which is specific
+The primary class for integrating cartopy into Matplotlib is the GeoAxes, which is a subclass of
+a normal Matplotlib Axes. The GeoAxes class adds extra functionality to an axes which is specific
 to drawing maps. The majority of the methods which have been specialised from the original Axes
 are there to add improved -expected- behaviour, but some are to work around limitations that the
-standard matplotlib axes treats data in a Cartesian way (most of which either have, or will be,
-submitted back to the matplotlib project).
+standard Matplotlib axes treats data in a Cartesian way (most of which either have, or will be,
+submitted back to the Matplotlib project).
 
 
 .. autoclass:: cartopy.mpl.geoaxes.GeoAxes

--- a/docs/source/matplotlib/intro.rst
+++ b/docs/source/matplotlib/intro.rst
@@ -13,7 +13,7 @@ Beautifully simple maps
 -----------------------
 
 Cartopy has exposed an interface to enable easy map creation using matplotlib.
-Creating a basic map is as simple as telling matplotlib to use a specific map projection,
+Creating a basic map is as simple as telling Matplotlib to use a specific map projection,
 and then adding some coastlines to the axes:
 
 .. plot::
@@ -25,10 +25,14 @@ and then adding some coastlines to the axes:
     ax = plt.axes(projection=ccrs.PlateCarree())
     ax.coastlines()
 
+    # Save the plot by calling plt.savefig() BEFORE plt.show()
+    plt.savefig('coastlines.pdf')
+    plt.savefig('coastlines.png')
+
     plt.show()
 
 
-A list of the available projections to be used with matplotlib can be 
+A list of the available projections to be used with Matplotlib can be
 found on the :ref:`cartopy_projections` page.
 
 The line ``plt.axes(projection=ccrs.PlateCarree())`` sets up a 
@@ -37,6 +41,9 @@ which exposes a variety of other map related methods, in the case of the
 previous example, we used the 
 :meth:`~cartopy.mpl.geoaxes.GeoAxes.coastlines` method
 to add coastlines to the map.
+
+To save the figure, use Matplotlib's :func:`~matplotlib.pyplot.savefig`
+function.
 
 Lets create another map in a different projection, and make use of the
 :meth:`~cartopy.mpl.geoaxes.GeoAxes.stock_img` method to add an underlay
@@ -61,7 +68,7 @@ Adding data to the map
 ----------------------
 
 Once you have the map just the way you want it, data can be added to it in exactly the same way as
-with normal matplotlib axes. By default, the coordinate system of any data added to a GeoAxes is 
+with normal Matplotlib axes. By default, the coordinate system of any data added to a GeoAxes is
 the same as the coordinate system of the GeoAxes itself, to control which coordinate system 
 that the given data is in, you can add the ``transform`` keyword with an appropriate 
 :class:`cartopy.crs.CRS` instance:
@@ -108,7 +115,7 @@ those points *on the globe* rather than 2d Cartesian space.
 
 .. note::
 
-    By default, matplotlib automatically sets the limits of your Axes based on the data
+    By default, Matplotlib automatically sets the limits of your Axes based on the data
     that you plot. Because cartopy implements a :class:`~cartopy.mpl.geoaxes.GeoAxes`
     class, this equates to the limits of the resulting map. Sometimes this autoscaling
     is a desirable feature and other times it is not.

--- a/docs/source/sphinxext/plot_directive.py
+++ b/docs/source/sphinxext/plot_directive.py
@@ -2,7 +2,7 @@
 # https://github.com/matplotlib/matplotlib/pull/6213.
 # License: matplotlib BSD-3.
 """
-A directive for including a matplotlib plot in a Sphinx document.
+A directive for including a Matplotlib plot in a Sphinx document.
 
 By default, in HTML output, `plot` will include a .png file with a
 link to a high-res .png and .pdf.  In LaTeX output, it will include a

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -86,7 +86,7 @@ Features
   every service supports this method, and so those will use non-secured HTTP connections
   instead. (See :pull:`736` for full details.)
 
-* Cartopy now supports, and is tested against, matplotlib 1.3 and 1.5 as well as
+* Cartopy now supports, and is tested against, Matplotlib 1.3 and 1.5 as well as
   numpy 1.7, 1.8 and 1.10.
 
 * Daniel Eriksson added a new example to the gallery:
@@ -125,7 +125,7 @@ Features
 
 * Peter Killick fixed the cartopy.crs.Mercator projection for non-zero central longitudes. (:pull:`633`)
 
-* Conversion between matplotlib :class:`matplotlib.path.Path` and
+* Conversion between Matplotlib :class:`matplotlib.path.Path` and
   :class:`shapely.geometry.Geometry <Shapely geometry>` using
   :func:`cartopy.mpl.patch.path_to_geos` and :func:`cartopy.mpl.patch.geos_to_path` now
   handles degenerate point paths.
@@ -221,7 +221,7 @@ Features
         plt.show()
 
 * A new method has been added to the :class:`~cartopy.mpl.geoaxes.GeoAxes` to
-  allow control of the neatline of a map drawn with the matplotlib interface.
+  allow control of the neatline of a map drawn with the Matplotlib interface.
   The method, :meth:`~cartopy.mpl.geoaxes.GeoAxes.set_boundary`, takes a
   :class:`matplotlib Path<matplotlib.path.Path>` object, which means that
   arbitrary shaped edges can be achieved:

--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -209,7 +209,7 @@ cdef class CRS:
     def _as_mpl_transform(self, axes=None):
         """
         Casts this CRS instance into a :class:`matplotlib.axes.Axes` using
-        the matplotlib ``_as_mpl_transform`` interface.
+        the Matplotlib ``_as_mpl_transform`` interface.
 
         """
         # lazy import mpl.geoaxes (and therefore matplotlib) as mpl

--- a/lib/cartopy/examples/miscellanea/un_flag.py
+++ b/lib/cartopy/examples/miscellanea/un_flag.py
@@ -20,7 +20,7 @@ filled_land = True
 
 def olive_path():
     """
-    Returns a matplotlib path representing a single olive branch from the
+    Returns a Matplotlib path representing a single olive branch from the
     UN Flag. The path coordinates were extracted from the SVG at
     https://commons.wikimedia.org/wiki/File:Flag_of_the_United_Nations.svg.
 

--- a/lib/cartopy/examples/scalar_data/aurora_forecast.py
+++ b/lib/cartopy/examples/scalar_data/aurora_forecast.py
@@ -128,7 +128,7 @@ def fill_dark_side(ax, time=None, *args, **kwargs):
 
     Parameters
     ----------
-        ax : matplotlib axes
+        ax : Matplotlib axes
             The axes to plot on.
         time : datetime
             The time to calculate terminator for. Defaults to datetime.utcnow()

--- a/lib/cartopy/feature.py
+++ b/lib/cartopy/feature.py
@@ -70,7 +70,7 @@ class Feature(six.with_metaclass(ABCMeta)):
 
     .. seealso::
 
-        To add features to the current matplotlib axes, see
+        To add features to the current Matplotlib axes, see
         :func:`GeoAxes <cartopy.mpl.geoaxes.GeoAxes.add_feature>`.
 
     """
@@ -88,7 +88,7 @@ class Feature(six.with_metaclass(ABCMeta)):
     def kwargs(self):
         """
         The read-only dictionary of keyword arguments that are used when
-        creating the matplotlib artists for this feature.
+        creating the Matplotlib artists for this feature.
 
         """
         return dict(self._kwargs)

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -19,7 +19,7 @@
 Implements image tile identification and fetching from various sources.
 
 
-The matplotlib interface can make use of tile objects (defined below) via the
+The Matplotlib interface can make use of tile objects (defined below) via the
 :meth:`cartopy.mpl.geoaxes.GeoAxes.add_image` method. For example, to add a
 :class:`MapQuest Open Aerial tileset <MapQuestOpenAerial>` to an existing axes
 at zoom level 2, do ``ax.add_image(MapQuestOpenAerial(), 2)``. An example of

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -61,13 +61,13 @@ class FeatureArtist(matplotlib.artist.Artist):
     _geom_key_to_geometry_cache = weakref.WeakValueDictionary()
     """
     A mapping from _GeomKey to geometry to assist with the caching of
-    transformed matplotlib paths.
+    transformed Matplotlib paths.
 
     """
     _geom_key_to_path_cache = weakref.WeakKeyDictionary()
     """
     A nested mapping from geometry (converted to a _GeomKey) and target
-    projection to the resulting transformed matplotlib paths::
+    projection to the resulting transformed Matplotlib paths::
 
         {geom: {target_projection: list_of_paths}}
 

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2016, Met Office
+# (C) British Crown Copyright 2011 - 2017, Met Office
 #
 # This file is part of cartopy.
 #

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -17,7 +17,7 @@
 """
 This module defines the :class:`GeoAxes` class, for use with matplotlib.
 
-When a matplotlib figure contains a GeoAxes the plotting commands can transform
+When a Matplotlib figure contains a GeoAxes the plotting commands can transform
 plot results from source coordinates to the GeoAxes' target projection.
 
 """
@@ -145,12 +145,12 @@ class InterProjectionTransform(mtransforms.Transform):
 
         Args:
 
-            * src_path - A matplotlib :class:`~matplotlib.path.Path` object
+            * src_path - A Matplotlib :class:`~matplotlib.path.Path` object
                          with vertices in source coordinates.
 
         Returns
 
-            * A matplotlib :class:`~matplotlib.path.Path` with vertices
+            * A Matplotlib :class:`~matplotlib.path.Path` with vertices
               in target coordinates.
 
         """
@@ -211,7 +211,7 @@ class InterProjectionTransform(mtransforms.Transform):
 
     def inverted(self):
         """
-        Return a matplotlib :class:`~matplotlib.transforms.Transform`
+        Return a Matplotlib :class:`~matplotlib.transforms.Transform`
         from target to source coordinates.
 
         """
@@ -224,7 +224,7 @@ class GeoAxes(matplotlib.axes.Axes):
     A subclass of :class:`matplotlib.axes.Axes` which represents a
     map :class:`~cartopy.crs.Projection`.
 
-    This class replaces the matplotlib :class:`~matplotlib.axes.Axes` class
+    This class replaces the Matplotlib :class:`~matplotlib.axes.Axes` class
     when created with the *projection* keyword. For example::
 
         # Set up a standard map for latlon data.
@@ -234,7 +234,7 @@ class GeoAxes(matplotlib.axes.Axes):
         geo_axes = pyplot.subplot(2, 2, 1, projection=cartopy.crs.OSGB())
 
     When a source projection is provided to one of it's plotting methods,
-    using the *transform* keyword, the standard matplotlib plot result is
+    using the *transform* keyword, the standard Matplotlib plot result is
     transformed from source coordinates to the target projection. For example::
 
         # Plot latlon data on an OSGB map.
@@ -337,7 +337,7 @@ class GeoAxes(matplotlib.axes.Axes):
         Extends the standard behaviour of :func:`matplotlib.axes.Axes.draw`.
 
         Draws grid lines and image factory results before invoking standard
-        matplotlib drawing. A global range is used if no limits have yet
+        Matplotlib drawing. A global range is used if no limits have yet
         been set.
 
         """
@@ -396,7 +396,7 @@ class GeoAxes(matplotlib.axes.Axes):
         return result
 
     def format_coord(self, x, y):
-        """Return a string formatted for the matplotlib GUI status bar."""
+        """Return a string formatted for the Matplotlib GUI status bar."""
         lon, lat = ccrs.Geodetic().transform_point(x, y, self.projection)
 
         ns = 'N' if lat >= 0.0 else 'S'
@@ -520,7 +520,7 @@ class GeoAxes(matplotlib.axes.Axes):
 
         Kwargs:
             Keyword arguments to be used when drawing the feature. This allows
-            standard matplotlib control over aspects such as 'facecolor',
+            standard Matplotlib control over aspects such as 'facecolor',
             'alpha', etc.
 
         Returns:
@@ -1031,7 +1031,7 @@ class GeoAxes(matplotlib.axes.Axes):
         Parameters
         ----------
 
-        transform : :class:`~cartopy.crs.Projection` or matplotlib transform
+        transform : :class:`~cartopy.crs.Projection` or Matplotlib transform
             The coordinate system in which the given image is rectangular.
         regrid_shape : int or pair of ints
             The shape of the desired image if it needs to be transformed.
@@ -1407,7 +1407,7 @@ class GeoAxes(matplotlib.axes.Axes):
         A temporary, modified duplicate of
         :func:`~matplotlib.pyplot.pcolormesh'.
 
-        This function contains a workaround for a matplotlib issue
+        This function contains a workaround for a Matplotlib issue
         and will be removed once the issue has been resolved.
         https://github.com/matplotlib/matplotlib/pull/1314
 
@@ -1618,7 +1618,7 @@ class GeoAxes(matplotlib.axes.Axes):
 
         Extra Kwargs:
 
-        * transform: :class:`cartopy.crs.Projection` or matplotlib transform
+        * transform: :class:`cartopy.crs.Projection` or Matplotlib transform
             The coordinate system in which the vectors are defined.
 
         * regrid_shape: int or 2-tuple of ints
@@ -1689,7 +1689,7 @@ class GeoAxes(matplotlib.axes.Axes):
 
         Extra Kwargs:
 
-        * transform: :class:`cartopy.crs.Projection` or matplotlib transform
+        * transform: :class:`cartopy.crs.Projection` or Matplotlib transform
             The coordinate system in which the vectors are defined.
 
         * regrid_shape: int or 2-tuple of ints
@@ -1760,7 +1760,7 @@ class GeoAxes(matplotlib.axes.Axes):
 
         Extra Kwargs:
 
-        * transform: :class:`cartopy.crs.Projection` or matplotlib transform
+        * transform: :class:`cartopy.crs.Projection` or Matplotlib transform
             The coordinate system in which the vector field is defined.
 
         See :func:`matplotlib.pyplot.streamplot` for details on arguments

--- a/lib/cartopy/tests/mpl/__init__.py
+++ b/lib/cartopy/tests/mpl/__init__.py
@@ -41,7 +41,7 @@ MPL_VERSION = distutils.version.LooseVersion(mpl.__version__)
 
 class ImageTesting(object):
     """
-    Provides a convenient class for running visual matplotlib tests.
+    Provides a convenient class for running visual Matplotlib tests.
 
     In general, this class should be used as a decorator to a test function
     which generates one (or more) figures.

--- a/setup.py
+++ b/setup.py
@@ -88,11 +88,13 @@ def find_package_tree(root_path, root_package):
     for (dir_path, dir_names, _) in os.walk(convert_path(root_path)):
         # Prune dir_names *in-place* to prevent unwanted directory recursion
         for dir_name in list(dir_names):
-            if not os.path.isfile(os.path.join(dir_path, dir_name, '__init__.py')):
+            if not os.path.isfile(os.path.join(dir_path, dir_name,
+                                               '__init__.py')):
                 dir_names.remove(dir_name)
         if dir_names:
             prefix = dir_path.split(os.path.sep)[root_count:]
-            packages.extend(['.'.join([root_package] + prefix + [dir_name]) for dir_name in dir_names])
+            packages.extend(['.'.join([root_package] + prefix + [dir_name])
+                             for dir_name in dir_names])
     return packages
 
 
@@ -352,10 +354,12 @@ setup(
     url='http://scitools.org.uk/cartopy/docs/latest/',
     download_url='https://github.com/SciTools/cartopy',
     author='UK Met Office',
-    description='A cartographic python library with matplotlib support for visualisation',
+    description='A cartographic python library with Matplotlib support for '
+                'visualisation',
     long_description=description,
-    license = "LGPLv3",
-    keywords = "cartography map transform projection proj.4 geos shapely shapefile",
+    license="LGPLv3",
+    keywords="cartography map transform projection proj.4 geos shapely "
+             "shapefile",
 
     install_requires=install_requires,
     extras_require=extras_require,
@@ -363,20 +367,22 @@ setup(
 
     packages=find_package_tree('lib/cartopy', 'cartopy'),
     package_dir={'': 'lib'},
-    package_data={'cartopy': list(file_walk_relative('lib/cartopy/tests/mpl/baseline_images/',
-                                                     remove='lib/cartopy/')) +\
-                             list(file_walk_relative('lib/cartopy/data/raster',
-                                                     remove='lib/cartopy/')) +\
-                             list(file_walk_relative('lib/cartopy/data/netcdf',
-                                                     remove='lib/cartopy/')) +\
-                             list(file_walk_relative('lib/cartopy/data/wmts',
-                                                     remove='lib/cartopy/')) +\
-                             list(file_walk_relative('lib/cartopy/data/shapefiles/natural_earth',
-                                                     remove='lib/cartopy/')) +\
-                             list(file_walk_relative('lib/cartopy/data/shapefiles/gshhs',
-                                                     remove='lib/cartopy/')) +\
-                             ['io/srtm.npz']
-                 },
+    package_data={'cartopy': list(file_walk_relative('lib/cartopy/tests/'
+                                                     'mpl/baseline_images/',
+                                                     remove='lib/cartopy/')) +
+                  list(file_walk_relative('lib/cartopy/data/raster',
+                                          remove='lib/cartopy/')) +
+                  list(file_walk_relative('lib/cartopy/data/netcdf',
+                                          remove='lib/cartopy/')) +
+                  list(file_walk_relative('lib/cartopy/data/wmts',
+                                          remove='lib/cartopy/')) +
+                  list(file_walk_relative('lib/cartopy/data/'
+                                          'shapefiles/natural_earth',
+                                          remove='lib/cartopy/')) +
+                  list(file_walk_relative('lib/cartopy/data/'
+                                          'shapefiles/gshhs',
+                                          remove='lib/cartopy/')) +
+                  ['io/srtm.npz']},
 
 
     # requires proj4 headers
@@ -399,8 +405,10 @@ setup(
             library_dirs=[library_dir] + proj_library_dirs,
             **extra_extension_args
         ),
-	# Requires proj4 v4.9
-	Extension('cartopy.geodesic._geodesic', ['lib/cartopy/geodesic/_geodesic.pyx'],
+        # Requires proj4 v4.9
+        Extension(
+            'cartopy.geodesic._geodesic',
+            ['lib/cartopy/geodesic/_geodesic.pyx'],
             include_dirs=[include_dir, np.get_include()] + proj_includes,
             libraries=proj_libraries,
             library_dirs=[library_dir] + proj_library_dirs,
@@ -411,7 +419,8 @@ setup(
     cmdclass={'build_ext': build_ext},
     classifiers=[
             'Development Status :: 4 - Beta',
-            'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
+            'License :: OSI Approved :: GNU Lesser General Public License v3 '
+            'or later (LGPLv3+)',
             'Operating System :: MacOS :: MacOS X',
             'Operating System :: Microsoft :: Windows',
             'Operating System :: POSIX',


### PR DESCRIPTION
This is the same as https://github.com/SciTools/cartopy/pull/962/files except that there shouldn't be any merge conflicts, and I don't have to rebase it.  Which is good because I was getting in a proper pickle.

This PR simply adds a couple of examples of savefig into the intro to matplotlib docs, and also adds a link to the mpl savefig function in the text following the example.

Closes https://github.com/SciTools/cartopy/issues/922