### PR TITLE
Improve warped rectangular projections

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1573,9 +1573,11 @@ class _Eckert(six.with_metaclass(ABCMeta, _WarpedRectangularProjection)):
         ----------
         central_longitude: optional
             The central longitude. Defaults to 0.
-        globe: optional
-            A :class:`cartopy.crs.Globe`. If omitted, a default globe is
-            created.
+        globe: :class:`cartopy.crs.Globe`, optional
+            If omitted, a default globe is created.
+
+            .. note::
+                This projection does not handle elliptical globes.
 
         """
         if globe is None:
@@ -1677,6 +1679,17 @@ class EckertVI(_Eckert):
 
 class Mollweide(_WarpedRectangularProjection):
     def __init__(self, central_longitude=0, globe=None):
+        if globe is None:
+            globe = Globe(semimajor_axis=WGS84_SEMIMAJOR_AXIS, ellipse=None)
+
+        # TODO: Let the globe return the semimajor axis always.
+        a = globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS
+        b = globe.semiminor_axis or a
+
+        if b != a or globe.ellipse is not None:
+            warnings.warn('The proj "moll" projection does not handle '
+                          'elliptical globes.')
+
         proj4_params = [('proj', 'moll'), ('lon_0', central_longitude)]
         super(Mollweide, self).__init__(proj4_params, central_longitude,
                                         globe=globe)
@@ -1701,6 +1714,17 @@ class Robinson(_WarpedRectangularProjection):
             warnings.warn('Cannot determine Proj version. The Robinson '
                           'projection may be unreliable and should be used '
                           'with caution.')
+
+        if globe is None:
+            globe = Globe(semimajor_axis=WGS84_SEMIMAJOR_AXIS, ellipse=None)
+
+        # TODO: Let the globe return the semimajor axis always.
+        a = globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS
+        b = globe.semiminor_axis or a
+
+        if b != a or globe.ellipse is not None:
+            warnings.warn('The proj "robin" projection does not handle '
+                          'elliptical globes.')
 
         proj4_params = [('proj', 'robin'), ('lon_0', central_longitude)]
         super(Robinson, self).__init__(proj4_params, central_longitude,

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1577,11 +1577,11 @@ class _Eckert(six.with_metaclass(ABCMeta, _WarpedRectangularProjection)):
         """
         Parameters
         ----------
-        central_longitude: optional
+        central_longitude: float, optional
             The central longitude. Defaults to 0.
-        false_easting: optional
+        false_easting: float, optional
             X offset from planar origin in metres. Defaults to 0.
-        false_northing: optional
+        false_northing: float, optional
             Y offset from planar origin in metres. Defaults to 0.
         globe: :class:`cartopy.crs.Globe`, optional
             If omitted, a default globe is created.

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1521,7 +1521,12 @@ class Orthographic(Projection):
 
 
 class _WarpedRectangularProjection(six.with_metaclass(ABCMeta, Projection)):
-    def __init__(self, proj4_params, central_longitude, globe=None):
+    def __init__(self, proj4_params, central_longitude,
+                 false_easting=None, false_northing=None, globe=None):
+        if false_easting is not None:
+            proj4_params += [('x_0', false_easting)]
+        if false_northing is not None:
+            proj4_params += [('y_0', false_northing)]
         super(_WarpedRectangularProjection, self).__init__(proj4_params,
                                                            globe=globe)
 
@@ -1567,12 +1572,17 @@ class _Eckert(six.with_metaclass(ABCMeta, _WarpedRectangularProjection)):
 
     """
 
-    def __init__(self, central_longitude=0, globe=None):
+    def __init__(self, central_longitude=0, false_easting=None,
+                 false_northing=None, globe=None):
         """
         Parameters
         ----------
         central_longitude: optional
             The central longitude. Defaults to 0.
+        false_easting: optional
+            X offset from planar origin in metres. Defaults to 0.
+        false_northing: optional
+            Y offset from planar origin in metres. Defaults to 0.
         globe: :class:`cartopy.crs.Globe`, optional
             If omitted, a default globe is created.
 
@@ -1594,6 +1604,8 @@ class _Eckert(six.with_metaclass(ABCMeta, _WarpedRectangularProjection)):
         proj4_params = [('proj', self._proj_name),
                         ('lon_0', central_longitude)]
         super(_Eckert, self).__init__(proj4_params, central_longitude,
+                                      false_easting=false_easting,
+                                      false_northing=false_northing,
                                       globe=globe)
 
     @property
@@ -1690,12 +1702,17 @@ class Mollweide(_WarpedRectangularProjection):
 
     """
 
-    def __init__(self, central_longitude=0, globe=None):
+    def __init__(self, central_longitude=0, globe=None,
+                 false_easting=None, false_northing=None):
         """
         Parameters
         ----------
         central_longitude: float, optional
             The central longitude. Defaults to 0.
+        false_easting: float, optional
+            X offset from planar origin in metres. Defaults to 0.
+        false_northing: float, optional
+            Y offset from planar origin in metres. Defaults to 0.
         globe: :class:`cartopy.crs.Globe`, optional
             If omitted, a default globe is created.
 
@@ -1716,6 +1733,8 @@ class Mollweide(_WarpedRectangularProjection):
 
         proj4_params = [('proj', 'moll'), ('lon_0', central_longitude)]
         super(Mollweide, self).__init__(proj4_params, central_longitude,
+                                        false_easting=false_easting,
+                                        false_northing=false_northing,
                                         globe=globe)
 
     @property
@@ -1735,12 +1754,17 @@ class Robinson(_WarpedRectangularProjection):
 
     """
 
-    def __init__(self, central_longitude=0, globe=None):
+    def __init__(self, central_longitude=0, globe=None,
+                 false_easting=None, false_northing=None):
         """
         Parameters
         ----------
         central_longitude: float, optional
             The central longitude. Defaults to 0.
+        false_easting: float, optional
+            X offset from planar origin in metres. Defaults to 0.
+        false_northing: float, optional
+            Y offset from planar origin in metres. Defaults to 0.
         globe: :class:`cartopy.crs.Globe`, optional
             If omitted, a default globe is created.
 
@@ -1775,6 +1799,8 @@ class Robinson(_WarpedRectangularProjection):
 
         proj4_params = [('proj', 'robin'), ('lon_0', central_longitude)]
         super(Robinson, self).__init__(proj4_params, central_longitude,
+                                       false_easting=false_easting,
+                                       false_northing=false_northing,
                                        globe=globe)
 
     @property

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1678,7 +1678,31 @@ class EckertVI(_Eckert):
 
 
 class Mollweide(_WarpedRectangularProjection):
+    """
+    A Mollweide projection.
+
+    This projection is pseudocylindrical, and equal area. Parallels are
+    unequally-spaced straight lines, while meridians are elliptical arcs up to
+    semicircles on the edges. Poles are points.
+
+    It is commonly used for world maps, or interrupted with several central
+    meridians.
+
+    """
+
     def __init__(self, central_longitude=0, globe=None):
+        """
+        Parameters
+        ----------
+        central_longitude: float, optional
+            The central longitude. Defaults to 0.
+        globe: :class:`cartopy.crs.Globe`, optional
+            If omitted, a default globe is created.
+
+            .. note::
+                This projection does not handle elliptical globes.
+
+        """
         if globe is None:
             globe = Globe(semimajor_axis=WGS84_SEMIMAJOR_AXIS, ellipse=None)
 
@@ -1700,7 +1724,30 @@ class Mollweide(_WarpedRectangularProjection):
 
 
 class Robinson(_WarpedRectangularProjection):
+    """
+    A Robinson projection.
+
+    This projection is pseudocylindrical, and a compromise that is neither
+    equal-area nor conformal. Parallels are unequally-spaced straight lines,
+    and meridians are curved lines of no particular form.
+
+    It is commonly used for "visually-appealing" world maps.
+
+    """
+
     def __init__(self, central_longitude=0, globe=None):
+        """
+        Parameters
+        ----------
+        central_longitude: float, optional
+            The central longitude. Defaults to 0.
+        globe: :class:`cartopy.crs.Globe`, optional
+            If omitted, a default globe is created.
+
+            .. note::
+                This projection does not handle elliptical globes.
+
+        """
         # Warn when using Robinson with proj 4.8 due to discontinuity at
         # 40 deg N introduced by incomplete fix to issue #113 (see
         # https://github.com/OSGeo/proj.4/issues/113).

--- a/lib/cartopy/tests/crs/test_eckert.py
+++ b/lib/cartopy/tests/crs/test_eckert.py
@@ -51,6 +51,23 @@ def test_default(name, proj, lim):
     assert_almost_equal(eck.y_limits, [-lim / 2, lim / 2])
 
 
+@pytest.mark.parametrize('name, proj', [
+    pytest.param('eck1', ccrs.EckertI, id='EckertI'),
+    pytest.param('eck2', ccrs.EckertII, id='EckertII'),
+    pytest.param('eck3', ccrs.EckertIII, id='EckertIII'),
+    pytest.param('eck4', ccrs.EckertIV, id='EckertIV'),
+    pytest.param('eck5', ccrs.EckertV, id='EckertV'),
+    pytest.param('eck6', ccrs.EckertVI, id='EckertVI'),
+])
+def test_offset(name, proj):
+    crs = proj()
+    crs_offset = proj(false_easting=1234, false_northing=-4321)
+    other_args = {'a=6378137.0', 'lon_0=0', 'x_0=1234', 'y_0=-4321'}
+    check_proj4_params(name, crs_offset, other_args)
+    assert tuple(np.array(crs.x_limits) + 1234) == crs_offset.x_limits
+    assert tuple(np.array(crs.y_limits) - 4321) == crs_offset.y_limits
+
+
 @pytest.mark.parametrize('name, proj, lim', [
     pytest.param('eck1', ccrs.EckertI, 18460911.739778, id='EckertI'),
     pytest.param('eck2', ccrs.EckertII, 18460911.739778, id='EckertII'),

--- a/lib/cartopy/tests/crs/test_mollweide.py
+++ b/lib/cartopy/tests/crs/test_mollweide.py
@@ -45,6 +45,15 @@ def test_default():
                         [-9020047.8480736, 9020047.8480736])
 
 
+def test_offset():
+    crs = ccrs.Mollweide()
+    crs_offset = ccrs.Mollweide(false_easting=1234, false_northing=-4321)
+    other_args = {'a=6378137.0', 'lon_0=0', 'x_0=1234', 'y_0=-4321'}
+    check_proj4_params(crs_offset, other_args)
+    assert tuple(np.array(crs.x_limits) + 1234) == crs_offset.x_limits
+    assert tuple(np.array(crs.y_limits) - 4321) == crs_offset.y_limits
+
+
 @pytest.mark.parametrize('lon', [-10.0, 10.0])
 def test_central_longitude(lon):
     moll = ccrs.Mollweide(central_longitude=lon)

--- a/lib/cartopy/tests/crs/test_mollweide.py
+++ b/lib/cartopy/tests/crs/test_mollweide.py
@@ -36,7 +36,7 @@ def check_proj4_params(crs, other_args):
 
 def test_default():
     moll = ccrs.Mollweide()
-    other_args = {'ellps=WGS84', 'lon_0=0'}
+    other_args = {'a=6378137.0', 'lon_0=0'}
     check_proj4_params(moll, other_args)
 
     assert_almost_equal(np.array(moll.x_limits),
@@ -45,23 +45,10 @@ def test_default():
                         [-9020047.8480736, 9020047.8480736])
 
 
-def test_eccentric_globe():
-    globe = ccrs.Globe(semimajor_axis=1000, semiminor_axis=500,
-                       ellipse=None)
-    moll = ccrs.Mollweide(globe=globe)
-    other_args = {'a=1000', 'b=500', 'lon_0=0'}
-    check_proj4_params(moll, other_args)
-
-    assert_almost_equal(np.array(moll.x_limits),
-                        [-2828.4271247, 2828.4271247])
-    assert_almost_equal(np.array(moll.y_limits),
-                        [-1414.2135623731, 1414.2135623731])
-
-
 @pytest.mark.parametrize('lon', [-10.0, 10.0])
 def test_central_longitude(lon):
     moll = ccrs.Mollweide(central_longitude=lon)
-    other_args = {'ellps=WGS84', 'lon_0={}'.format(lon)}
+    other_args = {'a=6378137.0', 'lon_0={}'.format(lon)}
     check_proj4_params(moll, other_args)
 
     assert_almost_equal(np.array(moll.x_limits),

--- a/lib/cartopy/tests/crs/test_robinson.py
+++ b/lib/cartopy/tests/crs/test_robinson.py
@@ -14,24 +14,19 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
-'''
+"""
 Tests for Robinson projection.
 
-For now, mostly tests the workaround for a specific problem.
-Problem report in : https://github.com/SciTools/cartopy/issues/23
-Fix covered in : https://github.com/SciTools/cartopy/pull/277
-
-'''
+"""
 
 from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal as assert_arr_almost_eq
+from numpy.testing import assert_array_almost_equal
 
 import cartopy.crs as ccrs
 
 
-_NAN = float('nan')
 _CRS_PC = ccrs.PlateCarree()
 _CRS_ROB = ccrs.Robinson()
 
@@ -40,50 +35,63 @@ _TOL = -1 if ccrs.PROJ4_VERSION < (4, 9) else 7
 
 
 def test_transform_point():
+    """
+    Mostly tests the workaround for a specific problem.
+    Problem report in: https://github.com/SciTools/cartopy/issues/23
+    Fix covered in: https://github.com/SciTools/cartopy/pull/277
+    """
+
     # this way has always worked
     result = _CRS_ROB.transform_point(35.0, 70.0, _CRS_PC)
-    assert_arr_almost_eq(result, (2376187.27182751, 7275317.81573085), _TOL)
+    assert_array_almost_equal(result, (2376187.27182751, 7275317.81573085),
+                              _TOL)
 
     # this always did something, but result has altered
-    result = _CRS_ROB.transform_point(_NAN, 70.0, _CRS_PC)
+    result = _CRS_ROB.transform_point(np.nan, 70.0, _CRS_PC)
     assert np.all(np.isnan(result))
 
     # this used to crash + is now fixed
-    result = _CRS_ROB.transform_point(35.0, _NAN, _CRS_PC)
+    result = _CRS_ROB.transform_point(35.0, np.nan, _CRS_PC)
     assert np.all(np.isnan(result))
 
 
 def test_transform_points():
+    """
+    Mostly tests the workaround for a specific problem.
+    Problem report in: https://github.com/SciTools/cartopy/issues/23
+    Fix covered in: https://github.com/SciTools/cartopy/pull/277
+    """
+
     # these always worked
     result = _CRS_ROB.transform_points(_CRS_PC,
                                        np.array([35.0]),
                                        np.array([70.0]))
-    assert_arr_almost_eq(result,
-                         [[2376187.27182751, 7275317.81573085, 0]], _TOL)
+    assert_array_almost_equal(result,
+                              [[2376187.27182751, 7275317.81573085, 0]], _TOL)
 
     result = _CRS_ROB.transform_points(_CRS_PC,
                                        np.array([35.0]),
                                        np.array([70.0]),
                                        np.array([0.0]))
-    assert_arr_almost_eq(result,
-                         [[2376187.27182751, 7275317.81573085, 0]], _TOL)
+    assert_array_almost_equal(result,
+                              [[2376187.27182751, 7275317.81573085, 0]], _TOL)
 
     # this always did something, but result has altered
     result = _CRS_ROB.transform_points(_CRS_PC,
-                                       np.array([_NAN]),
+                                       np.array([np.nan]),
                                        np.array([70.0]))
     assert np.all(np.isnan(result))
 
     # this used to crash + is now fixed
     result = _CRS_ROB.transform_points(_CRS_PC,
                                        np.array([35.0]),
-                                       np.array([_NAN]))
+                                       np.array([np.nan]))
     assert np.all(np.isnan(result))
 
     # multipoint case
-    x = np.array([10.0, 21.0, 0.0, 77.7, _NAN, 0.0])
-    y = np.array([10.0, _NAN, 10.0, 77.7, 55.5, 0.0])
-    z = np.array([10.0, 0.0, 0.0, _NAN, 55.5, 0.0])
+    x = np.array([10.0, 21.0, 0.0, 77.7, np.nan, 0.0])
+    y = np.array([10.0, np.nan, 10.0, 77.7, 55.5, 0.0])
+    z = np.array([10.0, 0.0, 0.0, np.nan, 55.5, 0.0])
     expect_result = np.array(
         [[9.40422591e+05, 1.06952091e+06, 1.00000000e+01],
          [11.1, 11.2, 11.3],

--- a/lib/cartopy/tests/crs/test_robinson.py
+++ b/lib/cartopy/tests/crs/test_robinson.py
@@ -53,6 +53,15 @@ def test_default():
                         [-8625154.6651000, 8625154.6651000], _LIMIT_TOL)
 
 
+def test_offset():
+    crs = ccrs.Robinson()
+    crs_offset = ccrs.Robinson(false_easting=1234, false_northing=-4321)
+    other_args = {'a=6378137.0', 'lon_0=0', 'x_0=1234', 'y_0=-4321'}
+    check_proj_params(crs_offset, other_args)
+    assert tuple(np.array(crs.x_limits) + 1234) == crs_offset.x_limits
+    assert tuple(np.array(crs.y_limits) - 4321) == crs_offset.y_limits
+
+
 @pytest.mark.parametrize('lon', [-10.0, 10.0])
 def test_central_longitude(lon):
     robin = ccrs.Robinson(central_longitude=lon)

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -175,9 +175,11 @@ class TestCRS(object):
     def test_globe(self):
         # Ensure the globe affects output.
         rugby_globe = ccrs.Globe(semimajor_axis=9000000,
-                                 semiminor_axis=1000000)
+                                 semiminor_axis=9000000,
+                                 ellipse=None)
         footy_globe = ccrs.Globe(semimajor_axis=1000000,
-                                 semiminor_axis=1000000)
+                                 semiminor_axis=1000000,
+                                 ellipse=None)
 
         rugby_moll = ccrs.Mollweide(globe=rugby_globe)
         footy_moll = ccrs.Mollweide(globe=footy_globe)


### PR DESCRIPTION
Improves warped rectangular projections in a few ways:
* add the standard set of tests for Robinson
* it turns out that Mollweide and Robinson do not support ellipses, so warn about them and remove tests for it
* add support for offsets (false easting/northing) to Mollweide and Robinson
* add docs for Mollweide and Robinson