### PR TITLE
Enable doc building on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,143 @@
+# Circle CI configuration file
+# https://circleci.com/docs/
+
+version: 2
+
+
+###########################################
+# Define some common steps as YAML anchors.
+#
+
+apt-run:  &apt-install
+  name: Install apt packages
+  command: |
+    apt-get -qq update
+    apt-get install -y \
+      gcc \
+      g++ \
+      make
+
+env-run:  &env-setup
+  # Create the basic testing environment
+  # Mixing conda-forge and defaults in root is a recipe for trouble, so create
+  # a separate environment.
+  name: Setup conda environment
+  command: |
+    conda config --set always_yes yes --set changeps1 no --set show_channel_urls yes
+    conda create -n test-environment python=$PYTHON_VERSION
+    conda config --add channels conda-forge
+
+deps-run: &deps-install
+  name: Install Python dependencies
+  command: |
+    source activate test-environment
+    conda install --quiet \
+        numpy \
+        matplotlib \
+        scipy \
+        cython \
+        pillow \
+        proj4 \
+        pyshp \
+        shapely \
+        six \
+        requests \
+        pyepsg \
+        owslib \
+        $EXTRA_PACKAGES
+    conda install --quiet --file docs/doc-requirements.txt
+    conda list
+
+cp-run: &cp-install
+  name: Install Cartopy
+  command: |
+    source activate test-environment
+    pip install -ve .
+
+doc-run: &doc-build
+  name: Build documentation
+  command: |
+    source activate test-environment
+    make html
+  working_directory: docs
+
+doc-bundle-run: &doc-bundle
+  name: Bundle sphinx-gallery documentation artifacts
+  command: |
+    tar cf docs/build/sphinx-gallery-files.tar.gz \
+        docs/source/api \
+        docs/source/cartopy_outline.rst \
+        docs/source/gallery
+  when: always
+
+
+##########################################
+# Here is where the real jobs are defined.
+#
+
+jobs:
+  docs-python3:
+    docker:
+      - image: continuumio/miniconda3:latest
+    steps:
+      - checkout
+
+      - run: *apt-install
+      - run:
+          <<: *env-setup
+          environment:
+            PYTHON_VERSION: 3
+      - run: *deps-install
+      - run: *cp-install
+
+      - run: *doc-build
+
+      - run: *doc-bundle
+      - store_artifacts:
+          path: docs/build/sphinx-gallery-files.tar.gz
+
+      - store_artifacts:
+          path: docs/build/html
+
+      - run:
+          name: "Built documentation is available at:"
+          command: echo "${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/docs/build/html/index.html"
+
+  docs-python2:
+    docker:
+      - image: continuumio/miniconda:latest
+    steps:
+      - checkout
+
+      - run: *apt-install
+      - run:
+          <<: *env-setup
+          environment:
+            PYTHON_VERSION: 2
+      - run: *deps-install
+      - run: *cp-install
+
+      - run: *doc-build
+
+      - run: *doc-bundle
+      - store_artifacts:
+          path: docs/build/sphinx-gallery-files.tar.gz
+
+      - store_artifacts:
+          path: docs/build/html
+
+      - run:
+          name: "Built documentation is available at:"
+          command: echo "${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/docs/build/html/index.html"
+
+
+#########################################
+# Defining workflows gets us parallelism.
+#
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - docs-python3
+      - docs-python2

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,6 +1,7 @@
 sphinx
 netCDF4
 iris
+iris-sample-data
 cf_units
 sphinx-gallery
 beautifulsoup4

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,3 +1,4 @@
+sphinx
 netCDF4
 iris
 cf_units

--- a/lib/cartopy/examples/lines_and_polygons/effects_of_the_ellipse.py
+++ b/lib/cartopy/examples/lines_and_polygons/effects_of_the_ellipse.py
@@ -82,8 +82,8 @@ def main():
 
     # Using these differently referenced geometries, assume that they are
     # both referenced to WGS84.
-    ax.add_geometries(wgs84_geoms, wgs84, edgecolor='white', color='none')
-    ax.add_geometries(sphere_geoms, wgs84, edgecolor='gray', color='none')
+    ax.add_geometries(wgs84_geoms, wgs84, edgecolor='white', facecolor='none')
+    ax.add_geometries(sphere_geoms, wgs84, edgecolor='gray', facecolor='none')
 
     # Create a legend for the coastlines.
     legend_artists = [Line([0], [0], color=color, linewidth=3)
@@ -106,7 +106,7 @@ def main():
     sub_ax.add_feature(cfeature.LAND)
     sub_ax.coastlines()
     extent_box = sgeom.box(extent[0], extent[2], extent[1], extent[3])
-    sub_ax.add_geometries([extent_box], ccrs.PlateCarree(), color='none',
+    sub_ax.add_geometries([extent_box], ccrs.PlateCarree(), facecolor='none',
                           edgecolor='blue', linewidth=2)
 
     plt.show()


### PR DESCRIPTION
Enable doc building on CircleCI using a method similar to Matplotlib. It builds on both Python 2 and 3. Warnings are not fatal at the moment, but could be made so (probably after they're fixed though.) The last step in the build prints out a link that you can use to view the rendered docs. Here's the link for [Python 2](https://circleci.com/gh/QuLogic/cartopy/18/artifacts/0//root/project/docs/build/html/index.html) and for [Python 3](https://circleci.com/gh/QuLogic/cartopy/19/artifacts/0//root/project/docs/build/html/index.html). Someone with admin privileges will have to enable CircleCI for this project before this is merged.

I already see a few bugs:
* The [Interrupted Goode Homolosine plot](https://19-21996491-gh.circle-artifacts.com/0/root/project/docs/build/html/crs/projections.html#interruptedgoodehomolosine) seems to have only one gridline.
* There are some extra `REMOVE` pages in the gallery. I'm not sure if @choldgraf figured out how to get rid of the `__init__.py` files when rendered. Maybe we can get rid of them now that we have CircleCI testing examples instead.
* The [circular boundary example](https://19-21996491-gh.circle-artifacts.com/0/root/project/docs/build/html/gallery/lines_and_polygons/always_circular_stereo.html) is missing the features (both 2 and 3).
* ~~"The effect of badly referencing an ellipse" works on [Python 2](https://18-21996491-gh.circle-artifacts.com/0/root/project/docs/build/html/gallery/lines_and_polygons/effects_of_the_ellipse.html), but is missing the features on [Python 3](https://19-21996491-gh.circle-artifacts.com/0/root/project/docs/build/html/gallery/lines_and_polygons/effects_of_the_ellipse.html).~~ FIXED