### PR TITLE
Add links to the Gitter chatroom

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
 <a href="https://zenodo.org/badge/latestdoi/5282596">
 <img src="https://zenodo.org/badge/5282596.svg"
  alt="zenodo" /></a>
+<a href="https://gitter.im/SciTools/cartopy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge">
+<img src="https://badges.gitter.im/SciTools/cartopy.svg" alt="Gitter Chat" /></a>
 </p>
 <br>
 
@@ -77,6 +79,8 @@ Documentation can be found at <http://scitools.org.uk/cartopy/docs/latest/>.
   [Google Group](https://groups.google.com/forum/#!forum/scitools-iris).
 - Report bugs, suggest features or view the source code on
   [GitHub](https://github.com/SciTools/cartopy).
+- To chat with developers and other users you can use the
+  [Gitter Chat](https://gitter.im/SciTools/cartopy)
 
 ## License and copyright
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -84,6 +84,7 @@ There are many ways to get involved in the development of cartopy:
    re-designing its layout/logos etc.. The `documentation source <https://github.com/SciTools/cartopy>`_ is kept in the same repository as the source code.
  * Contribute bug fixes (:issues:`a list of outstanding bugs can be found on github <bug>`).
  * Contribute enhancements and new features on the issue tracker.
+ * Chat with users and developers in the `Gitter chat room <https://gitter.im/SciTools/cartopy>`_.
 
 
 


### PR DESCRIPTION
Now that we have Gitter for chat, we should advertise it. (attn: @QuLogic @ocefpaf )