### PR TITLE
Fix transform_points for empty arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,11 +45,15 @@ cartopy_test_output
 \.\#*
 *.swp
 .ipynb_checkpoints/
+.idea/
 
 # Operating system files
 \.DS_Store
 .cache/
 __pycache__/
+
+# PyTest cache files
+.pytest_cache
 
 # Egg that gets created with 'pip install -v -e .'
 *.egg-info/

--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -376,9 +376,11 @@ cdef class CRS:
         else:
             result[:, 2] = z
 
-        # call proj.4. The result array is modified in place.
-        status = pj_transform(src_crs.proj4, self.proj4, npts, 3,
-                              &result[0, 0], &result[0, 1], &result[0, 2])
+        # call proj.4. The result array is modified in place. This is only
+        # safe if npts is not 0.
+        if npts:
+            status = pj_transform(src_crs.proj4, self.proj4, npts, 3,
+                                  &result[0, 0], &result[0, 1], &result[0, 2])
 
         if self.is_geodetic():
             result[:, :2] = np.rad2deg(result[:, :2])

--- a/lib/cartopy/tests/mpl/test_plots.py
+++ b/lib/cartopy/tests/mpl/test_plots.py
@@ -1,0 +1,45 @@
+# (C) British Crown Copyright 2018, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+
+from io import BytesIO
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import cartopy.crs as ccrs
+
+
+def test_empty_plot():
+    """Test making a plot with empty arrays."""
+    fig = plt.figure()
+    ax = plt.axes(projection=ccrs.Mercator())
+    ax.plot([], [], transform=ccrs.PlateCarree())
+    fig.savefig(BytesIO())
+
+
+def test_triplot_bbox_tight():
+    """Test triplot with a tight bbox (#1060)."""
+    x = np.degrees([-0.101, -0.090, -0.069])
+    y = np.degrees([0.872, 0.883, 0.888])
+    triangles = np.asarray([[0, 1, 2]])
+
+    fig = plt.figure()
+    ax = plt.axes(projection=ccrs.OSGB())
+    ax.triplot(x, y, triangles, transform=ccrs.Geodetic())
+    fig.savefig(BytesIO(), bbox_inches='tight')


### PR DESCRIPTION
In matplotlib, calling: `plot([], [])` is perfectly fine; in fact, this is required for `triplot()` to work properly--in the case of no markers (or explicitly no lines), this is exactly what it does. Currently the following cases fail in CartoPy:

1. `plot([], [], transform=...)`
2. `triplot()` followed by a `savefig(..., bbox_inches='tight')` (i.e. Jupyter notebook inline)

with the failure occurring in `CRS.tranform_points()`. This is because it is trying to transform an array with a size of 0 for the first dimension.

The easy solution is to add a guard on `npts` around the call to `pj_transform()`, which was explicitly passed arrays indexed to 0 on size 0 axes, which is invalid.

Closes #1060.