### PR TITLE
Update SRTM url and fix tests

### DIFF
--- a/lib/cartopy/io/srtm.py
+++ b/lib/cartopy/io/srtm.py
@@ -393,8 +393,8 @@ class SRTMDownloader(Downloader):
     """
     FORMAT_KEYS = ('config', 'resolution', 'x', 'y')
 
-    _SRTM_BASE_URL = ('https://e4ftl01.cr.usgs.gov/SRTM/SRTMGL{resolution}.'
-                      '003/2000.02.11/')
+    _SRTM_BASE_URL = ('https://e4ftl01.cr.usgs.gov/MEASURES/'
+                      'SRTMGL{resolution}.003/2000.02.11/')
     _SRTM_LOOKUP_CACHE = os.path.join(os.path.dirname(__file__),
                                       'srtm.npz')
     _SRTM_LOOKUP_MASK = np.load(_SRTM_LOOKUP_CACHE)['mask']

--- a/lib/cartopy/tests/io/test_srtm.py
+++ b/lib/cartopy/tests/io/test_srtm.py
@@ -26,6 +26,8 @@ import pytest
 import cartopy.crs as ccrs
 import cartopy.io.srtm
 
+from .test_downloaders import download_to_temp  # noqa: F401 (used as fixture)
+
 
 pytestmark = [pytest.mark.skip('SRTM login not supported'),
               pytest.mark.network]
@@ -89,8 +91,10 @@ class TestSRTMSource__single_tile(object):
     def test_in_range(self, Source):
         if Source == cartopy.io.srtm.SRTM3Source:
             shape = (1201, 1201)
-        elif Source == cartopy.io.srtm.SRTM3Source:
+        elif Source == cartopy.io.srtm.SRTM1Source:
             shape = (3601, 3601)
+        else:
+            raise ValueError('Source is of unexpected type.')
         source = Source()
         img, crs, extent = source.single_tile(-1, 50)
         assert isinstance(img, np.ndarray)


### PR DESCRIPTION
## Rationale

The SRTM location has changed; see #1080. Also, tests were a bit broken since they aren't currently being run.

## Implications

SRTM should work again; note that you still need to set up a username and password and patch it in to get tests to run.