### PR TITLE
TST: Add a fixture enabling SRTM login using envvars.

### DIFF
--- a/lib/cartopy/io/srtm.py
+++ b/lib/cartopy/io/srtm.py
@@ -413,11 +413,12 @@ class SRTMDownloader(Downloader):
         Downloader.__init__(self, None,
                             target_path_template,
                             pre_downloaded_path_template)
-        warnings.warn('SRTM requires an account set up and log in to access.'
-                      'use of this class is likely to fail with'
-                      ' HTTP 401 errors.')
 
     def url(self, format_dict):
+        warnings.warn('SRTM requires an account set up and log in to access. '
+                      'Use of this Downloader is likely to fail with HTTP 401 '
+                      'errors.')
+
         # override the url method, looking up the url from the
         # ``SRTMDownloader._SRTM_LOOKUP_MASK`` array
         lat = int(format_dict['y'][1:])

--- a/lib/cartopy/tests/io/test_srtm.py
+++ b/lib/cartopy/tests/io/test_srtm.py
@@ -30,6 +30,7 @@ from .test_downloaders import download_to_temp  # noqa: F401 (used as fixture)
 
 
 pytestmark = [pytest.mark.network,
+              pytest.mark.filterwarnings('ignore:SRTM requires an account'),
               pytest.mark.usefixtures('srtm_login_or_skip')]
 
 


### PR DESCRIPTION
## Rationale

There is currently no way to run SRTM tests, so they tend to fall into disrepair (cf #1080).

## Implications

If you set `SRTM_USERNAME` and `SRTM_PASSWORD` in the environment, you can run pytest and have the SRTM tests work. In the future, we may want to [define an encrypted variable on Travis](https://docs.travis-ci.com/user/environment-variables/#defining-encrypted-variables-in-travisyml) to enable running these on CI. I don't want to do this myself as I'd rather someone from the Met Office handle the credentials.