### PR TITLE
Restrict to not version 3 of Matplotlib.

### DIFF
--- a/requirements/plotting.txt
+++ b/requirements/plotting.txt
@@ -1,4 +1,4 @@
-matplotlib>=1.5.1
+matplotlib>=1.5.1,<3
 GDAL>=1.10.0
 pillow>=1.7.8
 scipy>=0.10


### PR DESCRIPTION

## Rationale

Due to conflicts with API changes in Matplotlib 3, make sure we only use compatible versions of Matplotlib.


## Implications

Fix issues with using some features such as contour plotting that do not work with Matplotlib 3.
