### PR TITLE
Fix deprecations from NumPy

### DIFF
--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -42,9 +42,9 @@ def mesh_projection(projection, nx, ny,
     ----------
     projection
         A :class:`~cartopy.crs.Projection` instance.
-    nx
+    nx: int
         The number of sample points in the projection x-direction.
-    ny
+    ny: int
         The number of sample points in the projection y-direction.
     x_extents: optional
         The (lower, upper) x-direction extent of the projection.

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -122,7 +122,8 @@ def _warped_located_image(image, source_projection, source_extent,
                                  source_proj=source_projection,
                                  source_extent=source_extent,
                                  target_proj=output_projection,
-                                 target_res=target_resolution,
+                                 target_res=np.asarray(target_resolution,
+                                                       dtype=int),
                                  target_extent=output_extent,
                                  mask_extrapolated=True)
 

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1052,9 +1052,9 @@ class GeoAxes(matplotlib.axes.Axes):
             x_range, y_range = np.diff(target_extent)[::2]
             desired_aspect = x_range / y_range
             if x_range >= y_range:
-                regrid_shape = (target_size * desired_aspect, target_size)
+                regrid_shape = (int(target_size * desired_aspect), target_size)
             else:
-                regrid_shape = (target_size, target_size / desired_aspect)
+                regrid_shape = (target_size, int(target_size / desired_aspect))
         return regrid_shape
 
     def imshow(self, img, *args, **kwargs):

--- a/lib/cartopy/tests/test_polygon.py
+++ b/lib/cartopy/tests/test_polygon.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2017, Met Office
+# (C) British Crown Copyright 2011 - 2018, Met Office
 #
 # This file is part of cartopy.
 #
@@ -254,7 +254,7 @@ class TestQuality(object):
 
         # For each region, check if the number of increasing steps is roughly
         # equal to the number of decreasing steps.
-        for i in range(boundary[0], regions.max(), 2):
+        for i in range(int(boundary[0]), regions.max(), 2):
             indices = np.where(regions == i)
             x = xy[indices, 0]
             delta = np.diff(x)


### PR DESCRIPTION
This fixes several deprecation warnings from NumPy when running the tests:

```
cartopy/lib/cartopy/tests/test_polygon.py:257: DeprecationWarning: In future, it will be an error for 'np.bool_' scalars to be interpreted as an index
  for i in range(boundary[0], regions.max(), 2):

cartopy/lib/cartopy/img_transform.py:76: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  endpoint=False)
cartopy/lib/cartopy/img_transform.py:78: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  endpoint=False)

cartopy/lib/cartopy/img_transform.py:76: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  endpoint=False)
cartopy/lib/cartopy/img_transform.py:78: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  endpoint=False)
cartopy/lib/cartopy/img_transform.py:76: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  endpoint=False)
cartopy/lib/cartopy/img_transform.py:78: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  endpoint=False)

cartopy/lib/cartopy/img_transform.py:76: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  endpoint=False)

cartopy/lib/cartopy/img_transform.py:76: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  endpoint=False)

cartopy/lib/cartopy/img_transform.py:76: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  endpoint=False)

cartopy/lib/cartopy/img_transform.py:78: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  endpoint=False)

cartopy/lib/cartopy/img_transform.py:76: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  endpoint=False)

cartopy/lib/cartopy/img_transform.py:76: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  endpoint=False)

cartopy/lib/cartopy/img_transform.py:76: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  endpoint=False)

cartopy/lib/cartopy/vector_transform.py:63: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  x_grid, y_grid = np.meshgrid(np.linspace(0, 1, nx),

code/cartopy/lib/cartopy/vector_transform.py:63: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  x_grid, y_grid = np.meshgrid(np.linspace(0, 1, nx),

cartopy/lib/cartopy/vector_transform.py:63: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  x_grid, y_grid = np.meshgrid(np.linspace(0, 1, nx),

code/cartopy/lib/cartopy/vector_transform.py:63: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
  x_grid, y_grid = np.meshgrid(np.linspace(0, 1, nx),
```