### PR TITLE
Close shapefiles opened with shapereader

### DIFF
--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -38,6 +38,7 @@ geometry representation of shapely:
     >>> geoms = list(reader.geometries())
     >>> print(type(geoms[0]))
     <class 'shapely.geometry.point.Point'>
+    >>> reader.close()
 
 """
 
@@ -232,6 +233,25 @@ class Reader(object):
             attributes = dict(zip(field_names, shape_record.record))
             yield Record(shape_record.shape, geometry_factory, attributes,
                          fields)
+
+    def close(self):
+        """
+        Close a shapefile and its siblings (.shx and .dbf).
+        """
+        if hasattr(self._reader, 'close'):
+            self._reader.close()
+        else:
+            try:
+                if hasattr(self._reader.shp, 'close'):
+                    self._reader.shp.close()
+                if hasattr(self._reader.shx, 'close'):
+                    self._reader.shx.close()
+                if hasattr(self._reader.dbf, 'close'):
+                    self._reader.dbf.close()
+            except IOError:
+                pass
+        self._reader = None
+        self._fields = None
 
 
 def natural_earth(resolution='110m', category='physical', name='coastline'):


### PR DESCRIPTION
Hi,

There was no close() method in shapereader.Reader interface which results in dangling file objects in case of long-running process opening a lot of files during its lifetime. The underlying pyshp library has close() method in its most recent version but older versions lacks this functionality. This patch uses close() from pyshp if available. If not it falls back to direct closing of associated shp, shx and dbf files exactly as pyshp does.

Best regards,
Andrey
