### PR TITLE
BLD: Add pyproject.toml defining build requirements.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include CHANGES
 include COPYING*
 include INSTALL
 include README.rst
+include pyproject.toml
 include requirements/*.txt
 include lib/cartopy/data/*
 include lib/cartopy/io/srtm.npz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy>=1.10", "Cython>=0.15.1"]

--- a/setup.py
+++ b/setup.py
@@ -36,13 +36,6 @@ import warnings
 import versioneer
 
 
-# Ensure build-time dependencies are available.
-# See https://stackoverflow.com/a/12061891
-setuptools.dist.Distribution(
-    dict(
-        setup_requires=['Cython>=0.15.1', 'numpy>=1.10']))
-
-
 try:
     from Cython.Distutils import build_ext
 except ImportError:


### PR DESCRIPTION
This follows the new PEP518 metadata to get Cython and NumPy installed prior to building.

Fixes #1112.
See also #1035.