### PR TITLE
Fix for 'linestring being readded' bug

### DIFF
--- a/lib/cartopy/tests/test_polygon.py
+++ b/lib/cartopy/tests/test_polygon.py
@@ -193,6 +193,27 @@ class TestMisc(object):
         assert 81330 < area < 81340, \
             'Got area {}, expecting ~81336'.format(area)
 
+    def test_same_points_on_boundary_1(self):
+        source = ccrs.PlateCarree()
+        target = ccrs.PlateCarree(central_longitude=180)
+
+        geom = sgeom.Polygon([(-20, -20), (20, -20), (20, 20), (-20, 20)],
+                             [[(-10, 0), (0, 20), (10, 0), (0, -20)]])
+        projected = target.project_geometry(geom, source)
+
+        assert abs(1200 - projected.area) < 1e-5
+
+    def test_same_points_on_boundary_2(self):
+        source = ccrs.PlateCarree()
+        target = ccrs.PlateCarree(central_longitude=180)
+
+        geom = sgeom.Polygon([(-20, -20), (20, -20), (20, 20), (-20, 20)],
+                             [[(0, 0), (-10, 10), (0, 20), (10, 10)],
+                              [(0, 0), (10, -10), (0, -20), (-10, -10)]])
+        projected = target.project_geometry(geom, source)
+
+        assert abs(1200 - projected.area) < 1e-5
+
 
 class TestQuality(object):
     def setup_class(self):


### PR DESCRIPTION
When attaching lines to the boundary, the points where the lines meet the boundary, plus the boundary points, are put into a list and sorted by their distance along the boundary. If two lines happen to have an end-point at the same location then there is a risk that the end-points of the two lines will be interleaved, which causes the algorithm to fail later on with the 'linestring being re-added' error. This PR adds extra elements to the key used for the sort to prevent this happening.