### PR TITLE
Improve compatibility with proj >= 5

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -964,7 +964,8 @@ class Mercator(Projection):
         proj4_params = [('proj', 'merc'),
                         ('lon_0', central_longitude),
                         ('lat_ts', latitude_true_scale),
-                        ('units', 'm')]
+                        ('units', 'm'),
+                        ('over', None)]
         super(Mercator, self).__init__(proj4_params, globe=globe)
 
         # Calculate limits.

--- a/lib/cartopy/tests/crs/test_mercator.py
+++ b/lib/cartopy/tests/crs/test_mercator.py
@@ -26,7 +26,7 @@ def test_default():
     crs = ccrs.Mercator()
 
     assert crs.proj4_init == ('+ellps=WGS84 +proj=merc +lon_0=0.0 +lat_ts=0.0 '
-                              '+units=m +no_defs')
+                              '+units=m +over +no_defs')
     assert_almost_equal(crs.boundary.bounds,
                         [-20037508, -15496571, 20037508, 18764656], decimal=0)
 
@@ -36,7 +36,7 @@ def test_eccentric_globe():
                        ellipse=None)
     crs = ccrs.Mercator(globe=globe, min_latitude=-40, max_latitude=40)
     assert crs.proj4_init == ('+a=10000 +b=5000 +proj=merc +lon_0=0.0 '
-                              '+lat_ts=0.0 +units=m +no_defs')
+                              '+lat_ts=0.0 +units=m +over +no_defs')
 
     assert_almost_equal(crs.boundary.bounds,
                         [-31415.93, -2190.5, 31415.93, 2190.5], decimal=2)
@@ -61,7 +61,7 @@ def test_central_longitude():
     cl = 10.0
     crs = ccrs.Mercator(central_longitude=cl)
     proj4_str = ('+ellps=WGS84 +proj=merc +lon_0={} +lat_ts=0.0 '
-                 '+units=m +no_defs'.format(cl))
+                 '+units=m +over +no_defs'.format(cl))
     assert crs.proj4_init == proj4_str
 
     assert_almost_equal(crs.boundary.bounds,
@@ -72,7 +72,7 @@ def test_latitude_true_scale():
     lat_ts = 20.0
     crs = ccrs.Mercator(latitude_true_scale=lat_ts)
     proj4_str = ('+ellps=WGS84 +proj=merc +lon_0=0.0 +lat_ts={} '
-                 '+units=m +no_defs'.format(lat_ts))
+                 '+units=m +over +no_defs'.format(lat_ts))
     assert crs.proj4_init == proj4_str
 
     assert_almost_equal(crs.boundary.bounds,


### PR DESCRIPTION

## Rationale

Improve compatibility with proj 5.
Currently crs/test_mercator.py fails as follows with proj >= 5.0

```
$ python3 -m pytest lib/cartopy/tests/crs/test_mercator.py 
======================================================== test session starts ========================================================
platform linux -- Python 3.6.5, pytest-3.3.2, py-1.5.3, pluggy-0.6.0
rootdir: /home/antonio/projects/cartopy, inifile: setup.cfg
collected 5 items                                                                                                                   

lib/cartopy/tests/crs/test_mercator.py ...F.                                                                                  [100%]

============================================================= FAILURES ==============================================================
______________________________________________________ test_central_longitude _______________________________________________________

    def test_central_longitude():
        cl = 10.0
        crs = ccrs.Mercator(central_longitude=cl)
        proj4_str = ('+ellps=WGS84 +proj=merc +lon_0={} +lat_ts=0.0 '
                     '+units=m +no_defs'.format(cl))
        assert crs.proj4_init == proj4_str
    
        assert_almost_equal(crs.boundary.bounds,
>                           [-20037508, -15496570, 20037508, 18764656], decimal=0)
E       AssertionError: 
E       Arrays are not almost equal to 0 decimals
E       
E       (mismatch 25.0%)
E        x: array([-20037508., -15496571., -20037508.,  18764656.])
E        y: array([-20037508, -15496570,  20037508,  18764656])

lib/cartopy/tests/crs/test_mercator.py:68: AssertionError
================================================ 1 failed, 4 passed in 0.15 seconds =================================================
```
See also https://github.com/OSGeo/proj.4/issues/985 Example 1 and https://github.com/OSGeo/proj.4/issues/941.


## Implications

As reported in https://proj4.org/usage/projections.html:

`+over | Allow longitude output outside -180 to 180 range, disables wrapping (see below)`

It seems to be the be behaviour subsume in some test but please carefully check it before applying the patch.
See discussions in https://github.com/OSGeo/proj.4/issues/985 and https://github.com/OSGeo/proj.4/issues/941.
