### PR TITLE
Enable adaptive scaling of NaturalEarthFeatures

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -7,10 +7,11 @@ What's New in cartopy 0.17
 Features
 --------
 * The :class:`cartopy.feature.NaturalEarthFeature` class now allows a
-:class:`cartopy.feature.AdaptiveScaler` object to be passed to the `scale`
+:class:`cartopy.feature.AdaptiveScaler` object to be passed as the `scale`
 argument. This will automatically choose the appropriate feature scale from
 the GeoAxes extent. This can also be used interactively while panning and
-zooming in a figure.
+zooming in a figure. :data:`cartopy.feature.NaturalEarthFeature.scale` is
+now read-only.
 
 --------
 

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -11,7 +11,7 @@ Features
 argument. This will automatically choose the appropriate feature scale from
 the GeoAxes extent. This can also be used interactively while panning and
 zooming in a figure. :data:`cartopy.feature.NaturalEarthFeature.scale` is
-now read-only.
+now read-only. (:pull:`1102`, :pull:`983`)
 
 --------
 

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -93,6 +93,12 @@ Features
 * If Fiona is installed on a user's system, this will now be the default
   shapefile reader, adding significant speed improvements. (:pull:`1000`)
 
+* The :class:`cartopy.feature.NaturalEarthFeature` class now allows the
+`scale` argument to be set to `'auto'`. This will automatically choose the
+appropriate feature scale from the GeoAxes extent. This can also be used
+interactively while panning and zooming in a figure.
+
+
 What's New in cartopy 0.15
 ==========================
 

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -1,3 +1,21 @@
+What's New in cartopy 0.17
+==========================
+
+:Release: 0.17.0
+:Date:
+
+Features
+--------
+* The :class:`cartopy.feature.NaturalEarthFeature` class now allows a
+:class:`cartopy.feature.AdaptiveScaler` object to be passed to the `scale`
+argument. This will automatically choose the appropriate feature scale from
+the GeoAxes extent. This can also be used interactively while panning and
+zooming in a figure.
+
+--------
+
+
+
 What's New in cartopy 0.16
 ==========================
 
@@ -93,10 +111,8 @@ Features
 * If Fiona is installed on a user's system, this will now be the default
   shapefile reader, adding significant speed improvements. (:pull:`1000`)
 
-* The :class:`cartopy.feature.NaturalEarthFeature` class now allows the
-`scale` argument to be set to `'auto'`. This will automatically choose the
-appropriate feature scale from the GeoAxes extent. This can also be used
-interactively while panning and zooming in a figure.
+-----------
+
 
 
 What's New in cartopy 0.15

--- a/lib/cartopy/feature.py
+++ b/lib/cartopy/feature.py
@@ -123,6 +123,90 @@ class Feature(six.with_metaclass(ABCMeta)):
             return self.geometries()
 
 
+class Scaler(object):
+    """
+    General object for handling the scale of the geometries used in a Feature.
+    """
+    def __init__(self, scale):
+        self._scale = scale
+
+    @property
+    def scale(self):
+        return self._scale
+
+    def scale_from_extent(self, extent):
+        """
+        Given an extent, update the scale.
+
+        Parameters
+        ----------
+        extent
+            The extent over which we should choose a scale. The
+            coordinate system of the extent should be constant, and at the
+            same scale as the scales argument in the constructor.
+
+        """
+        # Note: Implementation does nothing. For subclasses to specialise.
+        return self.scale
+
+
+class AdaptiveScaler(Scaler):
+    """
+    Object for changing scales of geometries based on extent of axes used to
+    plot geometries.
+    """
+    def __init__(self, default_scale, limits):
+        """
+        Parameters
+        ----------
+        default_scale
+            Coursest scale used as default when plot is at maximum extent.
+
+        limits
+            Scale-extent pairs at which scale of geometries change. Must be a
+            tuple of tuples ordered from coursest to finest scales. Limit
+            values are the upper bounds for their corresponding scale
+            (in degrees).
+
+        Example:
+
+        >>> s = AdaptiveScaler('coarse',
+        ...           (('intermediate', 30), ('fine', 10)))
+        >>> s.scale_from_extent([-180, 180, -90, 90])
+        'coarse'
+        >>> s.scale_from_extent([-5, 6, 45, 56])
+        'intermediate'
+        >>> s.scale_from_extent([-5, 5, 45, 56])
+        'fine'
+
+        """
+        super(AdaptiveScaler, self).__init__(default_scale)
+        self._default_scale = default_scale
+        # Upper limit on extent in degrees.
+        self._limits = limits
+
+    def scale_from_extent(self, extent):
+        scale = self._default_scale
+
+        if extent is not None:
+            width = abs(extent[1] - extent[0])
+            height = abs(extent[3] - extent[2])
+            min_extent = min(width, height)
+
+            if min_extent != 0:
+                for scale_candidate, upper_bound in self._limits:
+                    if min_extent <= upper_bound:
+                        # It is a valid scale, so track it.
+                        scale = scale_candidate
+                    else:
+                        # This scale is not valid and we can stop looking.
+                        # We use the last (valid) scale that we saw.
+                        break
+
+        self._scale = scale
+        return self._scale
+
+
 class ShapelyFeature(Feature):
     """
     A class capable of drawing a collection of
@@ -158,7 +242,7 @@ class NaturalEarthFeature(Feature):
     See http://www.naturalearthdata.com/
 
     """
-    def __init__(self, category, name, scale, **kwargs):
+    def __init__(self, category, name, scaler, **kwargs):
         """
         Parameters
         ----------
@@ -166,7 +250,7 @@ class NaturalEarthFeature(Feature):
             The category of the dataset, i.e. either 'cultural' or 'physical'.
         name
             The name of the dataset, e.g. 'admin_0_boundary_lines_land'.
-        scale
+        scaler
             The dataset scale, i.e. one of '10m', '50m', or '110m'.
             Corresponding to 1:10,000,000, 1:50,000,000, and 1:110,000,000
             respectively. If set to 'auto', the scale will be automatically
@@ -182,13 +266,15 @@ class NaturalEarthFeature(Feature):
                                                   **kwargs)
         self.category = category
         self.name = name
-        self.scale = scale
 
-        # Use autoscaling if scale == 'a', 'auto' or 'autoscale'
-        if scale == 'auto':
-            self.autoscale = True
-        else:
-            self.autoscale = False
+        if isinstance(scaler, six.string_types):
+            scaler = Scaler(scaler)
+
+        self.scaler = scaler
+
+    @property
+    def scale(self):
+        return self.scaler.scale
 
     def geometries(self):
         """
@@ -215,8 +301,7 @@ class NaturalEarthFeature(Feature):
         If extent is None, the method returns all geometries for this dataset.
         """
 
-        if self.autoscale:
-            self.scale = self._scale_from_extent(extent)
+        self.scaler.scale_from_extent(extent)
 
         if extent is not None:
             extent_geom = sgeom.box(extent[0], extent[2],
@@ -240,32 +325,6 @@ class NaturalEarthFeature(Feature):
         """
         return NaturalEarthFeature(self.category, self.name, new_scale,
                                    **self.kwargs)
-
-    def _scale_from_extent(self, extent):
-        """
-        Returns the appropriate scale (e.g. '50m') for the given extent
-        expressed in CRS of the feature (PlateCarree()).
-
-        """
-        # Default to 1:110,000,000 scale
-        scale = '110m'
-
-        if extent is not None:
-            # Upper limit on extent in degrees.
-            scale_limits = (('110m', 50.0),
-                            ('50m', 15.0),
-                            ('10m', 0.0))
-
-            width = abs(extent[1] - extent[0])
-            height = abs(extent[3] - extent[2])
-            min_extent = min(width, height)
-
-            if min_extent != 0:
-                for scale, limit in scale_limits:
-                    if min_extent > limit:
-                        break
-
-        return scale
 
 
 class GSHHSFeature(Feature):

--- a/lib/cartopy/feature.py
+++ b/lib/cartopy/feature.py
@@ -251,10 +251,9 @@ class NaturalEarthFeature(Feature):
         name
             The name of the dataset, e.g. 'admin_0_boundary_lines_land'.
         scaler
-            The dataset scale, i.e. one of '10m', '50m', or '110m'.
-            Corresponding to 1:10,000,000, 1:50,000,000, and 1:110,000,000
-            respectively. If set to 'auto', the scale will be automatically
-            set based on the extent of the axes.
+            The dataset scale, i.e. one of '10m', '50m', or '110m',
+            or Scaler object. Dataset scales correspond to 1:10,000,000,
+            1:50,000,000, and 1:110,000,000 respectively.
 
         Other Parameters
         ----------------

--- a/lib/cartopy/feature.py
+++ b/lib/cartopy/feature.py
@@ -118,7 +118,7 @@ class Feature(six.with_metaclass(ABCMeta)):
             extent_geom = sgeom.box(extent[0], extent[2],
                                     extent[1], extent[3])
             return (geom for geom in self.geometries() if
-                    extent_geom.intersects(geom))
+                    geom is not None and extent_geom.intersects(geom))
         else:
             return self.geometries()
 
@@ -205,7 +205,7 @@ class NaturalEarthFeature(Feature):
             geometries = _NATURAL_EARTH_GEOM_CACHE[key]
 
         return iter(geometries)
-    
+
     def intersecting_geometries(self, extent):
         """
         Returns an iterator of shapely geometries that intersect with
@@ -224,7 +224,7 @@ class NaturalEarthFeature(Feature):
             extent_geom = sgeom.box(extent[0], extent[2],
                                     extent[1], extent[3])
             return (geom for geom in self.geometries() if
-                    extent_geom.intersects(geom))
+                    geom is not None and extent_geom.intersects(geom))
         else:
             return self.geometries()
 

--- a/lib/cartopy/feature.py
+++ b/lib/cartopy/feature.py
@@ -169,7 +169,8 @@ class NaturalEarthFeature(Feature):
         scale
             The dataset scale, i.e. one of '10m', '50m', or '110m'.
             Corresponding to 1:10,000,000, 1:50,000,000, and 1:110,000,000
-            respectively. If set to 'auto', autoscaling is used.
+            respectively. If set to 'auto', the scale will be automatically
+            set based on the extent of the axes.
 
         Other Parameters
         ----------------
@@ -249,7 +250,7 @@ class NaturalEarthFeature(Feature):
         expressed in CRS of the feature (PlateCarree()).
 
         """
-        # Default to 1:10,000,000 scale
+        # Default to 1:110,000,000 scale
         scale = '110m'
 
         if extent is not None:
@@ -447,13 +448,13 @@ LAKES = NaturalEarthFeature('physical', 'lakes', '110m',
 
 LAND = NaturalEarthFeature('physical', 'land', '110m',
                            edgecolor='face',
-                           facecolor=COLORS['land'])
+                           facecolor=COLORS['land'], zorder=-1)
 """Small scale (1:110m) land polygons, including major islands."""
 
 
 OCEAN = NaturalEarthFeature('physical', 'ocean', '110m',
                             edgecolor='face',
-                            facecolor=COLORS['water'])
+                            facecolor=COLORS['water'], zorder=-1)
 """Small scale (1:110m) ocean polygons."""
 
 

--- a/lib/cartopy/feature.py
+++ b/lib/cartopy/feature.py
@@ -147,7 +147,7 @@ class Scaler(object):
 
         """
         # Note: Implementation does nothing. For subclasses to specialise.
-        return self.scale
+        return self._scale
 
 
 class AdaptiveScaler(Scaler):

--- a/lib/cartopy/feature.py
+++ b/lib/cartopy/feature.py
@@ -185,7 +185,7 @@ class NaturalEarthFeature(Feature):
         self.scale = scale
 
         # Use autoscaling if scale == 'a', 'auto' or 'autoscale'
-        if scale.lower() in ('a', 'auto', 'autoscale'):
+        if scale == 'auto':
             self.autoscale = True
         else:
             self.autoscale = False
@@ -213,13 +213,10 @@ class NaturalEarthFeature(Feature):
         the given extent.
         The extent is assumed to be in the CRS of the feature.
         If extent is None, the method returns all geometries for this dataset.
-
         """
 
         if self.autoscale:
             self.scale = self._scale_from_extent(extent)
-        else:
-            self.scale = self.scale
 
         if extent is not None:
             extent_geom = sgeom.box(extent[0], extent[2],

--- a/lib/cartopy/feature.py
+++ b/lib/cartopy/feature.py
@@ -141,7 +141,7 @@ class Scaler(object):
         Parameters
         ----------
         extent
-            The extent over which we should choose a scale. The
+            The boundaries of the plotted area of a projection. The
             coordinate system of the extent should be constant, and at the
             same scale as the scales argument in the constructor.
 
@@ -160,13 +160,12 @@ class AdaptiveScaler(Scaler):
         Parameters
         ----------
         default_scale
-            Coursest scale used as default when plot is at maximum extent.
+            Coarsest scale used as default when plot is at maximum extent.
 
         limits
             Scale-extent pairs at which scale of geometries change. Must be a
-            tuple of tuples ordered from coursest to finest scales. Limit
-            values are the upper bounds for their corresponding scale
-            (in degrees).
+            tuple of tuples ordered from coarsest to finest scales. Limit
+            values are the upper bounds for their corresponding scale.
 
         Example:
 
@@ -242,7 +241,7 @@ class NaturalEarthFeature(Feature):
     See http://www.naturalearthdata.com/
 
     """
-    def __init__(self, category, name, scaler, **kwargs):
+    def __init__(self, category, name, scale, **kwargs):
         """
         Parameters
         ----------
@@ -250,7 +249,7 @@ class NaturalEarthFeature(Feature):
             The category of the dataset, i.e. either 'cultural' or 'physical'.
         name
             The name of the dataset, e.g. 'admin_0_boundary_lines_land'.
-        scaler
+        scale
             The dataset scale, i.e. one of '10m', '50m', or '110m',
             or Scaler object. Dataset scales correspond to 1:10,000,000,
             1:50,000,000, and 1:110,000,000 respectively.
@@ -266,10 +265,11 @@ class NaturalEarthFeature(Feature):
         self.category = category
         self.name = name
 
-        if isinstance(scaler, six.string_types):
-            scaler = Scaler(scaler)
+        # Cast the given scale to a (constant) Scaler if a string is passed.
+        if isinstance(scale, six.string_types):
+            scale = Scaler(scale)
 
-        self.scaler = scaler
+        self.scaler = scale
 
     @property
     def scale(self):
@@ -299,7 +299,6 @@ class NaturalEarthFeature(Feature):
         The extent is assumed to be in the CRS of the feature.
         If extent is None, the method returns all geometries for this dataset.
         """
-
         self.scaler.scale_from_extent(extent)
 
         if extent is not None:

--- a/lib/cartopy/feature.py
+++ b/lib/cartopy/feature.py
@@ -118,7 +118,7 @@ class Feature(six.with_metaclass(ABCMeta)):
             extent_geom = sgeom.box(extent[0], extent[2],
                                     extent[1], extent[3])
             return (geom for geom in self.geometries() if
-                    geom is not None and extent_geom.intersects(geom))
+                    extent_geom.intersects(geom))
         else:
             return self.geometries()
 
@@ -169,7 +169,7 @@ class NaturalEarthFeature(Feature):
         scale
             The dataset scale, i.e. one of '10m', '50m', or '110m'.
             Corresponding to 1:10,000,000, 1:50,000,000, and 1:110,000,000
-            respectively.
+            respectively. If set to 'auto', autoscaling is used.
 
         Other Parameters
         ----------------
@@ -183,7 +183,17 @@ class NaturalEarthFeature(Feature):
         self.name = name
         self.scale = scale
 
+        # Use autoscaling if scale == 'a', 'auto' or 'autoscale'
+        if scale.lower() in ('a', 'auto', 'autoscale'):
+            self.autoscale = True
+        else:
+            self.autoscale = False
+
     def geometries(self):
+        """
+        Returns an iterator of (shapely) geometries for this feature.
+
+        """
         key = (self.name, self.category, self.scale)
         if key not in _NATURAL_EARTH_GEOM_CACHE:
             path = shapereader.natural_earth(resolution=self.scale,
@@ -195,6 +205,28 @@ class NaturalEarthFeature(Feature):
             geometries = _NATURAL_EARTH_GEOM_CACHE[key]
 
         return iter(geometries)
+    
+    def intersecting_geometries(self, extent):
+        """
+        Returns an iterator of shapely geometries that intersect with
+        the given extent.
+        The extent is assumed to be in the CRS of the feature.
+        If extent is None, the method returns all geometries for this dataset.
+
+        """
+
+        if self.autoscale:
+            self.scale = self._scale_from_extent(extent)
+        else:
+            self.scale = self.scale
+
+        if extent is not None:
+            extent_geom = sgeom.box(extent[0], extent[2],
+                                    extent[1], extent[3])
+            return (geom for geom in self.geometries() if
+                    extent_geom.intersects(geom))
+        else:
+            return self.geometries()
 
     def with_scale(self, new_scale):
         """
@@ -210,6 +242,32 @@ class NaturalEarthFeature(Feature):
         """
         return NaturalEarthFeature(self.category, self.name, new_scale,
                                    **self.kwargs)
+
+    def _scale_from_extent(self, extent):
+        """
+        Returns the appropriate scale (e.g. '50m') for the given extent
+        expressed in CRS of the feature (PlateCarree()).
+
+        """
+        # Default to 1:10,000,000 scale
+        scale = '110m'
+
+        if extent is not None:
+            # Upper limit on extent in degrees.
+            scale_limits = (('110m', 50.0),
+                            ('50m', 15.0),
+                            ('10m', 0.0))
+
+            width = abs(extent[1] - extent[0])
+            height = abs(extent[3] - extent[2])
+            min_extent = min(width, height)
+
+            if min_extent != 0:
+                for scale, limit in scale_limits:
+                    if min_extent > limit:
+                        break
+
+        return scale
 
 
 class GSHHSFeature(Feature):
@@ -389,13 +447,13 @@ LAKES = NaturalEarthFeature('physical', 'lakes', '110m',
 
 LAND = NaturalEarthFeature('physical', 'land', '110m',
                            edgecolor='face',
-                           facecolor=COLORS['land'], zorder=-1)
+                           facecolor=COLORS['land'])
 """Small scale (1:110m) land polygons, including major islands."""
 
 
 OCEAN = NaturalEarthFeature('physical', 'ocean', '110m',
                             edgecolor='face',
-                            facecolor=COLORS['water'], zorder=-1)
+                            facecolor=COLORS['water'])
 """Small scale (1:110m) ocean polygons."""
 
 

--- a/lib/cartopy/feature.py
+++ b/lib/cartopy/feature.py
@@ -300,14 +300,7 @@ class NaturalEarthFeature(Feature):
         If extent is None, the method returns all geometries for this dataset.
         """
         self.scaler.scale_from_extent(extent)
-
-        if extent is not None:
-            extent_geom = sgeom.box(extent[0], extent[2],
-                                    extent[1], extent[3])
-            return (geom for geom in self.geometries() if
-                    geom is not None and extent_geom.intersects(geom))
-        else:
-            return self.geometries()
+        return super(NaturalEarthFeature, self).intersecting_geometries(extent)
 
     def with_scale(self, new_scale):
         """

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -425,8 +425,8 @@ class GeoAxes(matplotlib.axes.Axes):
         ----------
         resolution
             A named resolution to use from the Natural Earth
-            dataset. Currently can be one of "110m", "50m", and "10m".
-            If set to 'auto', autoscaling is used.
+            dataset. Currently can be one of "110m", "50m", and "10m",
+            or a Scaler object.
 
         """
         kwargs['edgecolor'] = color

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -431,9 +431,11 @@ class GeoAxes(matplotlib.axes.Axes):
         """
         kwargs['edgecolor'] = color
         kwargs['facecolor'] = 'none'
-        feature = cartopy.feature.NaturalEarthFeature('physical', 'coastline',
-                                                      resolution, **kwargs)
-        return self.add_feature(feature)
+        feature = cartopy.feature.COASTLINE
+        if resolution != 'auto':
+            feature = feature.with_scale(resolution)
+
+        return self.add_feature(feature, **kwargs)
 
     def tissot(self, rad_km=500, lons=None, lats=None, n_samples=80, **kwargs):
         """

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -426,6 +426,7 @@ class GeoAxes(matplotlib.axes.Axes):
         resolution
             A named resolution to use from the Natural Earth
             dataset. Currently can be one of "110m", "50m", and "10m".
+            If set to 'auto', autoscaling is used.
 
         """
         kwargs['edgecolor'] = color

--- a/lib/cartopy/tests/test_features.py
+++ b/lib/cartopy/tests/test_features.py
@@ -46,11 +46,11 @@ class TestFeatures(object):
                                                    'a')
 
         assert autoscale_borders.scale == 'autoscale'
-        assert autoscale_borders.autoscale is True
+        assert autoscale_borders.autoscale
         assert a_coastline.scale == 'a'
-        assert a_coastline.autoscale is True
+        assert a_coastline.autoscale
         assert auto_land.scale == 'auto'
-        assert auto_land.autoscale is True
+        assert auto_land.autoscale
 
     def test_autoscale_default(self):
         # Check that autoscaling is not used by default.
@@ -68,11 +68,11 @@ class TestFeatures(object):
         assert cfeature.LAKES.scale == '110m'
         assert not cfeature.LAKES.autoscale
         assert ten_borders.scale == '10m'
-        assert ten_borders.autoscale is False
+        assert not ten_borders.autoscale
         assert fifty_coastline.scale == '50m'
-        assert fifty_coastline.autoscale is False
+        assert not fifty_coastline.autoscale
         assert hundredten_land.scale == '110m'
-        assert hundredten_land.autoscale is False
+        assert not hundredten_land.autoscale
 
     def test_scale_from_extent(self):
         # Check that _scale_from_extent produces the appropriate

--- a/lib/cartopy/tests/test_features.py
+++ b/lib/cartopy/tests/test_features.py
@@ -17,10 +17,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-import numpy as np
-import matplotlib.pyplot as plt
 import cartopy.feature as cfeature
-import cartopy.crs as ccrs
 
 small_extent = (-6, -8, 56, 59)
 medium_extent = (-20, 20, 20, 60)
@@ -42,18 +39,18 @@ class TestFeatures(object):
         # Check that autoscale variants can be passed as the scale
         # argument
         autoscale_borders = cfeature.NaturalEarthFeature(
-           'cultural', 'admin_0_boundary_lines_land',
-           'autoscale')
+                                   'cultural', 'admin_0_boundary_lines_land',
+                                   'autoscale')
 
         a_coastline = cfeature.NaturalEarthFeature('physical', 'coastline',
-                                             'a')
+                                                   'a')
 
         assert autoscale_borders.scale == 'autoscale'
-        assert autoscale_borders.autoscale == True
+        assert autoscale_borders.autoscale is True
         assert a_coastline.scale == 'a'
-        assert a_coastline.autoscale == True
+        assert a_coastline.autoscale is True
         assert auto_land.scale == 'auto'
-        assert auto_land.autoscale == True
+        assert auto_land.autoscale is True
 
     def test_autoscale_default(self):
         # Check that autoscaling is not used by default.
@@ -69,13 +66,13 @@ class TestFeatures(object):
                                                        '110m')
 
         assert cfeature.LAKES.scale == '110m'
-        assert cfeature.LAKES.autoscale == False
+        assert not cfeature.LAKES.autoscale
         assert ten_borders.scale == '10m'
-        assert ten_borders.autoscale == False
+        assert ten_borders.autoscale is False
         assert fifty_coastline.scale == '50m'
-        assert fifty_coastline.autoscale == False
+        assert fifty_coastline.autoscale is False
         assert hundredten_land.scale == '110m'
-        assert hundredten_land.autoscale == False
+        assert hundredten_land.autoscale is False
 
     def test_scale_from_extent(self):
         # Check that _scale_from_extent produces the appropriate

--- a/lib/cartopy/tests/test_features.py
+++ b/lib/cartopy/tests/test_features.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017-2018, Met Office
+# (C) British Crown Copyright 2017 - 2018, Met Office
 #
 # This file is part of cartopy.
 #

--- a/lib/cartopy/tests/test_features.py
+++ b/lib/cartopy/tests/test_features.py
@@ -17,14 +17,91 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+import numpy as np
+import matplotlib.pyplot as plt
 import cartopy.feature as cfeature
+import cartopy.crs as ccrs
 
+small_extent = (-6, -8, 56, 59)
+medium_extent = (-20, 20, 20, 60)
+large_extent = (-40, 40, 0, 80)
+
+auto_land = cfeature.NaturalEarthFeature('physical', 'land', 'auto')
 
 class TestFeatures(object):
     def test_change_scale(self):
-        # Check that features can easily be retrieved with a different scale.
+        # Check that features can easily be retrieved with a different
+        # scale.
         new_lakes = cfeature.LAKES.with_scale('10m')
         assert new_lakes.scale == '10m'
         assert new_lakes.kwargs == cfeature.LAKES.kwargs
         assert new_lakes.category == cfeature.LAKES.category
         assert new_lakes.name == cfeature.LAKES.name
+
+    def test_autoscale_keyword(self):
+        # Check that autoscale variants can be passed as the scale
+        # argument
+        autoscale_borders = cfeature.NaturalEarthFeature(
+           'cultural', 'admin_0_boundary_lines_land',
+           'autoscale')
+
+        a_coastline = cfeature.NaturalEarthFeature('physical', 'coastline',
+                                             'a')
+
+        assert autoscale_borders.scale == 'autoscale'
+        assert autoscale_borders.autoscale == True
+        assert a_coastline.scale == 'a'
+        assert a_coastline.autoscale == True
+        assert auto_land.scale == 'auto'
+        assert auto_land.autoscale == True
+
+    def test_autoscale_default(self):
+        # Check that autoscaling is not used by default.
+        ten_borders = cfeature.NaturalEarthFeature(
+           'cultural', 'admin_0_boundary_lines_land',
+           '10m')
+
+        fifty_coastline = cfeature.NaturalEarthFeature('physical',
+                                                       'coastline',
+                                                       '50m')
+
+        hundredten_land = cfeature.NaturalEarthFeature('physical', 'land',
+                                                       '110m')
+
+        assert cfeature.LAKES.scale == '110m'
+        assert cfeature.LAKES.autoscale == False
+        assert ten_borders.scale == '10m'
+        assert ten_borders.autoscale == False
+        assert fifty_coastline.scale == '50m'
+        assert fifty_coastline.autoscale == False
+        assert hundredten_land.scale == '110m'
+        assert hundredten_land.autoscale == False
+
+    def test_scale_from_extent(self):
+        # Check that _scale_from_extent produces the appropriate
+        # scales.
+        small_scale = auto_land._scale_from_extent(small_extent)
+        medium_scale = auto_land._scale_from_extent(medium_extent)
+        large_scale = auto_land._scale_from_extent(large_extent)
+        assert auto_land.scale == 'auto'
+        assert small_scale == '10m'
+        assert medium_scale == '50m'
+        assert large_scale == '110m'
+
+    def test_intersecting_geometries_small(self):
+        # Check that intersecting_geometries will set the scale to
+        # '10m' when the extent is small and autoscale is True.
+        auto_land.intersecting_geometries(small_extent)
+        assert auto_land.scale == '10m'
+
+    def test_intersecting_geometries_medium(self):
+        # Check that intersecting_geometries will set the scale to
+        # '50m' when the extent is medium and autoscale is True.
+        auto_land.intersecting_geometries(medium_extent)
+        assert auto_land.scale == '50m'
+
+    def test_intersecting_geometries_large(self):
+        # Check that intersecting_geometries will set the scale to
+        # '110m' when the extent is large and autoscale is True.
+        auto_land.intersecting_geometries(large_extent)
+        assert auto_land.scale == '110m'

--- a/lib/cartopy/tests/test_features.py
+++ b/lib/cartopy/tests/test_features.py
@@ -23,7 +23,10 @@ small_extent = (-6, -8, 56, 59)
 medium_extent = (-20, 20, 20, 60)
 large_extent = (-40, 40, 0, 80)
 
-auto_land = cfeature.NaturalEarthFeature('physical', 'land', 'auto')
+auto_scaler = cfeature.AdaptiveScaler('110m', (('50m', 50), ('10m', 15)))
+
+auto_land = cfeature.NaturalEarthFeature('physical', 'land', auto_scaler)
+
 
 class TestFeatures(object):
     def test_change_scale(self):
@@ -35,52 +38,12 @@ class TestFeatures(object):
         assert new_lakes.category == cfeature.LAKES.category
         assert new_lakes.name == cfeature.LAKES.name
 
-    def test_autoscale_keyword(self):
-        # Check that autoscale variants can be passed as the scale
-        # argument
-        autoscale_borders = cfeature.NaturalEarthFeature(
-                                   'cultural', 'admin_0_boundary_lines_land',
-                                   'autoscale')
-
-        a_coastline = cfeature.NaturalEarthFeature('physical', 'coastline',
-                                                   'a')
-
-        assert autoscale_borders.scale == 'autoscale'
-        assert autoscale_borders.autoscale
-        assert a_coastline.scale == 'a'
-        assert a_coastline.autoscale
-        assert auto_land.scale == 'auto'
-        assert auto_land.autoscale
-
-    def test_autoscale_default(self):
-        # Check that autoscaling is not used by default.
-        ten_borders = cfeature.NaturalEarthFeature(
-           'cultural', 'admin_0_boundary_lines_land',
-           '10m')
-
-        fifty_coastline = cfeature.NaturalEarthFeature('physical',
-                                                       'coastline',
-                                                       '50m')
-
-        hundredten_land = cfeature.NaturalEarthFeature('physical', 'land',
-                                                       '110m')
-
-        assert cfeature.LAKES.scale == '110m'
-        assert not cfeature.LAKES.autoscale
-        assert ten_borders.scale == '10m'
-        assert not ten_borders.autoscale
-        assert fifty_coastline.scale == '50m'
-        assert not fifty_coastline.autoscale
-        assert hundredten_land.scale == '110m'
-        assert not hundredten_land.autoscale
-
     def test_scale_from_extent(self):
-        # Check that _scale_from_extent produces the appropriate
+        # Check that scaler.scale_from_extent returns the appropriate
         # scales.
-        small_scale = auto_land._scale_from_extent(small_extent)
-        medium_scale = auto_land._scale_from_extent(medium_extent)
-        large_scale = auto_land._scale_from_extent(large_extent)
-        assert auto_land.scale == 'auto'
+        small_scale = auto_land.scaler.scale_from_extent(small_extent)
+        medium_scale = auto_land.scaler.scale_from_extent(medium_extent)
+        large_scale = auto_land.scaler.scale_from_extent(large_extent)
         assert small_scale == '10m'
         assert medium_scale == '50m'
         assert large_scale == '110m'

--- a/lib/cartopy/tests/test_features.py
+++ b/lib/cartopy/tests/test_features.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017, Met Office
+# (C) British Crown Copyright 2018, Met Office
 #
 # This file is part of cartopy.
 #

--- a/lib/cartopy/tests/test_features.py
+++ b/lib/cartopy/tests/test_features.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2018, Met Office
+# (C) British Crown Copyright 2017-2018, Met Office
 #
 # This file is part of cartopy.
 #


### PR DESCRIPTION
Continuation of `Enable automatic scaling for NaturalEarthFeatures` - PR #983.

## Rationale
When creating a plot it would be good to choose whether the scale of NaturalEarthFeatures (e.g. coastlines) changes automatically based on the extent of the axes. This PR adds such an option.

## Implications
This does not change any current behaviour but provides the option to use adaptive scalers if required. This was done by adding Scaler and AdaptiveScaler classes to `cartopy.feature`.