### PR TITLE
Add all 60 zones of the UTM projection to the docs projection list

### DIFF
--- a/docs/make_projection.py
+++ b/docs/make_projection.py
@@ -27,7 +27,7 @@ import cartopy.crs as ccrs
 SPECIAL_CASES = {
     ccrs.PlateCarree: [{}, {'central_longitude': 180}],
     ccrs.RotatedPole: [{'pole_longitude': 177.5, 'pole_latitude': 37.5}],
-    ccrs.UTM: [{'zone': 30}],
+    ccrs.UTM: [{'zone': 30}, {'zone': 50}],
     ccrs.AzimuthalEquidistant: [{'central_latitude': 90}],
     ccrs.NearsidePerspective: [{
         'central_longitude': -3.53, 'central_latitude': 50.72,

--- a/docs/make_projection.py
+++ b/docs/make_projection.py
@@ -27,7 +27,7 @@ import cartopy.crs as ccrs
 SPECIAL_CASES = {
     ccrs.PlateCarree: [{}, {'central_longitude': 180}],
     ccrs.RotatedPole: [{'pole_longitude': 177.5, 'pole_latitude': 37.5}],
-    ccrs.UTM: [{'zone': 30}, {'zone': 50}],
+    ccrs.UTM: [{'zone': 30}],
     ccrs.AzimuthalEquidistant: [{'central_latitude': 90}],
     ccrs.NearsidePerspective: [{
         'central_longitude': -3.53, 'central_latitude': 50.72,
@@ -91,19 +91,37 @@ if __name__ == '__main__':
         table.write('.. autoclass:: cartopy.crs.%s\n' % name)
 
         for instance_args in SPECIAL_CASES.get(prj, [{}]):
-            prj_inst = prj(**instance_args)
-            aspect = (np.diff(prj_inst.x_limits) /
-                      np.diff(prj_inst.y_limits))[0]
-            width = 3 * aspect
-            width = '{:.4f}'.format(width).rstrip('0').rstrip('.')
+            if name is "UTM":
+                code = """
+.. plot::
 
-            instance_params = ',\n        '.join(
-                '{}={}'.format(k, v)
-                for k, v in sorted(instance_args.items()))
-            if instance_params:
-                instance_params = '\n        ' + instance_params
-            instance_creation_code = '{}({})'.format(name, instance_params)
-            code = """
+    import matplotlib.pyplot as plt
+    import cartopy.crs as ccrs
+    zones = range(1, 61)
+    fig = plt.figure(figsize=(10, 3))
+    for zone in zones:
+        ax = fig.add_subplot(1, len(zones), zone,
+                             projection=ccrs.UTM(zone=zone,
+                                                 southern_hemisphere=True))
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
+
+\n"""
+
+            else:
+                prj_inst = prj(**instance_args)
+                aspect = (np.diff(prj_inst.x_limits) /
+                          np.diff(prj_inst.y_limits))[0]
+                width = 3 * aspect
+                width = '{:.4f}'.format(width).rstrip('0').rstrip('.')
+
+                instance_params = ',\n        '.join(
+                    '{}={}'.format(k, v)
+                    for k, v in sorted(instance_args.items()))
+                if instance_params:
+                    instance_params = '\n        ' + instance_params
+                instance_creation_code = '{}({})'.format(name, instance_params)
+                code = """
 .. plot::
 
     import matplotlib.pyplot as plt

--- a/docs/make_projection.py
+++ b/docs/make_projection.py
@@ -27,7 +27,7 @@ import cartopy.crs as ccrs
 SPECIAL_CASES = {
     ccrs.PlateCarree: [{}, {'central_longitude': 180}],
     ccrs.RotatedPole: [{'pole_longitude': 177.5, 'pole_latitude': 37.5}],
-    ccrs.UTM: [{'zone': 30}, {'zone': 50}],
+    ccrs.UTM: [{'zone': 30}],
     ccrs.AzimuthalEquidistant: [{'central_latitude': 90}],
     ccrs.NearsidePerspective: [{
         'central_longitude': -3.53, 'central_latitude': 50.72,

--- a/docs/source/crs/projections.rst
+++ b/docs/source/crs/projections.rst
@@ -9,7 +9,6 @@
 Cartopy projection list
 =======================
 
-
 PlateCarree
 -----------
 
@@ -20,14 +19,19 @@ PlateCarree
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 3)
-    fig = plt.figure(figsize=(12, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
+    fig = plt.figure(figsize=(10, 3))
+
+    def plate_carree_plot(i, nplots):
+        central_longitude = 0 if i == 1 else 180
+        ax = fig.add_subplot(1, nplots-1, i,
                              projection=ccrs.PlateCarree(
-                             central_longitude=180*plot)
+                             central_longitude=central_longitude))
         ax.coastlines(resolution='110m')
         ax.gridlines()
+
+
+    for i in range(1, 3):
+        plate_carree_plot(i, 3)
 
 
 AlbersEqualArea
@@ -40,13 +44,10 @@ AlbersEqualArea
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(5.1299, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.AlbersEqualArea()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(5.1299, 3))
+    ax = plt.axes(projection=ccrs.AlbersEqualArea())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 AzimuthalEquidistant
@@ -59,14 +60,11 @@ AzimuthalEquidistant
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(3, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.AzimuthalEquidistant(
-                             central_latitude=90)
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(3, 3))
+    ax = plt.axes(projection=ccrs.AzimuthalEquidistant(
+                             central_latitude=90))
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 LambertConformal
@@ -79,13 +77,10 @@ LambertConformal
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(4.2897, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.LambertConformal()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(4.2897, 3))
+    ax = plt.axes(projection=ccrs.LambertConformal())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 LambertCylindrical
@@ -98,13 +93,10 @@ LambertCylindrical
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(9.4248, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.LambertCylindrical()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(9.4248, 3))
+    ax = plt.axes(projection=ccrs.LambertCylindrical())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 Mercator
@@ -117,13 +109,10 @@ Mercator
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(3.5091, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.Mercator()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(3.5091, 3))
+    ax = plt.axes(projection=ccrs.Mercator())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 Miller
@@ -136,13 +125,10 @@ Miller
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(4.0915, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.Miller()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(4.0915, 3))
+    ax = plt.axes(projection=ccrs.Miller())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 Mollweide
@@ -155,13 +141,10 @@ Mollweide
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(6, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.Mollweide()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(6, 3))
+    ax = plt.axes(projection=ccrs.Mollweide())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 Orthographic
@@ -174,13 +157,10 @@ Orthographic
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(3, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.Orthographic()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(3, 3))
+    ax = plt.axes(projection=ccrs.Orthographic())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 Robinson
@@ -193,13 +173,10 @@ Robinson
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(5.915, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.Robinson()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(5.915, 3))
+    ax = plt.axes(projection=ccrs.Robinson())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 Sinusoidal
@@ -212,13 +189,10 @@ Sinusoidal
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(6.0101, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.Sinusoidal()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(6.0101, 3))
+    ax = plt.axes(projection=ccrs.Sinusoidal())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 Stereographic
@@ -231,13 +205,10 @@ Stereographic
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(3, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.Stereographic()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(3, 3))
+    ax = plt.axes(projection=ccrs.Stereographic())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 TransverseMercator
@@ -250,13 +221,10 @@ TransverseMercator
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(6, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.TransverseMercator()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(6, 3))
+    ax = plt.axes(projection=ccrs.TransverseMercator())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 UTM
@@ -269,14 +237,17 @@ UTM
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 61)
-    fig = plt.figure(figsize=(7.7143, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.UTM(
-                             zone=plot)
+    fig = plt.figure(figsize=(10, 3))
+
+    def utm_plot(i, nplots):
+        ax = fig.add_subplot(1, nplots-1, i,
+                             projection=ccrs.UTM(zone=i, southern_hemisphere=True))
         ax.coastlines(resolution='110m')
         ax.gridlines()
+
+
+    for i in range(1, 61):
+        utm_plot(i, 61)
 
 
 InterruptedGoodeHomolosine
@@ -289,13 +260,10 @@ InterruptedGoodeHomolosine
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(6.9228, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.InterruptedGoodeHomolosine()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(6.9228, 3))
+    ax = plt.axes(projection=ccrs.InterruptedGoodeHomolosine())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 RotatedPole
@@ -308,15 +276,12 @@ RotatedPole
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(6, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.RotatedPole(
+    plt.figure(figsize=(6, 3))
+    ax = plt.axes(projection=ccrs.RotatedPole(
                              pole_latitude=37.5,
-                             pole_longitude=177.5)
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+                             pole_longitude=177.5))
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 OSGB
@@ -329,13 +294,10 @@ OSGB
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(1.6154, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.OSGB()
-        ax.coastlines(resolution='50m')
-        ax.gridlines()
+    plt.figure(figsize=(1.6154, 3))
+    ax = plt.axes(projection=ccrs.OSGB())
+    ax.coastlines(resolution='50m')
+    ax.gridlines()
 
 
 EuroPP
@@ -348,13 +310,10 @@ EuroPP
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(2.6154, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.EuroPP()
-        ax.coastlines(resolution='50m')
-        ax.gridlines()
+    plt.figure(figsize=(2.6154, 3))
+    ax = plt.axes(projection=ccrs.EuroPP())
+    ax.coastlines(resolution='50m')
+    ax.gridlines()
 
 
 Geostationary
@@ -367,13 +326,10 @@ Geostationary
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(3, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.Geostationary()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(3, 3))
+    ax = plt.axes(projection=ccrs.Geostationary())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 NearsidePerspective
@@ -386,16 +342,13 @@ NearsidePerspective
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(3, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.NearsidePerspective(
+    plt.figure(figsize=(3, 3))
+    ax = plt.axes(projection=ccrs.NearsidePerspective(
                              central_latitude=50.72,
                              central_longitude=-3.53,
-                             satellite_height=10000000.0)
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+                             satellite_height=10000000.0))
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 Gnomonic
@@ -408,13 +361,10 @@ Gnomonic
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(3, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.Gnomonic()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(3, 3))
+    ax = plt.axes(projection=ccrs.Gnomonic())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 LambertAzimuthalEqualArea
@@ -427,13 +377,10 @@ LambertAzimuthalEqualArea
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(3.0066, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.LambertAzimuthalEqualArea()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(3.0066, 3))
+    ax = plt.axes(projection=ccrs.LambertAzimuthalEqualArea())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 NorthPolarStereo
@@ -446,13 +393,10 @@ NorthPolarStereo
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(3, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.NorthPolarStereo()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(3, 3))
+    ax = plt.axes(projection=ccrs.NorthPolarStereo())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 
 OSNI
@@ -465,13 +409,10 @@ OSNI
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(2.4323, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.OSNI()
-        ax.coastlines(resolution='10m')
-        ax.gridlines()
+    plt.figure(figsize=(2.4323, 3))
+    ax = plt.axes(projection=ccrs.OSNI())
+    ax.coastlines(resolution='10m')
+    ax.gridlines()
 
 
 SouthPolarStereo
@@ -484,12 +425,9 @@ SouthPolarStereo
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plots = range(1, 2)
-    fig = plt.figure(figsize=(3, 3))
-    for plot in plots:
-        ax = fig.add_subplot(1, len(plots), plot,
-                             projection=ccrs.SouthPolarStereo()
-        ax.coastlines(resolution='110m')
-        ax.gridlines()
+    plt.figure(figsize=(3, 3))
+    ax = plt.axes(projection=ccrs.SouthPolarStereo())
+    ax.coastlines(resolution='110m')
+    ax.gridlines()
 
 

--- a/docs/source/crs/projections.rst
+++ b/docs/source/crs/projections.rst
@@ -241,12 +241,14 @@ UTM
 
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
-
-    plt.figure(figsize=(0.1286, 3))
-    ax = plt.axes(projection=ccrs.UTM(
-        zone=30))
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    zones = range(1, 61)
+    fig = plt.figure(figsize=(10, 3))
+    for zone in zones:
+        ax = fig.add_subplot(1, len(zones), zone,
+                             projection=ccrs.UTM(zone=zone,
+                                                 southern_hemisphere=True))
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 InterruptedGoodeHomolosine

--- a/docs/source/crs/projections.rst
+++ b/docs/source/crs/projections.rst
@@ -20,23 +20,14 @@ PlateCarree
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(6, 3))
-    ax = plt.axes(projection=ccrs.PlateCarree())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
-
-
-
-.. plot::
-
-    import matplotlib.pyplot as plt
-    import cartopy.crs as ccrs
-
-    plt.figure(figsize=(6, 3))
-    ax = plt.axes(projection=ccrs.PlateCarree(
-        central_longitude=180))
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 3)
+    fig = plt.figure(figsize=(12, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.PlateCarree(
+                             central_longitude=180*plot)
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 AlbersEqualArea
@@ -49,10 +40,13 @@ AlbersEqualArea
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(5.1299, 3))
-    ax = plt.axes(projection=ccrs.AlbersEqualArea())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(5.1299, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.AlbersEqualArea()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 AzimuthalEquidistant
@@ -65,11 +59,14 @@ AzimuthalEquidistant
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(3, 3))
-    ax = plt.axes(projection=ccrs.AzimuthalEquidistant(
-        central_latitude=90))
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(3, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.AzimuthalEquidistant(
+                             central_latitude=90)
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 LambertConformal
@@ -82,10 +79,13 @@ LambertConformal
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(4.2897, 3))
-    ax = plt.axes(projection=ccrs.LambertConformal())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(4.2897, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.LambertConformal()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 LambertCylindrical
@@ -98,10 +98,13 @@ LambertCylindrical
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(9.4248, 3))
-    ax = plt.axes(projection=ccrs.LambertCylindrical())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(9.4248, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.LambertCylindrical()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 Mercator
@@ -114,10 +117,13 @@ Mercator
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(3.5091, 3))
-    ax = plt.axes(projection=ccrs.Mercator())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(3.5091, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.Mercator()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 Miller
@@ -130,10 +136,13 @@ Miller
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(4.0915, 3))
-    ax = plt.axes(projection=ccrs.Miller())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(4.0915, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.Miller()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 Mollweide
@@ -146,10 +155,13 @@ Mollweide
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(6, 3))
-    ax = plt.axes(projection=ccrs.Mollweide())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(6, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.Mollweide()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 Orthographic
@@ -162,10 +174,13 @@ Orthographic
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(3, 3))
-    ax = plt.axes(projection=ccrs.Orthographic())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(3, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.Orthographic()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 Robinson
@@ -178,10 +193,13 @@ Robinson
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(5.915, 3))
-    ax = plt.axes(projection=ccrs.Robinson())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(5.915, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.Robinson()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 Sinusoidal
@@ -194,10 +212,13 @@ Sinusoidal
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(6.0101, 3))
-    ax = plt.axes(projection=ccrs.Sinusoidal())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(6.0101, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.Sinusoidal()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 Stereographic
@@ -210,10 +231,13 @@ Stereographic
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(3, 3))
-    ax = plt.axes(projection=ccrs.Stereographic())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(3, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.Stereographic()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 TransverseMercator
@@ -226,10 +250,13 @@ TransverseMercator
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(6, 3))
-    ax = plt.axes(projection=ccrs.TransverseMercator())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(6, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.TransverseMercator()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 UTM
@@ -241,12 +268,13 @@ UTM
 
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
-    zones = range(1, 61)
-    fig = plt.figure(figsize=(10, 3))
-    for zone in zones:
-        ax = fig.add_subplot(1, len(zones), zone,
-                             projection=ccrs.UTM(zone=zone,
-                                                 southern_hemisphere=True))
+
+    plots = range(1, 61)
+    fig = plt.figure(figsize=(7.7143, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.UTM(
+                             zone=plot)
         ax.coastlines(resolution='110m')
         ax.gridlines()
 
@@ -261,10 +289,13 @@ InterruptedGoodeHomolosine
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(6.9228, 3))
-    ax = plt.axes(projection=ccrs.InterruptedGoodeHomolosine())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(6.9228, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.InterruptedGoodeHomolosine()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 RotatedPole
@@ -277,12 +308,15 @@ RotatedPole
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(6, 3))
-    ax = plt.axes(projection=ccrs.RotatedPole(
-        pole_latitude=37.5,
-        pole_longitude=177.5))
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(6, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.RotatedPole(
+                             pole_latitude=37.5,
+                             pole_longitude=177.5)
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 OSGB
@@ -295,10 +329,13 @@ OSGB
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(1.6154, 3))
-    ax = plt.axes(projection=ccrs.OSGB())
-    ax.coastlines(resolution='50m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(1.6154, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.OSGB()
+        ax.coastlines(resolution='50m')
+        ax.gridlines()
 
 
 EuroPP
@@ -311,10 +348,13 @@ EuroPP
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(2.6154, 3))
-    ax = plt.axes(projection=ccrs.EuroPP())
-    ax.coastlines(resolution='50m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(2.6154, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.EuroPP()
+        ax.coastlines(resolution='50m')
+        ax.gridlines()
 
 
 Geostationary
@@ -327,10 +367,13 @@ Geostationary
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(3, 3))
-    ax = plt.axes(projection=ccrs.Geostationary())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(3, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.Geostationary()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 NearsidePerspective
@@ -343,13 +386,16 @@ NearsidePerspective
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(3, 3))
-    ax = plt.axes(projection=ccrs.NearsidePerspective(
-        central_latitude=50.72,
-        central_longitude=-3.53,
-        satellite_height=10000000.0))
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(3, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.NearsidePerspective(
+                             central_latitude=50.72,
+                             central_longitude=-3.53,
+                             satellite_height=10000000.0)
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 Gnomonic
@@ -362,10 +408,13 @@ Gnomonic
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(3, 3))
-    ax = plt.axes(projection=ccrs.Gnomonic())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(3, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.Gnomonic()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 LambertAzimuthalEqualArea
@@ -378,10 +427,13 @@ LambertAzimuthalEqualArea
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(3.0066, 3))
-    ax = plt.axes(projection=ccrs.LambertAzimuthalEqualArea())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(3.0066, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.LambertAzimuthalEqualArea()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 NorthPolarStereo
@@ -394,10 +446,13 @@ NorthPolarStereo
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(3, 3))
-    ax = plt.axes(projection=ccrs.NorthPolarStereo())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(3, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.NorthPolarStereo()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 
 OSNI
@@ -410,10 +465,13 @@ OSNI
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(2.4323, 3))
-    ax = plt.axes(projection=ccrs.OSNI())
-    ax.coastlines(resolution='10m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(2.4323, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.OSNI()
+        ax.coastlines(resolution='10m')
+        ax.gridlines()
 
 
 SouthPolarStereo
@@ -426,9 +484,12 @@ SouthPolarStereo
     import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
 
-    plt.figure(figsize=(3, 3))
-    ax = plt.axes(projection=ccrs.SouthPolarStereo())
-    ax.coastlines(resolution='110m')
-    ax.gridlines()
+    plots = range(1, 2)
+    fig = plt.figure(figsize=(3, 3))
+    for plot in plots:
+        ax = fig.add_subplot(1, len(plots), plot,
+                             projection=ccrs.SouthPolarStereo()
+        ax.coastlines(resolution='110m')
+        ax.gridlines()
 
 


### PR DESCRIPTION
## Rationale
In the projection list of the documentation the UTM projection is depicted using only one zone. It would be more informative to include all 60 zones of the projection in the list, side by side (similar to the example added in PR #954).

## Implications
Rewrites make_projection.py to include options for multiple subplots as well as single plots. Multiple subplots have been utilised for both PlateCarree and UTM projections.
Closes issue #956.