### PR TITLE
shapely.geometry.LinearRing needs 4+ points

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -510,7 +510,7 @@ class Projection(six.with_metaclass(ABCMeta, CRS)):
 
         # filter out any non-valid linear rings
         processed_ls = [linear_ring for linear_ring in processed_ls if
-                        len(linear_ring.coords) > 2]
+                        len(linear_ring.coords) > 3]
 
         linear_rings = [sgeom.LinearRing(line) for line in processed_ls]
 

--- a/lib/cartopy/tests/mpl/test_contour.py
+++ b/lib/cartopy/tests/mpl/test_contour.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016 - 2017, Met Office
+# (C) British Crown Copyright 2016 - 2018, Met Office
 #
 # This file is part of cartopy.
 #
@@ -21,6 +21,8 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import cleanup
 import numpy as np
 from numpy.testing import assert_array_almost_equal
+from scipy.interpolate import NearestNDInterpolator
+from scipy.signal import convolve2d
 
 import cartopy.crs as ccrs
 
@@ -38,3 +40,32 @@ def test_contour_plot_bounds():
     ax.contourf(x, y, data, levels=np.arange(0, 40, 1))
     assert_array_almost_equal(ax.get_extent(),
                               np.array([x[0], x[-1], y[0], y[-1]]))
+
+
+@cleanup
+def test_contour_linear_ring():
+    """Test contourf with a section that only has 3 points."""
+    ax = plt.axes([0.01, 0.05, 0.898, 0.85], projection=ccrs.Mercator(),
+                  aspect='equal')
+    ax.set_extent([-99.6, -89.0, 39.8, 45.5])
+
+    xbnds = ax.get_xlim()
+    ybnds = ax.get_ylim()
+    ll = ccrs.Geodetic().transform_point(xbnds[0], ybnds[0], ax.projection)
+    ul = ccrs.Geodetic().transform_point(xbnds[0], ybnds[1], ax.projection)
+    ur = ccrs.Geodetic().transform_point(xbnds[1], ybnds[1], ax.projection)
+    lr = ccrs.Geodetic().transform_point(xbnds[1], ybnds[0], ax.projection)
+    xi = np.linspace(min(ll[0], ul[0]), max(lr[0], ur[0]), 100)
+    yi = np.linspace(min(ll[1], ul[1]), max(ul[1], ur[1]), 100)
+    xi, yi = np.meshgrid(xi, yi)
+    nn = NearestNDInterpolator((np.arange(-94, -85), np.arange(36, 45)),
+                               np.arange(9))
+    vals = nn(xi, yi)
+    lons = xi
+    lats = yi
+    window = np.ones((6, 6))
+    vals = convolve2d(vals, window / window.sum(), mode='same',
+                      boundary='symm')
+    ax.contourf(lons, lats, vals, np.arange(9), transform=ccrs.PlateCarree())
+
+    plt.draw()


### PR DESCRIPTION
avoids shapely error that leads to segmentation fault:
ERROR:shapely.geos:IllegalArgumentException: Invalid number of points in LinearRing found 3 - must be 0 or >= 4

## Rationale

A `LinearRing` should have at least four points, not three.

## Implications

I stop seeing segmentation faults!

