### PR TITLE
Add Stamen Toner and Watercolor image tiles

### DIFF
--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -275,6 +275,30 @@ class StamenTerrain(GoogleTiles):
         return url
 
 
+class StamenToner(GoogleTiles):
+    """
+    Implements web tile retrieval from Stamen Toner maps
+
+    """
+    def _image_url(self, tile):
+        x, y, z = tile
+        url = 'http://tile.stamen.com/toner/%s/%s/%s.png' % (
+            z, x, y)
+        return url
+
+
+class StamenWatercolor(GoogleTiles):
+    """
+    Implements web tile retrieval from Stamen Watercolor maps
+
+    """
+    def _image_url(self, tile):
+        x, y, z = tile
+        url = 'http://tile.stamen.com/watercolor/%s/%s/%s.png' % (
+            z, x, y)
+        return url
+
+
 class MapboxTiles(GoogleTiles):
     """
     Implement web tile retrieval from Mapbox.


### PR DESCRIPTION
This simple PR adds the two other versions of static map tiles that Stamen adds.

Basically I modified the `StamenTerrain` to access the different endpoints for the Toner maps (`http://tile.stamen.com/toner/`) and Watercolor (`http://tile.stamen.com/watercolor/`)