### PR TITLE
Enable automatic scaling for NaturalEarthFeatures

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -90,6 +90,10 @@ Features
 * Mahé Perrette and Ryan May collaborated to improve the
   :class:`~cartopy.crs.Stereographic` projection. (:pull:`929`)
 
+* The :class:`cartopy.feature.NaturalEarthFeature` class now allows the
+`scale` argument to be set to `'auto'`. This will automatically choose the
+appropriate feature scale from the GeoAxes extent. This can also be used
+interactively while panning and zooming in a figure.
 
 
 What's New in cartopy 0.15

--- a/lib/cartopy/feature.py
+++ b/lib/cartopy/feature.py
@@ -118,7 +118,7 @@ class Feature(six.with_metaclass(ABCMeta)):
             extent_geom = sgeom.box(extent[0], extent[2],
                                     extent[1], extent[3])
             return (geom for geom in self.geometries() if
-                    extent_geom.intersects(geom))
+                    geom is not None and extent_geom.intersects(geom))
         else:
             return self.geometries()
 
@@ -205,7 +205,7 @@ class NaturalEarthFeature(Feature):
             geometries = _NATURAL_EARTH_GEOM_CACHE[key]
 
         return iter(geometries)
-    
+
     def intersecting_geometries(self, extent):
         """
         Returns an iterator of shapely geometries that intersect with
@@ -224,7 +224,7 @@ class NaturalEarthFeature(Feature):
             extent_geom = sgeom.box(extent[0], extent[2],
                                     extent[1], extent[3])
             return (geom for geom in self.geometries() if
-                    extent_geom.intersects(geom))
+                    geom is not None and extent_geom.intersects(geom))
         else:
             return self.geometries()
 

--- a/lib/cartopy/feature.py
+++ b/lib/cartopy/feature.py
@@ -169,7 +169,8 @@ class NaturalEarthFeature(Feature):
         scale
             The dataset scale, i.e. one of '10m', '50m', or '110m'.
             Corresponding to 1:10,000,000, 1:50,000,000, and 1:110,000,000
-            respectively. If set to 'auto', autoscaling is used.
+            respectively. If set to 'auto', the scale will be automatically
+            set based on the extent of the axes.
 
         Other Parameters
         ----------------
@@ -249,7 +250,7 @@ class NaturalEarthFeature(Feature):
         expressed in CRS of the feature (PlateCarree()).
 
         """
-        # Default to 1:10,000,000 scale
+        # Default to 1:110,000,000 scale
         scale = '110m'
 
         if extent is not None:
@@ -447,13 +448,13 @@ LAKES = NaturalEarthFeature('physical', 'lakes', '110m',
 
 LAND = NaturalEarthFeature('physical', 'land', '110m',
                            edgecolor='face',
-                           facecolor=COLORS['land'])
+                           facecolor=COLORS['land'], zorder=-1)
 """Small scale (1:110m) land polygons, including major islands."""
 
 
 OCEAN = NaturalEarthFeature('physical', 'ocean', '110m',
                             edgecolor='face',
-                            facecolor=COLORS['water'])
+                            facecolor=COLORS['water'], zorder=-1)
 """Small scale (1:110m) ocean polygons."""
 
 

--- a/lib/cartopy/feature.py
+++ b/lib/cartopy/feature.py
@@ -185,7 +185,7 @@ class NaturalEarthFeature(Feature):
         self.scale = scale
 
         # Use autoscaling if scale == 'a', 'auto' or 'autoscale'
-        if scale.lower() in ('a', 'auto', 'autoscale'):
+        if scale == 'auto':
             self.autoscale = True
         else:
             self.autoscale = False
@@ -213,13 +213,10 @@ class NaturalEarthFeature(Feature):
         the given extent.
         The extent is assumed to be in the CRS of the feature.
         If extent is None, the method returns all geometries for this dataset.
-
         """
 
         if self.autoscale:
             self.scale = self._scale_from_extent(extent)
-        else:
-            self.scale = self.scale
 
         if extent is not None:
             extent_geom = sgeom.box(extent[0], extent[2],

--- a/lib/cartopy/feature.py
+++ b/lib/cartopy/feature.py
@@ -118,7 +118,7 @@ class Feature(six.with_metaclass(ABCMeta)):
             extent_geom = sgeom.box(extent[0], extent[2],
                                     extent[1], extent[3])
             return (geom for geom in self.geometries() if
-                    geom is not None and extent_geom.intersects(geom))
+                    extent_geom.intersects(geom))
         else:
             return self.geometries()
 
@@ -169,7 +169,7 @@ class NaturalEarthFeature(Feature):
         scale
             The dataset scale, i.e. one of '10m', '50m', or '110m'.
             Corresponding to 1:10,000,000, 1:50,000,000, and 1:110,000,000
-            respectively.
+            respectively. If set to 'auto', autoscaling is used.
 
         Other Parameters
         ----------------
@@ -183,7 +183,17 @@ class NaturalEarthFeature(Feature):
         self.name = name
         self.scale = scale
 
+        # Use autoscaling if scale == 'a', 'auto' or 'autoscale'
+        if scale.lower() in ('a', 'auto', 'autoscale'):
+            self.autoscale = True
+        else:
+            self.autoscale = False
+
     def geometries(self):
+        """
+        Returns an iterator of (shapely) geometries for this feature.
+
+        """
         key = (self.name, self.category, self.scale)
         if key not in _NATURAL_EARTH_GEOM_CACHE:
             path = shapereader.natural_earth(resolution=self.scale,
@@ -195,6 +205,28 @@ class NaturalEarthFeature(Feature):
             geometries = _NATURAL_EARTH_GEOM_CACHE[key]
 
         return iter(geometries)
+    
+    def intersecting_geometries(self, extent):
+        """
+        Returns an iterator of shapely geometries that intersect with
+        the given extent.
+        The extent is assumed to be in the CRS of the feature.
+        If extent is None, the method returns all geometries for this dataset.
+
+        """
+
+        if self.autoscale:
+            self.scale = self._scale_from_extent(extent)
+        else:
+            self.scale = self.scale
+
+        if extent is not None:
+            extent_geom = sgeom.box(extent[0], extent[2],
+                                    extent[1], extent[3])
+            return (geom for geom in self.geometries() if
+                    extent_geom.intersects(geom))
+        else:
+            return self.geometries()
 
     def with_scale(self, new_scale):
         """
@@ -210,6 +242,32 @@ class NaturalEarthFeature(Feature):
         """
         return NaturalEarthFeature(self.category, self.name, new_scale,
                                    **self.kwargs)
+
+    def _scale_from_extent(self, extent):
+        """
+        Returns the appropriate scale (e.g. '50m') for the given extent
+        expressed in CRS of the feature (PlateCarree()).
+
+        """
+        # Default to 1:10,000,000 scale
+        scale = '110m'
+
+        if extent is not None:
+            # Upper limit on extent in degrees.
+            scale_limits = (('110m', 50.0),
+                            ('50m', 15.0),
+                            ('10m', 0.0))
+
+            width = abs(extent[1] - extent[0])
+            height = abs(extent[3] - extent[2])
+            min_extent = min(width, height)
+
+            if min_extent != 0:
+                for scale, limit in scale_limits:
+                    if min_extent > limit:
+                        break
+
+        return scale
 
 
 class GSHHSFeature(Feature):
@@ -389,13 +447,13 @@ LAKES = NaturalEarthFeature('physical', 'lakes', '110m',
 
 LAND = NaturalEarthFeature('physical', 'land', '110m',
                            edgecolor='face',
-                           facecolor=COLORS['land'], zorder=-1)
+                           facecolor=COLORS['land'])
 """Small scale (1:110m) land polygons, including major islands."""
 
 
 OCEAN = NaturalEarthFeature('physical', 'ocean', '110m',
                             edgecolor='face',
-                            facecolor=COLORS['water'], zorder=-1)
+                            facecolor=COLORS['water'])
 """Small scale (1:110m) ocean polygons."""
 
 

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -426,6 +426,7 @@ class GeoAxes(matplotlib.axes.Axes):
         resolution
             A named resolution to use from the Natural Earth
             dataset. Currently can be one of "110m", "50m", and "10m".
+            If set to 'auto', autoscaling is used.
 
         """
         kwargs['edgecolor'] = color

--- a/lib/cartopy/tests/test_features.py
+++ b/lib/cartopy/tests/test_features.py
@@ -46,11 +46,11 @@ class TestFeatures(object):
                                                    'a')
 
         assert autoscale_borders.scale == 'autoscale'
-        assert autoscale_borders.autoscale is True
+        assert autoscale_borders.autoscale
         assert a_coastline.scale == 'a'
-        assert a_coastline.autoscale is True
+        assert a_coastline.autoscale
         assert auto_land.scale == 'auto'
-        assert auto_land.autoscale is True
+        assert auto_land.autoscale
 
     def test_autoscale_default(self):
         # Check that autoscaling is not used by default.
@@ -68,11 +68,11 @@ class TestFeatures(object):
         assert cfeature.LAKES.scale == '110m'
         assert not cfeature.LAKES.autoscale
         assert ten_borders.scale == '10m'
-        assert ten_borders.autoscale is False
+        assert not ten_borders.autoscale
         assert fifty_coastline.scale == '50m'
-        assert fifty_coastline.autoscale is False
+        assert not fifty_coastline.autoscale
         assert hundredten_land.scale == '110m'
-        assert hundredten_land.autoscale is False
+        assert not hundredten_land.autoscale
 
     def test_scale_from_extent(self):
         # Check that _scale_from_extent produces the appropriate

--- a/lib/cartopy/tests/test_features.py
+++ b/lib/cartopy/tests/test_features.py
@@ -17,10 +17,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-import numpy as np
-import matplotlib.pyplot as plt
 import cartopy.feature as cfeature
-import cartopy.crs as ccrs
 
 small_extent = (-6, -8, 56, 59)
 medium_extent = (-20, 20, 20, 60)
@@ -42,18 +39,18 @@ class TestFeatures(object):
         # Check that autoscale variants can be passed as the scale
         # argument
         autoscale_borders = cfeature.NaturalEarthFeature(
-           'cultural', 'admin_0_boundary_lines_land',
-           'autoscale')
+                                   'cultural', 'admin_0_boundary_lines_land',
+                                   'autoscale')
 
         a_coastline = cfeature.NaturalEarthFeature('physical', 'coastline',
-                                             'a')
+                                                   'a')
 
         assert autoscale_borders.scale == 'autoscale'
-        assert autoscale_borders.autoscale == True
+        assert autoscale_borders.autoscale is True
         assert a_coastline.scale == 'a'
-        assert a_coastline.autoscale == True
+        assert a_coastline.autoscale is True
         assert auto_land.scale == 'auto'
-        assert auto_land.autoscale == True
+        assert auto_land.autoscale is True
 
     def test_autoscale_default(self):
         # Check that autoscaling is not used by default.
@@ -69,13 +66,13 @@ class TestFeatures(object):
                                                        '110m')
 
         assert cfeature.LAKES.scale == '110m'
-        assert cfeature.LAKES.autoscale == False
+        assert not cfeature.LAKES.autoscale
         assert ten_borders.scale == '10m'
-        assert ten_borders.autoscale == False
+        assert ten_borders.autoscale is False
         assert fifty_coastline.scale == '50m'
-        assert fifty_coastline.autoscale == False
+        assert fifty_coastline.autoscale is False
         assert hundredten_land.scale == '110m'
-        assert hundredten_land.autoscale == False
+        assert hundredten_land.autoscale is False
 
     def test_scale_from_extent(self):
         # Check that _scale_from_extent produces the appropriate

--- a/lib/cartopy/tests/test_features.py
+++ b/lib/cartopy/tests/test_features.py
@@ -17,14 +17,91 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+import numpy as np
+import matplotlib.pyplot as plt
 import cartopy.feature as cfeature
+import cartopy.crs as ccrs
 
+small_extent = (-6, -8, 56, 59)
+medium_extent = (-20, 20, 20, 60)
+large_extent = (-40, 40, 0, 80)
+
+auto_land = cfeature.NaturalEarthFeature('physical', 'land', 'auto')
 
 class TestFeatures(object):
     def test_change_scale(self):
-        # Check that features can easily be retrieved with a different scale.
+        # Check that features can easily be retrieved with a different
+        # scale.
         new_lakes = cfeature.LAKES.with_scale('10m')
         assert new_lakes.scale == '10m'
         assert new_lakes.kwargs == cfeature.LAKES.kwargs
         assert new_lakes.category == cfeature.LAKES.category
         assert new_lakes.name == cfeature.LAKES.name
+
+    def test_autoscale_keyword(self):
+        # Check that autoscale variants can be passed as the scale
+        # argument
+        autoscale_borders = cfeature.NaturalEarthFeature(
+           'cultural', 'admin_0_boundary_lines_land',
+           'autoscale')
+
+        a_coastline = cfeature.NaturalEarthFeature('physical', 'coastline',
+                                             'a')
+
+        assert autoscale_borders.scale == 'autoscale'
+        assert autoscale_borders.autoscale == True
+        assert a_coastline.scale == 'a'
+        assert a_coastline.autoscale == True
+        assert auto_land.scale == 'auto'
+        assert auto_land.autoscale == True
+
+    def test_autoscale_default(self):
+        # Check that autoscaling is not used by default.
+        ten_borders = cfeature.NaturalEarthFeature(
+           'cultural', 'admin_0_boundary_lines_land',
+           '10m')
+
+        fifty_coastline = cfeature.NaturalEarthFeature('physical',
+                                                       'coastline',
+                                                       '50m')
+
+        hundredten_land = cfeature.NaturalEarthFeature('physical', 'land',
+                                                       '110m')
+
+        assert cfeature.LAKES.scale == '110m'
+        assert cfeature.LAKES.autoscale == False
+        assert ten_borders.scale == '10m'
+        assert ten_borders.autoscale == False
+        assert fifty_coastline.scale == '50m'
+        assert fifty_coastline.autoscale == False
+        assert hundredten_land.scale == '110m'
+        assert hundredten_land.autoscale == False
+
+    def test_scale_from_extent(self):
+        # Check that _scale_from_extent produces the appropriate
+        # scales.
+        small_scale = auto_land._scale_from_extent(small_extent)
+        medium_scale = auto_land._scale_from_extent(medium_extent)
+        large_scale = auto_land._scale_from_extent(large_extent)
+        assert auto_land.scale == 'auto'
+        assert small_scale == '10m'
+        assert medium_scale == '50m'
+        assert large_scale == '110m'
+
+    def test_intersecting_geometries_small(self):
+        # Check that intersecting_geometries will set the scale to
+        # '10m' when the extent is small and autoscale is True.
+        auto_land.intersecting_geometries(small_extent)
+        assert auto_land.scale == '10m'
+
+    def test_intersecting_geometries_medium(self):
+        # Check that intersecting_geometries will set the scale to
+        # '50m' when the extent is medium and autoscale is True.
+        auto_land.intersecting_geometries(medium_extent)
+        assert auto_land.scale == '50m'
+
+    def test_intersecting_geometries_large(self):
+        # Check that intersecting_geometries will set the scale to
+        # '110m' when the extent is large and autoscale is True.
+        auto_land.intersecting_geometries(large_extent)
+        assert auto_land.scale == '110m'


### PR DESCRIPTION
@kaedonkers and I added the ability to specify the scale in a NaturalEarthFeature as 'auto'. When this option is chosen the scale of the feature will automatically match the extent of the map. We've included some updates to the tests and additions to the documentation.

Some future developments might include making autoscaling the default and giving cartopy the ability to check what scales are available. This might allow for simple and more extensive tests as well as a more robust feature.

Closes #265