### PR TITLE
Update sphinx-gallery to 0.2.0

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -3,5 +3,5 @@ netCDF4
 iris
 iris-sample-data
 cf_units
-sphinx-gallery =0.1.12
+sphinx-gallery =0.2.0
 beautifulsoup4

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -98,10 +98,12 @@ version = cartopy.__version__
 release = cartopy.__version__
 
 # Sphinx gallery configuration
+from sphinx_gallery.sorting import ExampleTitleSortKey
 sphinx_gallery_conf = {
     'examples_dirs': ['../../lib/cartopy/examples'],
     'filename_pattern': '^((?!sgskip).)*$',
     'gallery_dirs': ['gallery'],
+    'within_subsection_order': ExampleTitleSortKey,
     'doc_module': ('cartopy',),
     'reference_url': {'cartopy': None},
     'backreferences_dir': '../build/backrefs',

--- a/docs/source/sphinxext/pre_sphinx_gallery.py
+++ b/docs/source/sphinxext/pre_sphinx_gallery.py
@@ -41,18 +41,18 @@ import shutil
 import tempfile
 import textwrap
 
+import sphinx_gallery
+if sphinx_gallery.__version__ not in ['0.1.12']:  # noqa: E402
+    raise RuntimeError('not tested with this version of sphinx_gallery ({}). '
+                       'Please modify this check, and validate sphinx_gallery'
+                       ' behaves as expected.'
+                       ''.format(sphinx_gallery.__version__))
+
 import sphinx_gallery.gen_gallery
 import sphinx_gallery.gen_rst
 from sphinx_gallery.gen_rst import (
     write_backreferences, extract_intro, _thumbnail_div,
     generate_file_rst, sphinx_compatibility)
-
-
-if sphinx_gallery.__version__ not in ['0.1.12']:
-    raise RuntimeError('not tested with this version of sphinx_gallery ({}). '
-                       'Please modify this check, and validate sphinx_gallery'
-                       ' behaves as expected.'
-                       ''.format(sphinx_gallery.__version__))
 
 
 GALLERY_HEADER = textwrap.dedent("""

--- a/docs/source/sphinxext/pre_sphinx_gallery.py
+++ b/docs/source/sphinxext/pre_sphinx_gallery.py
@@ -35,7 +35,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 import os.path
 import shutil
 import tempfile
@@ -74,21 +74,20 @@ def example_groups(src_dir):
 
     sorted_listdir = [fname for fname in sorted(os.listdir(src_dir))
                       if fname.endswith('.py') and not fname.startswith('_')]
-    tagged_examples = {}
+    tagged_examples = defaultdict(list)
 
     for fname in sorted_listdir:
         fpath = os.path.join(src_dir, fname)
         with open(fpath, 'r') as fh:
             for line in fh:
-                # Crudely remove the __tags__ line.
+                # Crudely extract the __tags__ line.
                 if line.startswith('__tags__ = '):
                     exec(line.strip(), locals(), globals())
                     for tag in __tags__:  # noqa:
-                        tagged_examples.setdefault(tag, []).append(fname)
+                        tagged_examples[tag].append(fname)
                     break
             else:
-                tag = 'Miscellanea'
-                tagged_examples.setdefault(tag, []).append(fname)
+                tagged_examples['Miscellanea'].append(fname)
     return tagged_examples
 
 


### PR DESCRIPTION
## Rationale

We currently only support a single version of sphinx-gallery due to patching; this updates to the latest one.

## Implications

I also changed the sorting to use the title of the example, which I personally think makes more sense than number of lines.