### PR TITLE
Make changes suggested to solve gshhs zipfile path problems on windows

### DIFF
--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -418,7 +418,7 @@ class NEShpDownloader(Downloader):
         for member_path in self.zip_file_contents(format_dict):
             ext = os.path.splitext(member_path)[1]
             target = os.path.splitext(target_path)[0] + ext
-            member = zfh.getinfo(member_path)
+            member = zfh.getinfo(member_path.replace(os.sep, '/'))
             with open(target, 'wb') as fh:
                 fh.write(zfh.open(member).read())
 
@@ -531,7 +531,7 @@ class GSHHSShpDownloader(Downloader):
             for member_path in self.zip_file_contents(modified_format_dict):
                 ext = os.path.splitext(member_path)[1]
                 target = os.path.splitext(target_path)[0] + ext
-                member = zfh.getinfo(member_path)
+                member = zfh.getinfo(member_path.replace(os.sep, '/'))
                 with open(target, 'wb') as fh:
                     fh.write(zfh.open(member).read())
 


### PR DESCRIPTION
## Rationale

Implement suggested changes in https://github.com/SciTools/cartopy/issues/1011 for the zipfile path separator problem on windows os.


## Implications

Should just force any os-default path sep to "/" forward slash which zipfile expects.
