### PR TITLE
Reorder Stereographic args to avoid API breaking 0.15 -> 0.16.

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1312,7 +1312,7 @@ class Stereographic(Projection):
     def __init__(self, central_latitude=0.0, central_longitude=0.0,
                  false_easting=0.0, false_northing=0.0,
                  true_scale_latitude=None,
-                 scale_factor=None, globe=None):
+                 globe=None, scale_factor=None):
         proj4_params = [('proj', 'stere'), ('lat_0', central_latitude),
                         ('lon_0', central_longitude),
                         ('x_0', false_easting), ('y_0', false_northing)]


### PR DESCRIPTION
In #929 a new argument was added into `Stereographic.__init__`, but not at the end.
This affects the meaning of usages that rely on argument-order, and broke a couple of tests in Iris.
See : https://github.com/SciTools/iris/pull/2971

**Do we want to consider putting this back ?**

I realise 
  1. it may look neater to put `globe` last ? (though other classes now don't)
  1. it's another breaking change (!)