### PR TITLE
Add ne_ prefix to NaturalEarth cache files.

### DIFF
--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -345,11 +345,11 @@ class NEShpDownloader(Downloader):
             >>> ne_dnldr = NEShpDownloader.default_downloader()
             >>> print(ne_dnldr.target_path_template)
             {config[data_dir]}/shapefiles/natural_earth/{category}/\
-{resolution}_{name}.shp
+ne_{resolution}_{name}.shp
 
         """
         default_spec = ('shapefiles', 'natural_earth', '{category}',
-                        '{resolution}_{name}.shp')
+                        'ne_{resolution}_{name}.shp')
         ne_path_template = os.path.join('{config[data_dir]}', *default_spec)
         pre_path_template = os.path.join('{config[pre_existing_data_dir]}',
                                          *default_spec)


### PR DESCRIPTION
This prefix is used in the zip files provided by NaturalEarth, so if you download anything manually, you need to rename all the files for Cartopy to find them. This change makes that renaming no longer necessary, at the expense of a few extra re-downloads.

I don't know if NE changed the filenames or we have just been messing it up all this time.