### PR TITLE
Fuzz more projection boundaries to work with proj >= 5

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -144,6 +144,18 @@ class Projection(six.with_metaclass(ABCMeta, CRS)):
             domain = self._domain = sgeom.Polygon(self.boundary)
         return domain
 
+    def _determine_longitude_bounds(self, central_longitude):
+        # In new proj, using exact limits will wrap-around, so subtract a
+        # small epsilon:
+        epsilon = 1e-10
+        minlon = -180 + central_longitude
+        maxlon = 180 + central_longitude
+        if central_longitude > 0:
+            maxlon -= epsilon
+        elif central_longitude < 0:
+            minlon += epsilon
+        return minlon, maxlon
+
     def _as_mpl_axes(self):
         import cartopy.mpl.geoaxes as geoaxes
         return geoaxes.GeoAxes, {'map_projection': self}
@@ -994,17 +1006,8 @@ class Mercator(Projection):
 
         super(Mercator, self).__init__(proj4_params, globe=globe)
 
-        # In new proj, using exact limits will wrap-around, so subtract a
-        # small epsilon:
-        epsilon = 1e-10
-        minlon = -180 + central_longitude
-        maxlon = 180 + central_longitude
-        if central_longitude > 0:
-            maxlon -= epsilon
-        elif central_longitude < 0:
-            minlon += epsilon
-
         # Calculate limits.
+        minlon, maxlon = self._determine_longitude_bounds(central_longitude)
         limits = self.transform_points(Geodetic(),
                                        np.array([minlon, maxlon]),
                                        np.array([min_latitude, max_latitude]))
@@ -1520,17 +1523,8 @@ class _WarpedRectangularProjection(six.with_metaclass(ABCMeta, Projection)):
         super(_WarpedRectangularProjection, self).__init__(proj4_params,
                                                            globe=globe)
 
-        # In new proj, using exact limits will wrap-around, so subtract a
-        # small epsilon:
-        epsilon = 1.e-10
-        minlon = -180 + central_longitude
-        maxlon = 180 + central_longitude
-        if central_longitude > 0:
-            maxlon -= epsilon
-        elif central_longitude < 0:
-            minlon += epsilon
-
         # Obtain boundary points
+        minlon, maxlon = self._determine_longitude_bounds(central_longitude)
         points = []
         n = 91
         geodetic_crs = self.as_geodetic()
@@ -1654,15 +1648,8 @@ class InterruptedGoodeHomolosine(Projection):
         super(InterruptedGoodeHomolosine, self).__init__(proj4_params,
                                                          globe=globe)
 
-        # In new proj, using exact limits will wrap-around, so subtract a
-        # small epsilon:
-        epsilon = 1.e-10
-        minlon = -180 + central_longitude
-        maxlon = 180 + central_longitude
-        if central_longitude > 0:
-            maxlon -= epsilon
-        elif central_longitude < 0:
-            minlon += epsilon
+        minlon, maxlon = self._determine_longitude_bounds(central_longitude)
+        epsilon = 1e-10
 
         # Obtain boundary points
         points = []
@@ -1856,17 +1843,8 @@ class AlbersEqualArea(Projection):
 
         super(AlbersEqualArea, self).__init__(proj4_params, globe=globe)
 
-        # In new proj, using exact limits will wrap-around, so subtract a
-        # small epsilon:
-        epsilon = 1e-10
-        minlon = -180 + central_longitude
-        maxlon = 180 + central_longitude
-        if central_longitude > 0:
-            maxlon -= epsilon
-        elif central_longitude < 0:
-            minlon += epsilon
-
         # bounds
+        minlon, maxlon = self._determine_longitude_bounds(central_longitude)
         n = 103
         lons = np.empty(2 * n + 1)
         lats = np.empty(2 * n + 1)
@@ -2008,17 +1986,8 @@ class Sinusoidal(Projection):
                         ('y_0', false_northing)]
         super(Sinusoidal, self).__init__(proj4_params, globe=globe)
 
-        # In new proj, using exact limits will wrap-around, so subtract a
-        # small epsilon:
-        epsilon = 1.e-10
-        minlon = -180 + central_longitude
-        maxlon = 180 + central_longitude
-        if central_longitude > 0:
-            maxlon -= epsilon
-        elif central_longitude < 0:
-            minlon += epsilon
-
         # Obtain boundary points
+        minlon, maxlon = self._determine_longitude_bounds(central_longitude)
         points = []
         n = 91
         geodetic_crs = self.as_geodetic()

--- a/lib/cartopy/tests/crs/test_albers_equal_area.py
+++ b/lib/cartopy/tests/crs/test_albers_equal_area.py
@@ -22,7 +22,8 @@ Tests for the Albers Equal Area coordinate system.
 from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_array_almost_equal
+import pytest
 
 import cartopy.crs as ccrs
 
@@ -69,6 +70,17 @@ class TestAlbersEqualArea(object):
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=1234',
                       'y_0=-4321', 'lat_1=20.0', 'lat_2=50.0'}
         check_proj4_params(aea_offset, other_args)
+
+    @pytest.mark.parametrize('lon', [-10.0, 10.0])
+    def test_central_longitude(self, lon):
+        aea = ccrs.AlbersEqualArea()
+        aea_offset = ccrs.AlbersEqualArea(central_longitude=lon)
+        other_args = {'ellps=WGS84', 'lon_0={}'.format(lon), 'lat_0=0.0',
+                      'x_0=0.0', 'y_0=0.0', 'lat_1=20.0', 'lat_2=50.0'}
+        check_proj4_params(aea_offset, other_args)
+
+        assert_array_almost_equal(aea_offset.boundary, aea.boundary,
+                                  decimal=0)
 
     def test_standard_parallels(self):
         aea = ccrs.AlbersEqualArea(standard_parallels=(13, 37))

--- a/lib/cartopy/tests/crs/test_interrupted_goode_homolosine.py
+++ b/lib/cartopy/tests/crs/test_interrupted_goode_homolosine.py
@@ -1,0 +1,71 @@
+# (C) British Crown Copyright 2018, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Tests for the InterruptedGoodeHomolosine coordinate system.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+import numpy as np
+from numpy.testing import assert_almost_equal
+import pytest
+
+import cartopy.crs as ccrs
+
+
+def check_proj4_params(crs, other_args):
+    expected = other_args | {'proj=igh', 'no_defs'}
+    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
+    assert expected == pro4_params
+
+
+def test_default():
+    igh = ccrs.InterruptedGoodeHomolosine()
+    other_args = {'ellps=WGS84', 'lon_0=0'}
+    check_proj4_params(igh, other_args)
+
+    assert_almost_equal(np.array(igh.x_limits),
+                        [-20037508.3427892, 20037508.3427892])
+    assert_almost_equal(np.array(igh.y_limits),
+                        [-8683259.7164347, 8683259.7164347])
+
+
+def test_eccentric_globe():
+    globe = ccrs.Globe(semimajor_axis=1000, semiminor_axis=500,
+                       ellipse=None)
+    igh = ccrs.InterruptedGoodeHomolosine(globe=globe)
+    other_args = {'a=1000', 'b=500', 'lon_0=0'}
+    check_proj4_params(igh, other_args)
+
+    assert_almost_equal(np.array(igh.x_limits),
+                        [-3141.5926536, 3141.5926536])
+    assert_almost_equal(np.array(igh.y_limits),
+                        [-1361.410035, 1361.410035])
+
+
+@pytest.mark.parametrize('lon', [-10.0, 10.0])
+def test_central_longitude(lon):
+    igh = ccrs.InterruptedGoodeHomolosine(central_longitude=lon)
+    other_args = {'ellps=WGS84', 'lon_0={}'.format(lon)}
+    check_proj4_params(igh, other_args)
+
+    assert_almost_equal(np.array(igh.x_limits),
+                        [-20037508.3427892, 20037508.3427892],
+                        decimal=5)
+    assert_almost_equal(np.array(igh.y_limits),
+                        [-8683259.7164347, 8683259.7164347])

--- a/lib/cartopy/tests/crs/test_sinusoidal.py
+++ b/lib/cartopy/tests/crs/test_sinusoidal.py
@@ -19,6 +19,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal
+import pytest
 
 import cartopy.crs as ccrs
 
@@ -62,6 +63,20 @@ class TestSinusoidal(object):
         check_proj4_params(crs_offset, other_args)
         assert tuple(np.array(crs.x_limits) + 1234) == crs_offset.x_limits
         assert tuple(np.array(crs.y_limits) - 4321) == crs_offset.y_limits
+
+    @pytest.mark.parametrize('lon', [-10.0, 10.0])
+    def test_central_longitude(self, lon):
+        crs = ccrs.Sinusoidal(central_longitude=lon)
+        other_args = {'ellps=WGS84', 'lon_0={}'.format(lon),
+                      'x_0=0.0', 'y_0=0.0'}
+        check_proj4_params(crs, other_args)
+
+        assert_almost_equal(np.array(crs.x_limits),
+                            [-20037508.3428, 20037508.3428],
+                            decimal=4)
+        assert_almost_equal(np.array(crs.y_limits),
+                            [-10001965.7293, 10001965.7293],
+                            decimal=4)
 
     def test_MODIS(self):
         # Testpoints verified with MODLAND Tile Calculator


### PR DESCRIPTION
So I missed a few projections in #1124 that use a projection of min/max longitudes to determine the boundary. They are currently broken with proj5.

This fixes those projections and adds some tests so that they won't break again.