### PR TITLE
TST: Speed up travis a bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
           PACKAGES="numpy=1.10.0 matplotlib=1.5.1 nose scipy=0.16.0 libgfortran=1 mock"
         - PYTHON_VERSION=3.5
           PACKAGES="numpy=1.10.0 matplotlib=1.5.1 nose scipy=0.16.0 libgfortran=1"
+          PYTHONHASHSEED=0  # So pytest-xdist works.
         # New FreeType causes changes in text output.
         - NAME="Latest everything."
           PYTHON_VERSION=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
   # Customise the testing environment
   # ---------------------------------
   - conda config --add channels conda-forge
-  - PACKAGES="$PACKAGES cython pillow pytest pep8 proj4=4.* pyshp shapely six requests pyepsg owslib"
+  - PACKAGES="$PACKAGES cython pillow pytest pytest-xdist pep8 proj4=4.* pyshp shapely six requests pyepsg owslib"
   - conda install --quiet $PACKAGES
 
   # Conda debug
@@ -71,9 +71,9 @@ script:
   - python $TRAVIS_BUILD_DIR/tools/feature_download.py gshhs physical --dry-run
 
   - if [[ "$NAME" == "Latest everything"* ]]; then
-      CARTOPY_GIT_DIR=$TRAVIS_BUILD_DIR pytest --doctest-modules --pyargs cartopy;
+      CARTOPY_GIT_DIR=$TRAVIS_BUILD_DIR pytest -n 4 --doctest-modules --pyargs cartopy;
     else
-      CARTOPY_GIT_DIR=$TRAVIS_BUILD_DIR pytest --pyargs cartopy;
+      CARTOPY_GIT_DIR=$TRAVIS_BUILD_DIR pytest -n 4 --pyargs cartopy;
     fi
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   # Customise the testing environment
   # ---------------------------------
   - conda config --add channels conda-forge
-  - PACKAGES="$PACKAGES cython pillow pytest pytest-xdist pep8 proj4=4.* pyshp shapely six requests pyepsg owslib"
+  - PACKAGES="$PACKAGES cython pillow pytest pytest-xdist filelock pep8 proj4=4.* pyshp shapely six requests pyepsg owslib"
   - conda install --quiet $PACKAGES
 
   # Conda debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ install:
   # Create the basic testing environment
   # ------------------------------------
   - conda config --set always_yes yes --set changeps1 no --set show_channel_urls yes
-  - conda update conda
   - ENV_NAME="test-environment"
   - conda create -n $ENV_NAME python=$PYTHON_VERSION
   - source activate $ENV_NAME

--- a/INSTALL
+++ b/INSTALL
@@ -114,6 +114,9 @@ Testing Dependencies
 ~~~~~~~~~~~~~~~~~~~~
 These packages are required for the full Cartopy test suite to run.
 
+**filelock** (https://filelock.readthedocs.io/)
+    A platform independent file lock for Python.
+
 **mock** 1.0.1 (https://pypi.python.org/pypi/mock/)
     Python mocking and patching package for testing. Note that this package
     is only required to support the Cartopy unit tests.

--- a/lib/cartopy/tests/mpl/__init__.py
+++ b/lib/cartopy/tests/mpl/__init__.py
@@ -25,6 +25,7 @@ import glob
 import shutil
 import warnings
 
+import filelock
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
@@ -156,9 +157,9 @@ class ImageTesting(object):
             if not os.path.isdir(os.path.dirname(result_path)):
                 os.makedirs(os.path.dirname(result_path))
 
-            self.save_figure(figure, result_path)
-
-            self.do_compare(result_path, expected_path, self.tolerance)
+            with filelock.FileLock(result_path + '.lock').acquire():
+                self.save_figure(figure, result_path)
+                self.do_compare(result_path, expected_path, self.tolerance)
 
     def save_figure(self, figure, result_fname):
         """

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,2 +1,3 @@
+filelock
 mock>=1.0.1
 pytest>=3.0.0


### PR DESCRIPTION
## Rationale

Currently, Travis takes approximately 250s (4m10s) to install conda, cartopy, and its dependencies, 153s (2.5m) to run tests, and 5s for other bits.
* `conda update conda` does nothing since we pull the latest miniconda, so it wastes 16s
* running tests in parallel locally gets me 120s-> 40/50s, or 2.5-3 times faster. I'm hoping we can shave a similar amount of time of the builds here.

## Implications

Hopefully, this will get builds a bit closer to 5m.
