### PR TITLE
Numpy docs style fixes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -387,9 +387,9 @@ autoclass_content = 'both'
 # Napoleon settings
 # napoleon_google_docstring = True
 napoleon_numpy_docstring = True
-napoleon_include_init_with_doc = True
+napoleon_include_init_with_doc = False
 napoleon_include_private_with_doc = False
-napoleon_include_special_with_doc = True
+napoleon_include_special_with_doc = False
 napoleon_use_admonition_for_examples = False
 napoleon_use_admonition_for_notes = False
 napoleon_use_admonition_for_references = False

--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -326,10 +326,11 @@ cdef class CRS:
             to transform.  May be 1 or 2 dimensional.
         y
             the y coordinates (array), in ``src_crs`` coordinates,
-            to transform
+            to transform.  Its shape must match that of x.
         z: optional
             the z coordinates (array), in ``src_crs`` coordinates, to
             transform.  Defaults to None.
+            If supplied, its shape must match that of x.
 
         Returns
         -------
@@ -405,15 +406,18 @@ cdef class CRS:
             The :class:`CRS.Projection` that represents the coordinate system
             the vectors are defined in.
         x
+            The x coordinates of the vectors in the source projection.
         y
-            The x and y coordinates, in the source projection
-            coordinates, where the vector components are located.
-            May be 1 or 2 dimensional, but must have matching shapes.
+            The y coordinates of the vectors in the source projection.
         u
+            The grid-eastward components of the vectors.
         v
-            The grid eastward and grid northward components of the
-            vector field respectively. Their shape must match the shape
-            of the x and y coordinates.
+            The grid-northward components of the vectors.
+
+        Note
+        ----
+            x, y, u and v may be 1 or 2 dimensional, but must all have matching
+            shapes.
 
         Returns
         -------

--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -404,11 +404,13 @@ cdef class CRS:
         src_proj
             The :class:`CRS.Projection` that represents the coordinate system
             the vectors are defined in.
-        x, y
+        x
+        y
             The x and y coordinates, in the source projection
             coordinates, where the vector components are located.
             May be 1 or 2 dimensional, but must have matching shapes.
-        u, v
+        u
+        v
             The grid eastward and grid northward components of the
             vector field respectively. Their shape must match the shape
             of the x and y coordinates.
@@ -417,8 +419,8 @@ cdef class CRS:
         -------
             ut, vt: The transformed vector components.
 
-        Notes
-        -----
+        Note
+        ----
            The algorithm used to transform vectors is an approximation
            rather than an exact transform, but the accuracy should be
            good enough for visualization purposes.

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1497,8 +1497,8 @@ class Robinson(_WarpedRectangularProjection):
         Needed because input NaNs can trigger a fatal error in the underlying
         implementation of the Robinson projection.
 
-        Notes
-        -----
+        Note
+        ----
             Although the original can in fact translate (nan, lat) into
             (nan, y-value), this patched version doesn't support that.
 
@@ -1517,8 +1517,8 @@ class Robinson(_WarpedRectangularProjection):
         Needed because input NaNs can trigger a fatal error in the underlying
         implementation of the Robinson projection.
 
-        Notes
-        -----
+        Note
+        ----
             Although the original can in fact translate (nan, lat) into
             (nan, y-value), this patched version doesn't support that.
             Instead, we invalidate any of the points that contain a NaN.

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -52,28 +52,26 @@ class RotatedGeodetic(CRS):
 
     Coordinates are measured in degrees.
 
+    The class uses proj4 to perform an ob_tran operation, using the
+    pole_longitude to set a lon_0 then performing two rotations based on
+    pole_latitude and central_rotated_longitude.
+    This is equivalent to setting the new pole to a location defined by
+    the pole_latitude and pole_longitude values in the GeogCRS defined by
+    globe, then rotating this new CRS about it's pole using the
+    central_rotated_longitude value.
+
     """
     def __init__(self, pole_longitude, pole_latitude,
                  central_rotated_longitude=0.0, globe=None):
         """
-        Create a RotatedGeodetic CRS.
-
-        The class uses proj4 to perform an ob_tran operation, using the
-        pole_longitude to set a lon_0 then performing two rotations based on
-        pole_latitude and central_rotated_longitude.
-        This is equivalent to setting the new pole to a location defined by
-        the pole_latitude and pole_longitude values in the GeogCRS defined by
-        globe, then rotating this new CRS about it's pole using the
-        central_rotated_longitude value.
-
         Parameters
         ----------
         pole_longitude
             Pole longitude position, in unrotated degrees.
         pole_latitude
             Pole latitude position, in unrotated degrees.
-        central_rotated_longitude
-            Longitude rotation about the new pole, in degrees.
+        central_rotated_longitude: optional
+            Longitude rotation about the new pole, in degrees.  Defaults to 0.
         globe: optional
             A :class:`cartopy.crs.Globe`.  Defaults to a "WGS84" datum.
 
@@ -161,8 +159,13 @@ class Projection(six.with_metaclass(ABCMeta, CRS)):
         src_crs: optional
             The source CRS.  Defaults to None.
 
-        If src_crs is None, the source CRS is assumed to be a geodetic
-        version of the target CRS.
+            If src_crs is None, the source CRS is assumed to be a geodetic
+            version of the target CRS.
+
+        Returns
+        -------
+        geometry
+            The projected result (a shapely geometry).
 
         """
         if src_crs is None:
@@ -590,8 +593,8 @@ class Projection(six.with_metaclass(ABCMeta, CRS)):
         Where possible, return a vertices array transformed to this CRS from
         the given vertices array of shape ``(n, 2)`` and the source CRS.
 
-        Notes
-        -----
+        Note
+        ----
             This method may return None to indicate that the vertices cannot
             be transformed quickly, and a more complex geometry transformation
             is required (see :meth:`cartopy.crs.Projection.project_geometry`).
@@ -1236,26 +1239,24 @@ class Miller(_RectangularProjection):
 
 class RotatedPole(_CylindricalProjection):
     """
-    Define a rotated latitude/longitude projected coordinate system
+    A rotated latitude/longitude projected coordinate system
     with cylindrical topology and projected distance.
 
     Coordinates are measured in projection metres.
+
+    The class uses proj4 to perform an ob_tran operation, using the
+    pole_longitude to set a lon_0 then performing two rotations based on
+    pole_latitude and central_rotated_longitude.
+    This is equivalent to setting the new pole to a location defined by
+    the pole_latitude and pole_longitude values in the GeogCRS defined by
+    globe, then rotating this new CRS about it's pole using the
+    central_rotated_longitude value.
 
     """
 
     def __init__(self, pole_longitude=0.0, pole_latitude=90.0,
                  central_rotated_longitude=0.0, globe=None):
         """
-        Create a RotatedPole CRS.
-
-        The class uses proj4 to perform an ob_tran operation, using the
-        pole_longitude to set a lon_0 then performing two rotations based on
-        pole_latitude and central_rotated_longitude.
-        This is equivalent to setting the new pole to a location defined by
-        the pole_latitude and pole_longitude values in the GeogCRS defined by
-        globe, then rotating this new CRS about it's pole using the
-        central_rotated_longitude value.
-
         Parameters
         ----------
         pole_longitude: optional
@@ -1716,7 +1717,7 @@ class AlbersEqualArea(Projection):
             The central longitude. Defaults to 0.
         central_latitude: optional
             The central latitude. Defaults to 0.
-        false_easting:
+        false_easting: optional
             X offset from planar origin in metres. Defaults to 0.
         false_northing: optional
             Y offset from planar origin in metres. Defaults to 0.
@@ -1976,8 +1977,8 @@ def epsg(code):
     so EPSG codes such as 4326 (WGS-84) which define a "geodetic coordinate
     system" will not work.
 
-    Notes
-    -----
+    Note
+    ----
         The conversion is performed by querying https://epsg.io/ so a
         live internet connection is required.
 

--- a/lib/cartopy/io/__init__.py
+++ b/lib/cartopy/io/__init__.py
@@ -278,7 +278,8 @@ class Downloader(object):
             typically this is left as None to use the
             default ``cartopy.config`` "downloaders" dictionary.
 
-        Example:
+        Example
+        -------
 
         >>> from cartopy.io import Downloader
         >>>

--- a/lib/cartopy/io/__init__.py
+++ b/lib/cartopy/io/__init__.py
@@ -113,12 +113,12 @@ class Downloader(object):
         :meth:`Downloader.path` is called it will not be downloaded
         to this location (unlike the ``target_path_template`` argument).
 
-    Notes
-    -----
-    All ``*_template`` arguments should be formattable using the
-    standard :meth:`string.format` rules. The formatting itself
-    is not done until a call to a subsequent method (such as
-    :meth:`Downloader.path`).
+    Note
+    ----
+        All ``*_template`` arguments should be formattable using the
+        standard :meth:`string.format` rules. The formatting itself
+        is not done until a call to a subsequent method (such as
+        :meth:`Downloader.path`).
 
     """
 

--- a/lib/cartopy/io/img_nest.py
+++ b/lib/cartopy/io/img_nest.py
@@ -62,8 +62,8 @@ class Img(collections.namedtuple('Img', _img_class_attrs)):
             The (x_scale, y_scale) pixel width, in units of the
             native projection per pixel.
 
-        Notes
-        -----
+        Note
+        ----
             API is likely to change in the future to include a CRS.
 
         """
@@ -238,8 +238,8 @@ class ImageCollection(object):
         img_class: optional
             The class used to construct each image in the Collection.
 
-        Notes
-        -----
+        Note
+        ----
             Does not recursively search sub-directories.
 
         """
@@ -484,8 +484,8 @@ class NestedImageCollection(object):
             file data, the (x_lower, x_upper, y_lower, y_upper) extent of the
             image, and the image origin.
 
-        Notes
-        -----
+        Note
+        ----
           The format of the retrieved image file data is controlled by
           :attr:`~cartopy.io.img_nest.NestedImageCollection.desired_tile_form`,
           which defaults to 'RGB' format.

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -138,12 +138,12 @@ class GoogleTiles(object):
         Parameters
         ----------
         x
+            The x tile coordinate in the Google tile numbering system.
         y
+            The y tile coordinate in the Google tile numbering system.
         z
-            The x, y, z tile coordinates in the Google tile
-            numbering system (with y=0 being at the north pole), unless
-            `y0_at_north_pole` is set to ``False``, in which case `y` is in
-            the TMS numbering system (with y=0 being at the south pole).
+            The z tile coordinate in the Google tile numbering system.
+
         y0_at_north_pole: optional
             Boolean representing whether the numbering of the y coordinate
             starts at the north pole (as is the convention for Google tiles)

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -137,7 +137,9 @@ class GoogleTiles(object):
 
         Parameters
         ----------
-        x, y, z
+        x
+        y
+        z
             The x, y, z tile coordinates in the Google tile
             numbering system (with y=0 being at the north pole), unless
             `y0_at_north_pole` is set to ``False``, in which case `y` is in

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -202,9 +202,9 @@ class WMSRasterSource(RasterSource):
     """
     A WMS imagery retriever which can be added to a map.
 
-    Notes
-    -----
-    Requires owslib and Pillow to work.
+    Note
+    ----
+        Requires owslib and Pillow to work.
 
     No caching of retrieved maps is done with this WMSRasterSource.
 
@@ -335,9 +335,9 @@ class WMTSRasterSource(RasterSource):
 
     Uses tile caching for fast repeated map retrievals.
 
-    Notes
-    -----
-    Requires owslib and Pillow to work.
+    Note
+    ----
+        Requires owslib and Pillow to work.
 
     """
 

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -244,8 +244,8 @@ def natural_earth(resolution='110m', category='physical', name='coastline'):
     https://github.com/nvkelso/natural-earth-vector/tree/master/zips to
     see the actual files which will be downloaded.
 
-    Notes
-    -----
+    Note
+    ----
         Some of the Natural Earth shapefiles have special features which are
         described in the name. For example, the 110m resolution
         "admin_0_countries" data also has a sibling shapefile called
@@ -448,8 +448,8 @@ class GSHHSShpDownloader(Downloader):
         Download the zip file and extracts the files listed in
         :meth:`zip_file_contents` to the target path.
 
-        Notes
-        -----
+        Note
+        ----
             Because some of the GSHSS data is available with the cartopy
             repository, scales of "l" or "c" will not be downloaded if they
             exist in the ``cartopy.config['repo_data_dir']`` directory.

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -518,13 +518,6 @@ class GeoAxes(matplotlib.axes.Axes):
         -------
         The created :class:`~matplotlib.collections.PathCollection`.
 
-        Note
-        ----
-            Currently no clipping is done on the geometries before adding them
-            to the axes. This means, if very high resolution geometries are
-            being used, performance is likely to be severely effected. This
-            should be resolved transparently by v0.5.
-
         """
         warnings.warn('This method has been deprecated.'
                       ' Please use `add_feature` instead.')

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -518,8 +518,8 @@ class GeoAxes(matplotlib.axes.Axes):
         -------
         The created :class:`~matplotlib.collections.PathCollection`.
 
-        Notes
-        -----
+        Note
+        ----
             Currently no clipping is done on the geometries before adding them
             to the axes. This means, if very high resolution geometries are
             being used, performance is likely to be severely effected. This
@@ -548,11 +548,11 @@ class GeoAxes(matplotlib.axes.Axes):
         A :class:`cartopy.mpl.feature_artist.FeatureArtist` instance
             The instance responsible for drawing the feature.
 
-        Notes
-        -----
-        Matplotlib keyword arguments can be used when drawing the feature.
-        This allows standard Matplotlib control over aspects such as
-        'facecolor', 'alpha', etc.
+        Note
+        ----
+            Matplotlib keyword arguments can be used when drawing the feature.
+            This allows standard Matplotlib control over aspects such as
+            'facecolor', 'alpha', etc.
 
         """
         # Instantiate an artist to draw the feature and add it to the axes.
@@ -575,11 +575,11 @@ class GeoAxes(matplotlib.axes.Axes):
         A :class:`cartopy.mpl.feature_artist.FeatureArtist` instance
             The instance responsible for drawing the feature.
 
-        Notes
-        -----
-        Matplotlib keyword arguments can be used when drawing the feature.
-        This allows standard Matplotlib control over aspects such as
-        'facecolor', 'alpha', etc.
+        Note
+        ----
+            Matplotlib keyword arguments can be used when drawing the feature.
+            This allows standard Matplotlib control over aspects such as
+            'facecolor', 'alpha', etc.
 
 
         """
@@ -706,8 +706,8 @@ class GeoAxes(matplotlib.axes.Axes):
         """
         Set the extent of the Axes to the limits of the projection.
 
-        Notes
-        -----
+        Note
+        ----
             In some cases where the projection has a limited sensible range
             the ``set_global`` method does not actually make the whole globe
             visible. Instead, the most appropriate extents will be used (e.g.
@@ -752,8 +752,8 @@ class GeoAxes(matplotlib.axes.Axes):
             to another rectangular coordinate system are supported (defaults
             to None).
 
-        Notes
-        -----
+        Note
+        ----
             This interface is subject to change whilst functionality is added
             to support other map projections.
 
@@ -799,8 +799,8 @@ class GeoAxes(matplotlib.axes.Axes):
             to another rectangular coordinate system are supported (defaults
             to None).
 
-        Notes
-        -----
+        Note
+        ----
             This interface is subject to change whilst functionality is added
             to support other map projections.
 
@@ -1204,10 +1204,10 @@ class GeoAxes(matplotlib.axes.Axes):
         gridliner
             A :class:`cartopy.mpl.gridliner.Gridliner` instance.
 
-        Notes
-        -----
-        All other keywords control line properties.  These are passed through
-        to :class:`matplotlib.collections.Collection`.
+        Note
+        ----
+            All other keywords control line properties.  These are passed
+            through to :class:`matplotlib.collections.Collection`.
 
         """
         if crs is None:
@@ -1239,12 +1239,12 @@ class GeoAxes(matplotlib.axes.Axes):
         Add the map's boundary to this GeoAxes, attaching the appropriate
         artists to :data:`.outline_patch` and :data:`.background_patch`.
 
-        Notes
-        -----
-        The boundary is not the ``axes.patch``. ``axes.patch``
-        is made invisible by this method - its only remaining
-        purpose is to provide a rectilinear clip patch for
-        all Axes artists.
+        Note
+        ----
+            The boundary is not the ``axes.patch``. ``axes.patch``
+            is made invisible by this method - its only remaining
+            purpose is to provide a rectilinear clip patch for
+            all Axes artists.
 
         """
         # Hide the old "background" patch used by matplotlib - it is not
@@ -1707,10 +1707,10 @@ class GeoAxes(matplotlib.axes.Axes):
         See :func:`matplotlib.pyplot.quiver` for details on arguments
         and other keyword arguments.
 
-        Notes
-        -----
-        The vector components must be defined as grid eastward and
-        grid northward.
+        Note
+        ----
+            The vector components must be defined as grid eastward and
+            grid northward.
 
         """
         t = kwargs.get('transform', None)
@@ -1788,10 +1788,10 @@ class GeoAxes(matplotlib.axes.Axes):
         See :func:`matplotlib.pyplot.barbs` for details on arguments
         and other keyword arguments.
 
-        Notes
-        -----
-        The vector components must be defined as grid eastward and
-        grid northward.
+        Note
+        ----
+            The vector components must be defined as grid eastward and
+            grid northward.
 
         """
         t = kwargs.get('transform', None)
@@ -1856,10 +1856,10 @@ class GeoAxes(matplotlib.axes.Axes):
         See :func:`matplotlib.pyplot.streamplot` for details on arguments
         and keyword arguments.
 
-        Notes
-        -----
-        The vector components must be defined as grid eastward and
-        grid northward.
+        Note
+        ----
+            The vector components must be defined as grid eastward and
+            grid northward.
 
         """
         t = kwargs.pop('transform', None)

--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -208,10 +208,10 @@ class Gridliner(object):
         """
         Get the drawing transform for our gridlines.
 
-        Notes
-        -----
-        The drawing transform depends on the transform of our 'axes', so
-        it may change dynamically.
+        Note
+        ----
+            The drawing transform depends on the transform of our 'axes', so
+            it may change dynamically.
 
         """
         transform = self.crs

--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -122,10 +122,10 @@ class LatitudeFormatter(_PlateCarreeFormatter):
             suitable for most use cases. To control the appearance of
             tick labels use the *number_format* keyword.
 
-        Notes
-        -----
-        A formatter can only be used for one axis. A new formatter
-        must be created for every axis that needs formatted labels.
+        Note
+        ----
+            A formatter can only be used for one axis. A new formatter
+            must be created for every axis that needs formatted labels.
 
         Examples
         --------
@@ -206,10 +206,10 @@ class LongitudeFormatter(_PlateCarreeFormatter):
             suitable for most use cases. To control the appearance of
             tick labels use the *number_format* keyword.
 
-        Notes
-        -----
-        A formatter can only be used for one axis. A new formatter
-        must be created for every axis that needs formatted labels.
+        Note
+        ----
+            A formatter can only be used for one axis. A new formatter
+            must be created for every axis that needs formatted labels.
 
         Examples
         --------


### PR DESCRIPTION
Fixes a few things that didn't look right following adoption of numpy-docstring format and `sphinx.ext.napoleon` in #987.

I attempted a full visual scan of all the docs to check for changes following #987.

A few particular common themes:
  * turn off the conf.py settings `napoleon_include_init_with_doc` and `napoleon_include_special_with_doc`, and reorganise class body + init docstrings to suit.
  * avoid groups of parameters, which look like type specs to napoleon
  * replace "Notes\\-----" sections with "Note\\----" to produce Sphinx "..note:" boxes