### PR TITLE
Improve docs for Cython extensions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -99,7 +99,7 @@ additional Cartopy functionality.
 **pyepsg** 0.2.0 or later (https://github.com/rhattersley/pyepsg)
     A simple Python interface to https://epsg.io
 
-**pykdtree* 1.2.2 or later (https://github.com/storpipfugl/pykdtree)
+**pykdtree** 1.2.2 or later (https://github.com/storpipfugl/pykdtree)
     Fast kd-tree implementation in Python; used for faster warping of images in
     preference to SciPy.
 

--- a/docs/source/cartopy/geodesic.rst
+++ b/docs/source/cartopy/geodesic.rst
@@ -1,0 +1,11 @@
+Geodesic calculations
+=====================
+
+This module defines the Geodesic class which can interface with the Proj
+geodesic functions. See the `Proj geodesic page`_ for more background
+information.
+
+.. _Proj geodesic page: https://proj4.org/geodesic.html
+
+.. autoclass:: cartopy.geodesic.Geodesic
+    :members:

--- a/docs/source/cartopy/trace.rst
+++ b/docs/source/cartopy/trace.rst
@@ -1,0 +1,5 @@
+LinearRing/LineString projection
+================================
+
+.. automodule:: cartopy.trace
+    :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -124,7 +124,7 @@ sphinx_gallery_conf = {
 exclude_patterns = []
 
 # The reST default role (used for this markup: `text`) to use for all documents.
-# default_role = None
+default_role = 'py:obj'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 # add_function_parentheses = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -347,6 +347,7 @@ epub_copyright = u'2012, Philip Elson, Richard Hattersley'
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
                        'matplotlib': ('https://matplotlib.org', None),
+                       'numpy': ('https://docs.scipy.org/doc/numpy/', None),
                        'shapely': ('http://toblerity.org/shapely', None), }
 
 

--- a/docs/source/crs/index.rst
+++ b/docs/source/crs/index.rst
@@ -5,7 +5,7 @@ The :class:`cartopy.crs.CRS` class is the very core of cartopy, all coordinate r
 in cartopy have :class:`~cartopy.crs.CRS` as a parent class, meaning all projections have
 the interface described below.
 
-.. autoclass:: cartopy.crs.CRS()
+.. autoclass:: cartopy.crs.CRS
    :members:
 
    .. data:: globe
@@ -17,7 +17,7 @@ The :class:`~cartopy.crs.Globe` class is used to encapsulate the underlying sphe
 All CRSs have an associated :class:`~cartopy.crs.Globe`, though often it is just the default :class:`~cartopy.crs.Globe`
 which represents the reference ellipsoid (i.e. "wgs84").
 
-.. autoclass:: cartopy.crs.Globe(datum=None, ellipse='WGS84', semimajor_axis=None, semiminor_axis=None, flattening=None, inverse_flattening=None, towgs84=None)
+.. autoclass:: cartopy.crs.Globe
    :members:
    :exclude-members: to_proj4_params
 
@@ -34,9 +34,9 @@ all projections in the :ref:`cartopy_projections`.
 There are a few non-:class:`~cartopy.crs.Projection` subclasses. These represent
 coordinate reference systems which are 3 dimensional and could not be drawn directly on a piece of paper.
 
-.. autoclass:: cartopy.crs.Geodetic(globe=None)
+.. autoclass:: cartopy.crs.Geodetic
 
-.. autoclass:: cartopy.crs.Geocentric(globe=None)
+.. autoclass:: cartopy.crs.Geocentric
 
 .. autoclass:: cartopy.crs.RotatedGeodetic
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,6 +56,7 @@ outlines recent changes, new features, and future development plans.
     :hidden:
 
     cartopy.rst
+    cartopy/geodesic.rst
     cartopy/io/img_tiles.rst
     cartopy/io/ogc_clients.rst
     cartopy/trace.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -58,6 +58,7 @@ outlines recent changes, new features, and future development plans.
     cartopy.rst
     cartopy/io/img_tiles.rst
     cartopy/io/ogc_clients.rst
+    cartopy/trace.rst
     cartopy/util/util.rst
 
 

--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+#
+# cython: embedsignature=True
 
 """
 This module defines the core CRS class which can interface with Proj.

--- a/lib/cartopy/geodesic/__init__.py
+++ b/lib/cartopy/geodesic/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2017, Met Office
+# (C) British Crown Copyright 2015 - 2018, Met Office
 #
 # This file is part of cartopy.
 #
@@ -19,3 +19,6 @@ from __future__ import (absolute_import, division, print_function)
 
 # NOTE: noqa for flake8 = unused import
 from cartopy.geodesic._geodesic import Geodesic  # noqa: F401
+
+# Need to be explicit because it's from a 'different' module.
+__document_these__ = ['Geodesic']

--- a/lib/cartopy/geodesic/_geodesic.pyx
+++ b/lib/cartopy/geodesic/_geodesic.pyx
@@ -52,23 +52,25 @@ cdef class Geodesic:
     cdef double radius
     cdef double flattening
 
-    def __cinit__(self, radius=6378137.0, flattening=1/298.257223563):
+    def __init__(self, radius=6378137.0, flattening=1/298.257223563):
         """
-        Create an ellipsoid with a given radius and flattening.
-
         Parameters
         ----------
-        radius: optional
+        radius: float, optional
             Equatorial radius (metres). Defaults to the WGS84 semimajor axis
             (6378137.0 metres).
 
-        flattening: optional
+        flattening: float, optional
             Flattening of ellipsoid.  Setting flattening = 0 gives a sphere.
             Negative flattening gives a prolate ellipsoid. If flattening > 1,
             set flattening to 1/flattening.
             Defaults to the WGS84 flattening (1/298.257223563).
 
         """
+        # This method exists solely for docstrings. The __cinit__ method is
+        # where the real work happens. Make sure to keep the signatures synced.
+
+    def __cinit__(self, radius=6378137.0, flattening=1/298.257223563):
         # allocate some memory (filled with random data)
         self.geod = <geod_geodesic*> PyMem_Malloc(sizeof(geod_geodesic))
         if not self.geod:
@@ -97,22 +99,20 @@ cdef class Geodesic:
 
         Parameters
         ----------
-        points
-            An n (or 1) by 2 numpy.ndarray, list or tuple of lon-lat
-            points.  The starting point(s) from which to travel.
+        points: array_like, shape=(n *or* 1, 2)
+            The starting longitude-latitude point(s) from which to travel.
 
-        azimuths
-            A length n (or 1) numpy.ndarray or list of azimuth
-            values (degrees).
+        azimuths: float or array_like with shape=(n, )
+            List of azimuth values (degrees).
 
-        distances
-            A length n (or 1) numpy.ndarray or list of distances
-            values (metres).
+        distances : float or array_like with shape(n, )
+            List of distances values (metres).
 
         Returns
         -------
-        An n by 3 np.ndarray of lons, lats, and forward azimuths of the
-        located endpoint(s).
+        `numpy.ndarray`, shape=(n, 3)
+            The longitudes, latitudes, and forward azimuths of the located
+            endpoint(s).
 
         """
 
@@ -167,18 +167,17 @@ cdef class Geodesic:
 
         Parameters
         ----------
-        points
-            An n (or 1) by 2 numpy.ndarray, list or tuple of lon-lat points.
-            The starting point(s) from which to travel.
+        points: array_like, shape=(n *or* 1, 2)
+            The starting longitude-latitude point(s) from which to travel.
 
-        endpoints:
-            An n (or 1) by 2 numpy.ndarray, list or tuple of lon-lat points.
-            The point(s) to travel to.
+        endpoints: array_like, shape=(n *or* 1, 2)
+            The longitude-latitude point(s) to travel to.
 
         Returns
         -------
-        An n by 3 np.ndarray of distances, and the (forward) azimuths of
-        the start and end points.
+        `numpy.ndarray`, shape=(n, 3)
+            The distances, and the (forward) azimuths of the start and end
+            points.
 
         """
 
@@ -230,22 +229,21 @@ cdef class Geodesic:
 
         Parameters
         ----------
-        lon
+        lon : float
             Longitude coordinate of the centre.
-        lat
+        lat : float
             Latitude coordinate of the centre.
-        radius
+        radius : float
             The radius of the circle (metres).
-        n_samples: optional
+        n_samples: int, optional
             Integer number of sample points of circle.
-        endpoint: optional
-            Boolean for whether to repeat endpoint at the end of returned
-            array.
+        endpoint: bool, optional
+            Whether to repeat endpoint at the end of returned array.
 
         Returns
         -------
-        An n_samples by 2 np.ndarray of evenly spaced lon-lat points on the
-        circle.
+        `numpy.ndarray`, shape=(n_samples, 2)
+            The evenly spaced longitude-latitude points on the circle.
 
         """
 
@@ -268,7 +266,7 @@ cdef class Geodesic:
 
         Parameters
         ----------
-        geometry
+        geometry : `shapely.geometry.BaseGeometry`
             The Shapely geometry to compute the length of. For polygons, the
             exterior length will be calculated. For multi-part geometries, the
             sum of the parts will be computed.

--- a/lib/cartopy/geodesic/_geodesic.pyx
+++ b/lib/cartopy/geodesic/_geodesic.pyx
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+#
+# cython: embedsignature=True
 
 """
 This module defines the Geodesic class which can interface with the Proj

--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+#
+# cython: embedsignature=True
 
 """
 This module pulls together _trace.cpp, proj, GEOS and _crs.pyx to implement a

--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -18,9 +18,10 @@
 # cython: embedsignature=True
 
 """
-This module pulls together _trace.cpp, proj, GEOS and _crs.pyx to implement a
-function to project a LinearRing/LineString. In general, this should never be
-called manually, instead leaving the processing to be done by the
+This module pulls together ``_trace.cpp``, proj, GEOS and ``_crs.pyx`` to
+implement a function to project a `~shapely.geometry.LinearRing` /
+`~shapely.geometry.LineString`. In general, this should never be called
+manually, instead leaving the processing to be done by the
 :class:`cartopy.crs.Projection` subclasses.
 """
 
@@ -88,19 +89,22 @@ cdef shapely_from_geos(GEOSGeometry *geom):
 def project_linear(geometry not None, CRS src_crs not None,
                    dest_projection not None):
     """
-    Return the MultiLineString which results from projecting the given
-    geometry from the source projection into the destination projection.
+    Project a geometry from one projection to another.
 
     Parameters
     ----------
-    line_string
-        A shapely LineString or LinearRing to be projected.
-    src_crs
-        The cartopy.crs.CRS defining the coordinate system of the line
-        to be projected.
-    dest_projection
-        The cartopy.crs.Projection defining the projection for the
-        resulting projected line.
+    geometry : `shapely.geometry.LineString` or `shapely.geometry.LinearRing`
+        A geometry to be projected.
+    src_crs : cartopy.crs.CRS
+        The coordinate system of the line to be projected.
+    dest_projection : cartopy.crs.Projection
+        The projection for the resulting projected line.
+
+    Returns
+    -------
+    `shapely.geometry.MultiLineString`
+        The result of projecting the given geometry from the source projection
+        into the destination projection.
 
     """
     cdef:


### PR DESCRIPTION
## Rationale

Both `.geodesic` and `.trace` are documented, but do not show up in the docs. There are currently errors and/or bad looking bits that are not fixed because they never show up. We can also use Cython's `embedsignature` option to avoid copying out signatures in docs.

## Implications

Fixes #996.