### PR TITLE
Read shapefiles containing geometries with Z coordinate.

### DIFF
--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -112,8 +112,11 @@ def _make_geometry(geometry_factory, shape):
 # The mapping from shapefile shapeType values to geometry creation functions.
 GEOMETRY_FACTORIES = {
     shapefile.POINT: _create_point,
+    shapefile.POINTZ: _create_point,
     shapefile.POLYLINE: _create_polyline,
+    shapefile.POLYLINEZ: _create_polyline,
     shapefile.POLYGON: _create_polygon,
+    shapefile.POLYGONZ: _create_polygon,
 }
 
 


### PR DESCRIPTION
Add support for reading shapes with the third (Z) dimension namely
POINTZ, POLYLINEZ and POLYGONZ.

Replaces #958.

Long-term, I'm not convinced some of the code will remain in shapereader as we move towards more powerful tools (geopandas, fiona, etc.), but there is no harm it being added at this point.