### PR TITLE
Creating a Fiona Reader for shapefiles

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -40,14 +40,14 @@ These external packages are required to install Cartopy or gain access to
 significant Cartopy functionality.
 
 Many of these packages are available in Linux package managers
-such as aptitude and yum. For example, it may be possible to install 
+such as aptitude and yum. For example, it may be possible to install
 Numpy using::
 
     apt-get install python-numpy
 
-If you are installing dependencies with a package manager on Linux, 
-you may need to install the development packages (look for a "-dev" 
-suffix) in addition to the core packages.  
+If you are installing dependencies with a package manager on Linux,
+you may need to install the development packages (look for a "-dev"
+suffix) in addition to the core packages.
 
 Many of these dependencies are built as part of Cartopy's conda distribution.
 The recipes for these can be found at https://github.com/conda-forge/feedstocks.
@@ -106,6 +106,9 @@ additional Cartopy functionality.
      Python package for client programming with Open Geospatial Consortium
      (OGC) web service.  Gives access to cartopy ogc clients.
 
+**Fiona** 1.0 or later (https://github.com/Toblerity/Fiona)
+    Python package for reading shapefiles faster than the default (pyshp).
+
 
 Testing Dependencies
 ~~~~~~~~~~~~~~~~~~~~
@@ -118,7 +121,5 @@ These packages are required for the full Cartopy test suite to run.
 **pytest** 3.0.0 or later (https://docs.pytest.org/en/latest/)
     Python package for software testing.
 
-**pep8** 1.3.3 or later (https://pypi.python.org/pypi/pep8) 
+**pep8** 1.3.3 or later (https://pypi.python.org/pypi/pep8)
     Python package for software testing.
-
-

--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -10,7 +10,7 @@ cartopy was born. From such simple beginnings cartopy has grown into a community
 package with exciting scientific geospatial visualisation capabilities and a simple, pythonic
 interface.
 
-The following people have dedicated their time and effort to deliver 
+The following people have dedicated their time and effort to deliver
 new functionality, fix bugs, review code and provide support for, cartopy, without whom
 the package wouldn't be as rich or diverse as it is today:
 
@@ -37,7 +37,7 @@ the package wouldn't be as rich or diverse as it is today:
  * Crispian Batstone
  * Daryl Herzmann
  * Robert Redl
-
+ * Greg Lucas
 
 Thank you!
 
@@ -45,4 +45,3 @@ Thank you!
 .. note::
 
     If you have been excluded from the list, please add yourself and submit a pull request.
-

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -17,7 +17,7 @@ Features
 
 * Ryan May improved the formulation of the boundary ellipse for the
   :class:`~cartopy.crs.Geostationary` projection and added the
-  ``sweep_angle_axis`` keyword argument. (:pull:`890`, :pull:`897`) 
+  ``sweep_angle_axis`` keyword argument. (:pull:`890`, :pull:`897`)
 
 * Elliott Sales de Andrade made a number of micro-optimisations to the
   Matplotlib interface, fixed a number of documentation issues with
@@ -90,7 +90,8 @@ Features
 * Mahé Perrette and Ryan May collaborated to improve the
   :class:`~cartopy.crs.Stereographic` projection. (:pull:`929`)
 
-
+* If Fiona is installed on a user's system, this will now be the default
+  shapefile reader, adding significant speed improvements. (:pull:`1000`)
 
 What's New in cartopy 0.15
 ==========================

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -605,8 +605,10 @@ class Projection(six.with_metaclass(ABCMeta, CRS)):
         if self == src_crs:
             x = vertices[:, 0]
             y = vertices[:, 1]
-            x_limits = self.x_limits
-            y_limits = self.y_limits
+            # Extend the limits a tiny amount to allow for precision mistakes
+            epsilon = 1.e-10
+            x_limits = (self.x_limits[0] - epsilon, self.x_limits[1] + epsilon)
+            y_limits = (self.y_limits[0] - epsilon, self.y_limits[1] + epsilon)
             if (x.min() >= x_limits[0] and x.max() <= x_limits[1] and
                     y.min() >= y_limits[0] and y.max() <= y_limits[1]):
                 return_value = vertices


### PR DESCRIPTION
This request fixes an issue with plotting 10m Oceans seen in #403. The issue is that the 10m and 110m ocean shapefiles go beyond the (-180, 180) limits within the Projection quick transform by ~1.e-12, so I added in an epsilon value of 1.e-10 to allow the quick transform to proceed as long as it is close. The 50m Oceans don't have this issue.

As mentioned in #403, even with this fix the 10m Oceans are still really slow because of making shapes initially. In #250  there is a request for using Fiona to read in shapefiles. I have essentially implemented the Geopandas Fiona reader to produce the same output as the current shapereader to try and provide continuity whether you have Fiona or not. There are now two readers, a BasicReader and FionaReader, that is set based on whether the Fiona import worked or not. I'm not sure this is the best way to go about this, so I would welcome feedback.

With these two changes I can load the 10m Ocean shapefile and plot them in several seconds.
  