### PR TITLE
Prevent segfault in LambertAzimuthalEqualArea

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1223,7 +1223,12 @@ class LambertAzimuthalEqualArea(Projection):
                                                         globe=globe)
 
         a = np.float(self.globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS)
-        lon, lat = central_longitude + 180, - central_latitude + 0.01
+
+        # Find the antipode, and shift it a small amount in latitude to
+        # approximate the extent of the projection:
+        lon = central_longitude + 180
+        sign = np.sign(central_latitude) or 1
+        lat = -central_latitude + sign * 0.01
         x, max_y = self.transform_point(lon, lat, PlateCarree())
 
         coords = _ellipse_boundary(a * 1.9999, max_y - false_northing,

--- a/lib/cartopy/tests/crs/test_lambert_azimuthal_equal_area.py
+++ b/lib/cartopy/tests/crs/test_lambert_azimuthal_equal_area.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2017, Met Office
+# (C) British Crown Copyright 2015 - 2018, Met Office
 #
 # This file is part of cartopy.
 #
@@ -19,6 +19,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal
+import pytest
 
 import cartopy.crs as ccrs
 
@@ -59,3 +60,10 @@ class TestLambertAzimuthalEqualArea(object):
         assert crs_offset.proj4_init == expected
         assert tuple(np.array(crs.x_limits) + 1234) == crs_offset.x_limits
         assert tuple(np.array(crs.y_limits) - 4321) == crs_offset.y_limits
+
+    @pytest.mark.parametrize("latitude", [-90, 90])
+    def test_extrema(self, latitude):
+        crs = ccrs.LambertAzimuthalEqualArea(central_latitude=latitude)
+        expected = ('+ellps=WGS84 +proj=laea +lon_0=0.0 +lat_0={} '
+                    '+x_0=0.0 +y_0=0.0 +no_defs'.format(latitude))
+        assert crs.proj4_init == expected


### PR DESCRIPTION
Computing the boundary of the Lambert azimuthal equal area projection requires finding the anitpode of the projection centre in lat and lon, shifting it a little bit in latitude then transforming to the native coordinate system. This shifting is required because the exact antipode is not within the target projection. The implementation of the shift allowed for out-of-range latitudes when the central latitude is less than -89.9 degrees. This change avoids shifting the antipode out-of-range of the `PlateCarree` projection before transforming to `LambertAzimuthalEqualArea` to compute the projection boundary.

Fixes #1099.
