### PR TITLE
Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,5 +91,5 @@ deploy:
     upload_docs: false
     on:
       repo: SciTools/cartopy
-      condition: $PYTHON_VERSION=="3.6"
+      condition: $NAME == "Latest everything"*
       tags: true

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -30,8 +30,8 @@ geometry representation of shapely:
     >>> records = list(reader.records())
     >>> print(type(records[0]))
     <class 'cartopy.io.shapereader.Record'>
-    >>> print(sorted(records[0].attributes.keys()))
-    ['comment', ... 'name', 'name_alt', ... 'region', ...]
+    >>> print(', '.join(str(r) for r in sorted(records[0].attributes.keys())))
+    comment, ... name, name_alt, ... region, ...
     >>> print(records[0].attributes['name'])
     Niagara Falls
     >>> geoms = list(reader.geometries())

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -236,18 +236,18 @@ class GeoAxes(matplotlib.axes.Axes):
     when created with the *projection* keyword. For example::
 
         # Set up a standard map for latlon data.
-        geo_axes = pyplot.axes(projection=cartopy.crs.PlateCarree())
+        geo_axes = plt.axes(projection=cartopy.crs.PlateCarree())
 
         # Set up an OSGB map.
-        geo_axes = pyplot.subplot(2, 2, 1, projection=cartopy.crs.OSGB())
+        geo_axes = plt.subplot(2, 2, 1, projection=cartopy.crs.OSGB())
 
     When a source projection is provided to one of it's plotting methods,
     using the *transform* keyword, the standard Matplotlib plot result is
     transformed from source coordinates to the target projection. For example::
 
         # Plot latlon data on an OSGB map.
-        pyplot.axes(projection=cartopy.crs.OSGB())
-        pyplot.contourf(x, y, data, transform=cartopy.crs.PlateCarree())
+        plt.axes(projection=cartopy.crs.OSGB())
+        plt.contourf(x, y, data, transform=cartopy.crs.PlateCarree())
 
     """
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
A few random odds and ends:
- Fix doctest on Python 2.7 (#1171). Just changed the output to eliminate the string repr
- Update Travis release deployment to use the $NAME of the build
- Removed uses of `pyplot.` and replaced with `plt.`