### PR TITLE
Better support colour overrides for Features.

### DIFF
--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -96,6 +96,12 @@ class FeatureArtist(matplotlib.artist.Artist):
             kwargs = {}
         self._kwargs = dict(kwargs)
 
+        if 'color' in self._kwargs:
+            # We want the user to be able to override both face and edge
+            # colours if the original feature already supplied it.
+            color = self._kwargs.pop('color')
+            self._kwargs['facecolor'] = self._kwargs['edgecolor'] = color
+
         # Set default zorder so that features are drawn before
         # lines e.g. contours but after images.
         # Note that the zorder of Patch, PatchCollection and PathCollection


### PR DESCRIPTION
If a Feature defines an `edgecolor` or `facecolor` but the user supplies plain `color` when add the feature to a plot, then which one wins depends on the dictionary and keyword sort order. This makes it more explicit by forcing `color` to override both.

See for example, https://github.com/SciTools/cartopy/issues/803#issuecomment-366686339 for a case where this difference comes up.