### PR TITLE
Deprecate clip_path.

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -13,6 +13,12 @@ Features
   zooming in a figure. :data:`cartopy.feature.NaturalEarthFeature.scale` is
   now read-only. (:pull:`1102`, :pull:`983`)
 
+Deprecations
+------------
+* :func:`cartopy.mpl.clip_path.clip_path` has been deprecated. It is a simple
+  wrapper for Matplotlib's path clipping, so use that instead. You can replace
+  ``clip_path(subject, clip_bbox)`` by ``subject.clip_to_bbox(clip_bbox)``.
+
 --------
 
 

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -45,7 +45,6 @@ from cartopy import config
 import cartopy.crs as ccrs
 import cartopy.feature
 import cartopy.img_transform
-from cartopy.mpl.clip_path import clip_path
 import cartopy.mpl.feature_artist as feature_artist
 import cartopy.mpl.patch as cpatch
 from cartopy.mpl.slippy_image_artist import SlippyImageArtist
@@ -353,8 +352,8 @@ class GeoAxes(matplotlib.axes.Axes):
             self.autoscale_view()
 
         if self.outline_patch.reclip or self.background_patch.reclip:
-            clipped_path = clip_path(self.outline_patch.orig_path,
-                                     self.viewLim)
+            clipped_path = self.outline_patch.orig_path.clip_to_bbox(
+                self.viewLim)
             self.outline_patch._path = clipped_path
             self.background_patch._path = clipped_path
 


### PR DESCRIPTION
It is just a thin wrapper around a Matplotlib method at this point, and the old compatibility function doesn't even work properly (it uses xrange). We also don't support a version of Matplotlib old enough to require use of the compatibility function now.