### PR TITLE
Use pykdtree when available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ deps-run: &deps-install
         requests \
         pyepsg \
         owslib \
+        pykdtree \
         $EXTRA_PACKAGES
     conda install --quiet --file docs/doc-requirements.txt
     conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
         # New FreeType causes changes in text output.
         - NAME="Latest everything."
           PYTHON_VERSION=3.6
-          PACKAGES="numpy matplotlib freetype<2.8 proj4 scipy"
+          PACKAGES="numpy matplotlib freetype<2.8 proj4 pykdtree scipy"
         - NAME="Latest everything (py2k)."
           PYTHON_VERSION=2
           PACKAGES="numpy matplotlib freetype<2.8 proj4 scipy mock"

--- a/INSTALL
+++ b/INSTALL
@@ -99,6 +99,10 @@ additional Cartopy functionality.
 **pyepsg** 0.2.0 or later (https://github.com/rhattersley/pyepsg)
     A simple Python interface to https://epsg.io
 
+**pykdtree* 1.2.2 or later (https://github.com/storpipfugl/pykdtree)
+    Fast kd-tree implementation in Python; used for faster warping of images in
+    preference to SciPy.
+
 **SciPy** 0.10 or later (https://www.scipy.org/)
     Python package for scientific computing.
 

--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -23,7 +23,12 @@ transformations.
 from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
-import scipy.spatial
+try:
+    import pykdtree.kdtree
+    _is_pykdtree = True
+except ImportError:
+    import scipy.spatial
+    _is_pykdtree = False
 
 import cartopy.crs as ccrs
 
@@ -270,15 +275,20 @@ def regrid(array, source_x_coords, source_y_coords, source_cs, target_proj,
                                            target_x_points.flatten(),
                                            target_y_points.flatten())
 
-    # Versions of scipy >= v0.16 added the balanced_tree argument,
-    # which caused the KDTree to hang with this input.
-    try:
-        kdtree = scipy.spatial.cKDTree(xyz, balanced_tree=False)
-    except TypeError:
-        kdtree = scipy.spatial.cKDTree(xyz)
-
-    distances, indices = kdtree.query(target_xyz, k=1)
-    mask = np.isinf(distances)
+    if _is_pykdtree:
+        kdtree = pykdtree.kdtree.KDTree(xyz)
+        # Use sqr_dists=True because we don't care about distances,
+        # and it saves a sqrt.
+        _, indices = kdtree.query(target_xyz, k=1, sqr_dists=True)
+    else:
+        # Versions of scipy >= v0.16 added the balanced_tree argument,
+        # which caused the KDTree to hang with this input.
+        try:
+            kdtree = scipy.spatial.cKDTree(xyz, balanced_tree=False)
+        except TypeError:
+            kdtree = scipy.spatial.cKDTree(xyz)
+        _, indices = kdtree.query(target_xyz, k=1)
+    mask = indices >= len(xyz)
     indices[mask] = 0
 
     desired_ny, desired_nx = target_x_points.shape


### PR DESCRIPTION
## Rationale

The pykdtree project by @storpipfugl is super fast compared to scipy, so this tries to use it if it's available.

## Implications

There is no effect on tests, but a great effect on the examples:
```
                   example   function     master   pykdtree     ratio
0          aurora_forecast    imshow0   1.614568   0.697115  0.431765
1          aurora_forecast    imshow1   1.620853   0.704454  0.434619
2          aurora_forecast       draw   0.916317   1.119499  1.221738
3        eccentric_ellipse     imshow   2.400456   1.269291  0.528771
4        eccentric_ellipse       draw   0.341589   0.677258  1.982666
5   effects_of_the_ellipse  add_image   0.000008   0.000008  1.031250
6   effects_of_the_ellipse       draw   1.835607   1.980497  1.078933
7             eyja_volcano  add_image   0.000003   0.000003  0.928571
8             eyja_volcano       draw   3.526339  10.100620  2.864336
9            geostationary     imshow  96.402943   1.546087  0.016038
10           geostationary       draw   0.643935   0.896134  1.391653
11                     wms    add_wms   0.514387   0.521981  1.014763
12                     wms       draw   2.045766   2.763029  1.350609
```
In almost all cases, the `imshow` is approximately half the time while `draw` is slightly slower. For some reason, the draw in `eyja_volcano` is much slower which I need to investigate a bit, but the real win here is `geostationary` which is two orders of magnitude faster.

This speedup should hopefully improve doc builds a bit (at least where it was added.)