### PR TITLE
Implement cartopy.mpl.style for matplotlib style composition

### DIFF
--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -475,7 +475,7 @@ class WFSFeature(Feature):
 
 
 BORDERS = NaturalEarthFeature('cultural', 'admin_0_boundary_lines_land',
-                              '110m', edgecolor='black', facecolor='none')
+                              '110m', edgecolor='black', facecolor='never')
 """Small scale (1:110m) country boundaries."""
 
 STATES = NaturalEarthFeature('cultural', 'admin_1_states_provinces_lakes',
@@ -483,7 +483,7 @@ STATES = NaturalEarthFeature('cultural', 'admin_1_states_provinces_lakes',
 """Small scale (1:110m) state and province boundaries."""
 
 COASTLINE = NaturalEarthFeature('physical', 'coastline', '110m',
-                                edgecolor='black', facecolor='none')
+                                edgecolor='black', facecolor='never')
 """Small scale (1:110m) coastline, including major islands."""
 
 
@@ -507,5 +507,5 @@ OCEAN = NaturalEarthFeature('physical', 'ocean', '110m',
 
 RIVERS = NaturalEarthFeature('physical', 'rivers_lake_centerlines', '110m',
                              edgecolor=COLORS['water'],
-                             facecolor='none')
+                             facecolor='never')
 """Small scale (1:110m) single-line drainages, including lake centerlines."""

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -200,8 +200,7 @@ class FeatureArtist(matplotlib.artist.Artist):
                 style = prepared_kwargs
             else:
                 # Unfreeze, then add the computed style, and then re-freeze.
-                style = dict(prepared_kwargs)
-                style.update(self._styler(geom))
+                style = style_merge(dict(prepared_kwargs), self._styler(geom))
                 style = _freeze(style)
 
             stylised_paths.setdefault(style, []).extend(geom_paths)
@@ -215,9 +214,7 @@ class FeatureArtist(matplotlib.artist.Artist):
             style = style_finalize(dict(style))
             # Build path collection and draw it.
             c = matplotlib.collections.PathCollection(
-                    paths,
-                    transform=transform,
-                    **dict(style))
+                    paths, transform=transform, **style)
             c.set_clip_path(ax.patch)
             c.set_figure(ax.figure)
             c.draw(renderer)

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -159,7 +159,8 @@ class FeatureArtist(matplotlib.artist.Artist):
         geoms = self._feature.intersecting_geometries(extent)
 
         # Combine all the keyword args in priority order.
-        prepared_kwargs = style_merge(self._feature.kwargs, self._kwargs, kwargs)
+        prepared_kwargs = style_merge(
+                self._feature.kwargs, self._kwargs, kwargs)
 
         # Freeze the kwargs so that we can use them as a dict key. We will
         # need to unfreeze this with dict(frozen) before passing to mpl.

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -31,6 +31,7 @@ import matplotlib.artist
 import matplotlib.collections
 
 import cartopy.mpl.patch as cpatch
+from .style import merge as style_merge, finalize as style_finalize
 
 
 class _GeomKey(object):
@@ -158,9 +159,7 @@ class FeatureArtist(matplotlib.artist.Artist):
         geoms = self._feature.intersecting_geometries(extent)
 
         # Combine all the keyword args in priority order.
-        prepared_kwargs = dict(self._feature.kwargs)
-        prepared_kwargs.update(self._kwargs)
-        prepared_kwargs.update(kwargs)
+        prepared_kwargs = style_merge(self._feature.kwargs, self._kwargs, kwargs)
 
         # Freeze the kwargs so that we can use them as a dict key. We will
         # need to unfreeze this with dict(frozen) before passing to mpl.
@@ -212,6 +211,7 @@ class FeatureArtist(matplotlib.artist.Artist):
         # of style items through to a single PathCollection, but that
         # complexity does not yet justify the effort.
         for style, paths in stylised_paths.items():
+            style = style_finalize(dict(style))
             # Build path collection and draw it.
             c = matplotlib.collections.PathCollection(
                     paths,

--- a/lib/cartopy/mpl/style.py
+++ b/lib/cartopy/mpl/style.py
@@ -1,0 +1,82 @@
+"""
+Handles matplotlib styling in a single consistent place.
+
+"""
+
+# Note: This should not contain the plural aliases (e.g. linewidths -> linewidth).
+# This is an intended duplication of
+# https://github.com/matplotlib/matplotlib/blob/\
+#   2d2dab511d22b6cc9c812cfbcca6df3f9bf3094a/lib/matplotlib/patches.py#L20-L26
+# Duplication intended to simplify readability, given the small number of
+# aliases.
+ALIASES = {
+    'lw': 'linewidth',
+    'ls': 'linestyle',
+    'fc': 'facecolor',
+    'ec': 'edgecolor',
+}
+
+
+
+def merge(*style_dicts):
+    """
+    Merges together multiple matplotlib style dictionaries in a predictable way.
+
+    The approach taken is:
+
+        For each style:
+            * Expand aliases, such as "lw" -> "linewidth", but always prefer
+              the full form if over-specified (i.e. lw AND linewidth
+              are both set)
+            * "color" overwrites "facecolor" and "edgecolor" (as per
+              matplotlib), UNLESS facecolor == "never", which will be expanded
+              at finalization to 'none'
+
+    >>> merge({'lw': 1, "edgecolor": "black", "facecolor": "never"},
+    ...       {"linewidth": 2, "color": "gray"})
+    {'edgecolor': 'gray', 'facecolor': 'none', 'linewidth': 2}
+
+    """
+    style = {}
+    facecolor = None
+
+    for orig_style in style_dicts:
+        this_style = orig_style.copy()
+
+        for alias_from, alias_to in ALIASES.items():
+            alias = this_style.pop(alias_from, None)
+            if alias:
+                # n.b. alias_from doesn't trump alias_to
+                # (e.g. 'lw' doesn't trump 'linewidth').
+                this_style.setdefault(alias_to, alias)
+
+        color = this_style.pop('color', None)
+        if color:
+            this_style['edgecolor'] = color
+            this_style['facecolor'] = color
+
+        if facecolor == 'never':
+            this_style.pop('facecolor', None)
+        else:
+            facecolor = this_style.get('facecolor', facecolor)
+
+        # Push the remainder of the style into the merged style.
+        style.update(this_style)
+
+    return style
+
+
+def finalize(style):
+    """
+    Update the given matplotlib style according to cartopy's style rules.
+
+    Rules:
+
+        1. A facecolor of 'never' is replaced with 'none'.
+
+    """
+    # Expand 'never' to 'none' if we have it.
+    facecolor = style.get('facecolor', None)
+    if facecolor == 'never':
+        style['facecolor'] = 'none'
+    return style

--- a/lib/cartopy/mpl/style.py
+++ b/lib/cartopy/mpl/style.py
@@ -81,8 +81,10 @@ def merge(*style_dicts):
 
         if isinstance(facecolor, six.string_types) and facecolor == 'never':
             requested_color = this_style.pop('facecolor', None)
-            if ('fc' in orig_style or 'facecolor' in orig_style and
-                    requested_color != 'none'):
+            setting_color = not (isinstance(requested_color, six.string_types)
+                                 and requested_color.lower() == 'none')
+            if (('fc' in orig_style or 'facecolor' in orig_style) and
+                    setting_color):
                 warnings.warn('facecolor will have no effect as it has been '
                               'defined as "never".')
         else:

--- a/lib/cartopy/mpl/style.py
+++ b/lib/cartopy/mpl/style.py
@@ -56,9 +56,10 @@ def merge(*style_dicts):
               matplotlib), UNLESS facecolor == "never", which will be expanded
               at finalization to 'none'
 
-    >>> merge({"lw": 1, "edgecolor": "black", "facecolor": "never"},
-    ...       {"linewidth": 2, "color": "gray"})
-    {'edgecolor': 'gray', 'facecolor': 'never', 'linewidth': 2}
+    >>> style = merge({"lw": 1, "edgecolor": "black", "facecolor": "never"},
+    ...               {"linewidth": 2, "color": "gray"})
+    >>> sorted(style.items())
+    [('edgecolor', 'gray'), ('facecolor', 'never'), ('linewidth', 2)]
 
     """
     style = {}

--- a/lib/cartopy/mpl/style.py
+++ b/lib/cartopy/mpl/style.py
@@ -1,15 +1,38 @@
+# (C) British Crown Copyright 2018, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+
 """
 Handles matplotlib styling in a single consistent place.
 
 """
+import warnings
 
-# Note: This should not contain the plural aliases (e.g. linewidths -> linewidth).
+
+# Define the matplotlib style aliases that cartopy can expand.
+# Note: This should not contain the plural aliases
+# (e.g. linewidths -> linewidth).
 # This is an intended duplication of
 # https://github.com/matplotlib/matplotlib/blob/\
 #   2d2dab511d22b6cc9c812cfbcca6df3f9bf3094a/lib/matplotlib/patches.py#L20-L26
 # Duplication intended to simplify readability, given the small number of
 # aliases.
-ALIASES = {
+_ALIASES = {
     'lw': 'linewidth',
     'ls': 'linestyle',
     'fc': 'facecolor',
@@ -17,10 +40,9 @@ ALIASES = {
 }
 
 
-
 def merge(*style_dicts):
     """
-    Merges together multiple matplotlib style dictionaries in a predictable way.
+    Merge together multiple matplotlib style dictionaries in a predictable way
 
     The approach taken is:
 
@@ -43,7 +65,7 @@ def merge(*style_dicts):
     for orig_style in style_dicts:
         this_style = orig_style.copy()
 
-        for alias_from, alias_to in ALIASES.items():
+        for alias_from, alias_to in _ALIASES.items():
             alias = this_style.pop(alias_from, None)
             if alias:
                 # n.b. alias_from doesn't trump alias_to
@@ -57,6 +79,9 @@ def merge(*style_dicts):
 
         if facecolor == 'never':
             this_style.pop('facecolor', None)
+            if 'fc' in orig_style or 'facecolor' in orig_style:
+                warnings.warn('facecolor may not be set, as it has been '
+                              'defined as "never".')
         else:
             facecolor = this_style.get('facecolor', facecolor)
 

--- a/lib/cartopy/tests/mpl/test_feature_artist.py
+++ b/lib/cartopy/tests/mpl/test_feature_artist.py
@@ -30,7 +30,7 @@ import cartopy.crs as ccrs
 import cartopy.mpl.geoaxes as geoaxes
 from cartopy.feature import ShapelyFeature
 from cartopy.mpl.feature_artist import FeatureArtist, _freeze, _GeomKey
-
+from cartopy.mpl import style
 
 @pytest.mark.parametrize("source, expected", [
     [{1: 0}, frozenset({(1, 0)})],
@@ -108,6 +108,7 @@ def test_feature_artist_draw_styler(path_collection_cls, feature):
     geoms = list(feature.geometries())
     style1 = {'facecolor': 'blue', 'edgecolor': 'white'}
     style2 = {'color': 'black', 'linewidth': 1}
+    style2_finalized = style.finalize(style.merge(style2))
 
     def styler(geom):
         if geom == geoms[0]:
@@ -126,7 +127,7 @@ def test_feature_artist_draw_styler(path_collection_cls, feature):
     calls = [{'paths': (cached_paths(geoms[0], prj_crs), ),
               'style': dict(linewidth=2, **style1)},
              {'paths': (cached_paths(geoms[1], prj_crs), ),
-              'style': style2}]
+              'style': style2_finalized}]
 
     assert path_collection_cls.call_count == 2
     for expected_call, (actual_args, actual_kwargs) in \

--- a/lib/cartopy/tests/mpl/test_style.py
+++ b/lib/cartopy/tests/mpl/test_style.py
@@ -19,7 +19,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import pytest
 
-from ...mpl import style
+from cartopy.mpl import style
 
 
 d = dict
@@ -51,6 +51,10 @@ d = dict
       d(linewidth=2)),
      ([d(lw=1, linewidth=2), d(lw=3)],
       d(linewidth=3)),
+     ([d(color=None), d(facecolor='red')],
+      d(facecolor='red', edgecolor=None)),
+     ([d(linewidth=1), d(lw=None)],
+      d(linewidth=None)),
      ]
 )
 def test_merge(styles, expected):

--- a/lib/cartopy/tests/mpl/test_style.py
+++ b/lib/cartopy/tests/mpl/test_style.py
@@ -1,10 +1,32 @@
+# (C) British Crown Copyright 2018, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
 
 import pytest
+
 from ...mpl import style
+
 
 d = dict
 
-@pytest.mark.parametrize(('styles', 'expected'),
+
+@pytest.mark.parametrize(
+    ('styles', 'expected'),
     [([], {}),
      ([{}, {}, {}], {}),
      ([{}, d(a=2), d(a=1)], d(a=1)),
@@ -22,25 +44,33 @@ d = dict
      # Even if you set an edgecolor, color should trump it.
      ([d(color='blue'), d(edgecolor='red', color='yellow')],
       d(edgecolor='yellow', facecolor='yellow')),
-    # Support for 'never' being honoured.
+     # Support for 'never' being honoured.
      ([d(facecolor='never'), d(color='yellow')],
       d(edgecolor='yellow', facecolor='never')),
      ([d(lw=1, linewidth=2)],
       d(linewidth=2)),
      ([d(lw=1, linewidth=2), d(lw=3)],
       d(linewidth=3)),
-    ])
+     ]
+)
 def test_merge(styles, expected):
     merged_style = style.merge(*styles)
     assert merged_style == expected
 
 
-@pytest.mark.parametrize(('style_d', 'expected'),
-   [
-    # Support for 'never' being honoured.
-    (d(facecolor='never', edgecolor='yellow'),
-     d(edgecolor='yellow', facecolor='none')),
-   ])
+def test_merge_warning():
+    with pytest.warns(UserWarning, match=r'defined as \"never\"') as record:
+        style.merge({'facecolor': 'never'}, {'fc': 'red'})
+    assert len(record) == 1
+
+
+@pytest.mark.parametrize(
+    ('style_d', 'expected'),
+    [
+     # Support for 'never' being honoured.
+     (d(facecolor='never', edgecolor='yellow'),
+      d(edgecolor='yellow', facecolor='none')),
+    ])
 def test_finalize(style_d, expected):
     assert style.finalize(style_d) == expected
     # Double check we are updating in-place

--- a/lib/cartopy/tests/mpl/test_style.py
+++ b/lib/cartopy/tests/mpl/test_style.py
@@ -1,0 +1,47 @@
+
+import pytest
+from ...mpl import style
+
+d = dict
+
+@pytest.mark.parametrize(('styles', 'expected'),
+    [([], {}),
+     ([{}, {}, {}], {}),
+     ([{}, d(a=2), d(a=1)], d(a=1)),
+     ([d(fc='red')], d(facecolor='red')),
+     ([d(fc='red', color='blue')], d(facecolor='blue', edgecolor='blue')),
+     ([d(fc='red', facecolor='blue')], d(facecolor='blue')),
+     ([d(color='red')],
+      d(edgecolor='red', facecolor='red')),
+     ([d(edgecolor='blue'), d(color='red')],
+      d(edgecolor='red', facecolor='red')),
+     ([d(edgecolor='blue'), d(color='red')],
+      d(edgecolor='red', facecolor='red')),
+     ([d(color='blue'), d(edgecolor='red')],
+      d(edgecolor='red', facecolor='blue')),
+     # Even if you set an edgecolor, color should trump it.
+     ([d(color='blue'), d(edgecolor='red', color='yellow')],
+      d(edgecolor='yellow', facecolor='yellow')),
+    # Support for 'never' being honoured.
+     ([d(facecolor='never'), d(color='yellow')],
+      d(edgecolor='yellow', facecolor='never')),
+     ([d(lw=1, linewidth=2)],
+      d(linewidth=2)),
+     ([d(lw=1, linewidth=2), d(lw=3)],
+      d(linewidth=3)),
+    ])
+def test_merge(styles, expected):
+    merged_style = style.merge(*styles)
+    assert merged_style == expected
+
+
+@pytest.mark.parametrize(('style_d', 'expected'),
+   [
+    # Support for 'never' being honoured.
+    (d(facecolor='never', edgecolor='yellow'),
+     d(edgecolor='yellow', facecolor='none')),
+   ])
+def test_finalize(style_d, expected):
+    assert style.finalize(style_d) == expected
+    # Double check we are updating in-place
+    assert style_d == expected

--- a/lib/cartopy/tests/mpl/test_style.py
+++ b/lib/cartopy/tests/mpl/test_style.py
@@ -62,10 +62,14 @@ def test_merge(styles, expected):
     assert merged_style == expected
 
 
-def test_merge_warning():
-    with pytest.warns(UserWarning, match=r'defined as \"never\"') as record:
-        style.merge({'facecolor': 'never'}, {'fc': 'red'})
-    assert len(record) == 1
+@pytest.mark.parametrize(
+    ('case', 'should_warn'),
+    [[{'fc': 'red'}, True], [{'fc': 'NoNe'}, False], [{'fc': 1}, True]])
+def test_merge_warning(case, should_warn):
+    warn_type = UserWarning if should_warn else None
+    with pytest.warns(warn_type, match=r'defined as \"never\"') as record:
+        style.merge({'facecolor': 'never'}, case)
+    assert len(record) == (1 if should_warn else 0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

## Rationale
Follows up from #1029 to support composable matplotlib styles.

**cartopy.mpl.style.merge** - join together one or more style dictionaries, using expansion suggested by @QuLogic in #1029.
**cartopy.mpl.style.finalize** - expand special meaning attributed in a style dictionary. Currently, this is just facecolor="never" -> facecolor="none"

## Implications

Closes #1029, #803, #1030.