### PR TITLE
Use tuple for multidimensional array indexing

### DIFF
--- a/lib/cartopy/util.py
+++ b/lib/cartopy/util.py
@@ -106,7 +106,7 @@ def add_cyclic_point(data, coord=None, axis=-1):
     except IndexError:
         raise ValueError('The specified axis does not correspond to an '
                          'array dimension.')
-    new_data = ma.concatenate((data, data[slicer]), axis=axis)
+    new_data = ma.concatenate((data, data[tuple(slicer)]), axis=axis)
     if coord is None:
         return_value = new_data
     else:


### PR DESCRIPTION
The add_cyclic_point tests were prompting numpy deprecation warnings due to the use of a list to index a multidimensional array. This has been changed to use a tuple to avoid problems when the numpy behaviour changes.