### PR TITLE
Utilise AdaptiveScalar in default NaturalEarthFeatures

### DIFF
--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -480,41 +480,43 @@ auto_scaler = AdaptiveScaler('110m', (('50m', 50), ('10m', 15)))
 degrees."""
 
 
-BORDERS = NaturalEarthFeature('cultural', 'admin_0_boundary_lines_land',
-                              auto_scaler, edgecolor='black', facecolor='never')
+BORDERS = NaturalEarthFeature(
+    'cultural', 'admin_0_boundary_lines_land',
+    auto_scaler, edgecolor='black', facecolor='never')
 """Automatically scaled country boundaries."""
 
 
-STATES = NaturalEarthFeature('cultural', 'admin_1_states_provinces_lakes',
-                             auto_scaler, edgecolor='black', facecolor='none')
+STATES = NaturalEarthFeature(
+    'cultural', 'admin_1_states_provinces_lakes',
+    auto_scaler, edgecolor='black', facecolor='none')
 """Automatically scaled state and province boundaries."""
 
 
-COASTLINE = NaturalEarthFeature('physical', 'coastline', auto_scaler,
-                                edgecolor='black', facecolor='never')
+COASTLINE = NaturalEarthFeature(
+    'physical', 'coastline', auto_scaler,
+    edgecolor='black', facecolor='never')
 """Automatically scaled coastline, including major islands."""
 
 
-LAKES = NaturalEarthFeature('physical', 'lakes', auto_scaler,
-                            edgecolor='face',
-                            facecolor=COLORS['water'])
+LAKES = NaturalEarthFeature(
+    'physical', 'lakes', auto_scaler,
+    edgecolor='face', facecolor=COLORS['water'])
 """Automatically scaled natural and artificial lakes."""
 
 
-LAND = NaturalEarthFeature('physical', 'land', auto_scaler,
-                           edgecolor='face',
-                           facecolor=COLORS['land'], zorder=-1)
+LAND = NaturalEarthFeature(
+    'physical', 'land', auto_scaler,
+    edgecolor='face', facecolor=COLORS['land'], zorder=-1)
 """Automatically scaled land polygons, including major islands."""
 
 
-OCEAN = NaturalEarthFeature('physical', 'ocean', auto_scaler,
-                            edgecolor='face',
-                            facecolor=COLORS['water'], zorder=-1)
+OCEAN = NaturalEarthFeature(
+    'physical', 'ocean', auto_scaler,
+    edgecolor='face', facecolor=COLORS['water'], zorder=-1)
 """Automatically scaled ocean polygons."""
 
 
-RIVERS = NaturalEarthFeature('physical', 'rivers_lake_centerlines',
-                             auto_scaler,
-                             edgecolor=COLORS['water'],
-                             facecolor='never')
+RIVERS = NaturalEarthFeature(
+    'physical', 'rivers_lake_centerlines', auto_scaler,
+    edgecolor=COLORS['water'], facecolor='never')
 """Automatically scaled single-line drainages, including lake centerlines."""

--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -474,38 +474,47 @@ class WFSFeature(Feature):
         return iter(geoms)
 
 
+auto_scaler = AdaptiveScaler('110m', (('50m', 50), ('10m', 15)))
+"""AdaptiveScaler for NaturalEarthFeature. Default scale is '110m'. 
+'110m' is used above 50 degrees, '50m' for 50-15 degrees and '10m' below 15 
+degrees."""
+
+
 BORDERS = NaturalEarthFeature('cultural', 'admin_0_boundary_lines_land',
-                              '110m', edgecolor='black', facecolor='never')
-"""Small scale (1:110m) country boundaries."""
+                              auto_scaler, edgecolor='black', facecolor='never')
+"""Automatically scaled country boundaries."""
+
 
 STATES = NaturalEarthFeature('cultural', 'admin_1_states_provinces_lakes',
-                             '110m', edgecolor='black', facecolor='none')
-"""Small scale (1:110m) state and province boundaries."""
+                             auto_scaler, edgecolor='black', facecolor='none')
+"""Automatically scaled state and province boundaries."""
 
-COASTLINE = NaturalEarthFeature('physical', 'coastline', '110m',
+
+COASTLINE = NaturalEarthFeature('physical', 'coastline', auto_scaler,
                                 edgecolor='black', facecolor='never')
-"""Small scale (1:110m) coastline, including major islands."""
+"""Automatically scaled coastline, including major islands."""
 
 
-LAKES = NaturalEarthFeature('physical', 'lakes', '110m',
+LAKES = NaturalEarthFeature('physical', 'lakes', auto_scaler,
                             edgecolor='face',
                             facecolor=COLORS['water'])
-"""Small scale (1:110m) natural and artificial lakes."""
+"""Automatically scaled natural and artificial lakes."""
 
 
-LAND = NaturalEarthFeature('physical', 'land', '110m',
+LAND = NaturalEarthFeature('physical', 'land', auto_scaler,
                            edgecolor='face',
                            facecolor=COLORS['land'], zorder=-1)
-"""Small scale (1:110m) land polygons, including major islands."""
+"""Automatically scaled land polygons, including major islands."""
 
 
-OCEAN = NaturalEarthFeature('physical', 'ocean', '110m',
+OCEAN = NaturalEarthFeature('physical', 'ocean', auto_scaler,
                             edgecolor='face',
                             facecolor=COLORS['water'], zorder=-1)
-"""Small scale (1:110m) ocean polygons."""
+"""Automatically scaled ocean polygons."""
 
 
-RIVERS = NaturalEarthFeature('physical', 'rivers_lake_centerlines', '110m',
+RIVERS = NaturalEarthFeature('physical', 'rivers_lake_centerlines',
+                             auto_scaler,
                              edgecolor=COLORS['water'],
                              facecolor='never')
-"""Small scale (1:110m) single-line drainages, including lake centerlines."""
+"""Automatically scaled single-line drainages, including lake centerlines."""

--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -475,8 +475,8 @@ class WFSFeature(Feature):
 
 
 auto_scaler = AdaptiveScaler('110m', (('50m', 50), ('10m', 15)))
-"""AdaptiveScaler for NaturalEarthFeature. Default scale is '110m'. 
-'110m' is used above 50 degrees, '50m' for 50-15 degrees and '10m' below 15 
+"""AdaptiveScaler for NaturalEarthFeature. Default scale is '110m'.
+'110m' is used above 50 degrees, '50m' for 50-15 degrees and '10m' below 15
 degrees."""
 
 

--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -1,19 +1,9 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# Copyright Cartopy Contributors
 #
-# This file is part of cartopy.
-#
-# cartopy is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cartopy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+# This file is part of Cartopy and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+
 """
 This module defines :class:`Feature` instances, for use with
 ax.add_feature().

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -1,19 +1,9 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# Copyright Cartopy Contributors
 #
-# This file is part of cartopy.
-#
-# cartopy is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cartopy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+# This file is part of Cartopy and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+
 """
 This module defines the :class:`FeatureArtist` class, for drawing
 :class:`Feature` instances with matplotlib.

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1,19 +1,9 @@
-# (C) British Crown Copyright 2011 - 2020, Met Office
+# Copyright Cartopy Contributors
 #
-# This file is part of cartopy.
-#
-# cartopy is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cartopy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+# This file is part of Cartopy and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+
 """
 This module defines the :class:`GeoAxes` class, for use with matplotlib.
 

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -533,7 +533,7 @@ class GeoAxes(matplotlib.axes.Axes):
         return u'%.4g, %.4g (%f\u00b0%s, %f\u00b0%s)' % (x, y, abs(lat),
                                                          ns, abs(lon), ew)
 
-    def coastlines(self, resolution='110m', color='black', **kwargs):
+    def coastlines(self, resolution='auto', color='black', **kwargs):
         """
         Add coastal **outlines** to the current axes from the Natural Earth
         "coastline" shapefile collection.

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -540,15 +540,19 @@ class GeoAxes(matplotlib.axes.Axes):
 
         Parameters
         ----------
-        resolution
+        resolution : str or :class:`cartopy.feature.Scaler`, optional
             A named resolution to use from the Natural Earth
-            dataset. Currently can be one of "110m", "50m", and "10m",
-            or a Scaler object.
+            dataset. Currently can be one of "auto" (default), "110m", "50m",
+            and "10m", or a Scaler object.
 
         """
         kwargs['edgecolor'] = color
         kwargs['facecolor'] = 'none'
         feature = cartopy.feature.COASTLINE
+
+        # The coastline feature is automatically scaled by default, but for
+        # anything else, including custom scaler instances, create a new
+        # feature which derives from the default one.
         if resolution != 'auto':
             feature = feature.with_scale(resolution)
 

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# Copyright Cartopy Contributors
 #
-# This file is part of cartopy.
-#
-# cartopy is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cartopy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+# This file is part of Cartopy and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -71,41 +60,41 @@ def test_gridliner():
 
     ax = plt.subplot(nx, ny, 1, projection=ccrs.PlateCarree())
     ax.set_global()
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     ax.gridlines(linestyle=':')
 
     ax = plt.subplot(nx, ny, 2, projection=ccrs.OSGB(approx=False))
     ax.set_global()
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     ax.gridlines(linestyle=':')
 
     ax = plt.subplot(nx, ny, 3, projection=ccrs.OSGB(approx=False))
     ax.set_global()
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     ax.gridlines(ccrs.PlateCarree(), color='blue', linestyle='-')
     ax.gridlines(ccrs.OSGB(approx=False), linestyle=':')
 
     ax = plt.subplot(nx, ny, 4, projection=ccrs.PlateCarree())
     ax.set_global()
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     ax.gridlines(ccrs.NorthPolarStereo(), alpha=0.5,
                  linewidth=1.5, linestyle='-')
 
     ax = plt.subplot(nx, ny, 5, projection=ccrs.PlateCarree())
     ax.set_global()
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     osgb = ccrs.OSGB(approx=False)
     ax.set_extent(tuple(osgb.x_limits) + tuple(osgb.y_limits), crs=osgb)
     ax.gridlines(osgb, linestyle=':')
 
     ax = plt.subplot(nx, ny, 6, projection=ccrs.NorthPolarStereo())
     ax.set_global()
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     ax.gridlines(alpha=0.5, linewidth=1.5, linestyle='-')
 
     ax = plt.subplot(nx, ny, 7, projection=ccrs.NorthPolarStereo())
     ax.set_global()
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     osgb = ccrs.OSGB(approx=False)
     ax.set_extent(tuple(osgb.x_limits) + tuple(osgb.y_limits), crs=osgb)
     ax.gridlines(osgb, linestyle=':')
@@ -113,7 +102,7 @@ def test_gridliner():
     ax = plt.subplot(nx, ny, 8,
                      projection=ccrs.Robinson(central_longitude=135))
     ax.set_global()
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     ax.gridlines(ccrs.PlateCarree(), alpha=0.5, linewidth=1.5, linestyle='-')
 
     delta = 1.5e-2
@@ -184,14 +173,14 @@ def test_grid_labels():
     crs_merc = ccrs.Mercator()
 
     ax = fig.add_subplot(3, 2, 1, projection=crs_pc)
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     ax.gridlines(draw_labels=True)
 
     # Check that adding labels to Mercator gridlines gives an error.
     # (Currently can only label PlateCarree gridlines.)
     ax = fig.add_subplot(3, 2, 2,
                          projection=ccrs.PlateCarree(central_longitude=180))
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
 
     ax.set_title('Known bug')
     gl = ax.gridlines(crs=crs_pc, draw_labels=True)
@@ -200,12 +189,12 @@ def test_grid_labels():
     gl.xlines = False
 
     ax = fig.add_subplot(3, 2, 3, projection=crs_merc)
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     gl = ax.gridlines(draw_labels=True)
     gl.xlabel_style = gl.ylabel_style = {'size': 9}
 
     ax = plt.subplot(3, 2, 4, projection=crs_pc)
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     gl = ax.gridlines(
         crs=crs_pc, linewidth=2, color='gray', alpha=0.5, linestyle=':')
     gl.bottom_labels = True
@@ -231,12 +220,12 @@ def test_grid_labels():
 
     ax = fig.add_subplot(3, 2, 5, projection=crs_pc)
     ax.set_extent([-20, 10.0, 45.0, 70.0])
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     ax.gridlines(draw_labels=True)
 
     ax = fig.add_subplot(3, 2, 6, projection=crs_merc)
     ax.set_extent([-20, 10.0, 45.0, 70.0], crs=crs_pc)
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     gl = ax.gridlines(draw_labels=True)
     gl.rotate_labels = False
     gl.xlabel_style = gl.ylabel_style = {'size': 9}
@@ -263,7 +252,7 @@ def test_grid_labels_inline():
             ax.gridlines()
         else:
             ax.gridlines(draw_labels=True, auto_inline=True)
-        ax.coastlines()
+        ax.coastlines(resolution="110m")
         ax.set_title(proj, y=1.075)
     plt.subplots_adjust(wspace=0.35, hspace=0.35)
 
@@ -297,5 +286,5 @@ def test_grid_labels_inline_usa():
             ax.gridlines()
         else:
             ax.gridlines(draw_labels=True, auto_inline=True, clip_on=True)
-        ax.coastlines()
+        ax.coastlines(resolution="110m")
     plt.subplots_adjust(wspace=0.35, hspace=0.35)

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2011 - 2020, Met Office
+# Copyright Cartopy Contributors
 #
-# This file is part of cartopy.
-#
-# cartopy is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cartopy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+# This file is part of Cartopy and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -198,7 +187,7 @@ def test_multiple_projections():
 
         ax.set_global()
 
-        ax.coastlines()
+        ax.coastlines(resolution="110m")
 
         plt.plot(-0.08, 51.53, 'o', transform=ccrs.PlateCarree())
 
@@ -472,7 +461,7 @@ def test_quiver_plate_carree():
     # plot on native projection
     ax = plt.subplot(211, projection=ccrs.PlateCarree())
     ax.set_extent(plot_extent, crs=ccrs.PlateCarree())
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     ax.quiver(x, y, u, v, mag)
     # plot on a different projection
     ax = plt.subplot(212, projection=ccrs.NorthPolarStereo())
@@ -556,12 +545,12 @@ def test_barbs():
     # plot on native projection
     ax = plt.subplot(211, projection=ccrs.PlateCarree())
     ax.set_extent(plot_extent, crs=ccrs.PlateCarree())
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     ax.barbs(x, y, u, v, length=4, linewidth=.25)
     # plot on a different projection
     ax = plt.subplot(212, projection=ccrs.NorthPolarStereo())
     ax.set_extent(plot_extent, crs=ccrs.PlateCarree())
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     ax.barbs(x, y, u, v, transform=ccrs.PlateCarree(), length=4, linewidth=.25)
 
 
@@ -614,7 +603,7 @@ def test_barbs_1d():
     plt.figure(figsize=(6, 5))
     ax = plt.axes(projection=ccrs.PlateCarree())
     ax.set_extent(plot_extent, crs=ccrs.PlateCarree())
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
     ax.barbs(x, y, u, v, transform=ccrs.PlateCarree(),
              length=8, linewidth=1, color='#7f7f7f')
 

--- a/lib/cartopy/tests/mpl/test_shapely_to_mpl.py
+++ b/lib/cartopy/tests/mpl/test_shapely_to_mpl.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2011 - 2018, Met Office
+# Copyright Cartopy Contributors
 #
-# This file is part of cartopy.
-#
-# cartopy is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cartopy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+# This file is part of Cartopy and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -67,7 +56,7 @@ def test_polygon_interiors():
     # test multiple interior polygons
     ax = plt.subplot(212, projection=ccrs.PlateCarree(),
                      xlim=[-5, 15], ylim=[-5, 15])
-    ax.coastlines()
+    ax.coastlines(resolution="110m")
 
     exterior = np.array(sgeom.box(0, 0, 12, 12).exterior.coords)
     interiors = [np.array(sgeom.box(1, 1, 2, 2, ccw=False).exterior.coords),


### PR DESCRIPTION
## Rationale
The default NaturalEarthFeatures in Cartopy (COASTLINE, OCEAN, etc) have a fixed scale at `'110m'`. It would be good to utilise the AdaptiveScaler to automatically scale to the extent of the plot by default.

## Implications
When, for instance, `ax.add_feature(OCEAN)` is called the scale of the feature will automatically adjust to the extent of the axes, instead of the default `'110m'`. The behaviour of `ax.coastlines()` has also changed to have adaptive scaling by default. This functionality can be reversed using the `with_scale()` method when adding default NaturalEarthFeatures or specifying a scale argument with `ax.coastlines()` e.g. `ax.coastlines('110m')`.