### PR TITLE
DOC: change natural_earth to shapereader.natural_earth in example

### DIFF
--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -21,9 +21,9 @@ Combine the shapefile access of pyshp with the
 geometry representation of shapely:
 
     >>> import cartopy.io.shapereader as shapereader
-    >>> filename = natural_earth(resolution='110m',
-    ...                          category='physical',
-    ...                          name='geography_regions_points')
+    >>> filename = shapereader.natural_earth(resolution='110m',
+    ...                                      category='physical',
+    ...                                      name='geography_regions_points')
     >>> reader = shapereader.Reader(filename)
     >>> len(reader)
     3


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

Working through my first example of learning how to plot data for a country/countries.
Noticed [this](https://stackoverflow.com/questions/27151614/mask-cube-with-features) SO answer by @ajdawson pointed me to cartopy.io.shapereader

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

None. Just a doc change to prevent: 
`NameError: name 'natural_earth' is not defined`
to other users who use this e.g.
<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
