### PR TITLE
Issue a warning when using the default origin with imshow

### DIFF
--- a/lib/cartopy/examples/eccentric_ellipse.py
+++ b/lib/cartopy/examples/eccentric_ellipse.py
@@ -64,7 +64,7 @@ def main():
 
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1, projection=projection)
-    ax.imshow(img, transform=crs, extent=extent)
+    ax.imshow(img, transform=crs, extent=extent, origin='lower')
     fig.text(.075, .012, "Image credit: NASA/JPL-Caltech/UCLA/MPS/DLR/IDA/PSI",
              bbox={'facecolor': 'w', 'edgecolor': 'k'})
     plt.show()

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1112,6 +1112,12 @@ class GeoAxes(matplotlib.axes.Axes):
                              'imshow. To hold the data and view limits see '
                              'GeoAxes.hold_limits.')
 
+        if 'origin' not in kwargs:
+            import warnings
+            warnings.warn('The default value for the origin argument will'
+                          ' change from "lower" to "upper" in CartoPy 0.18.',
+                          FutureWarning)
+
         kwargs.setdefault('origin', 'lower')
 
         same_projection = (isinstance(transform, ccrs.Projection) and

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -146,6 +146,15 @@ def test_imshow_projected():
     ax.imshow(img, extent=img_extent, origin='upper', transform=source_proj)
 
 
+def test_imshow_default_origin_warns():
+    """Test that using the default value for origin issues a warning."""
+    proj = ccrs.PlateCarree()
+    img = plt.imread(NATURAL_EARTH_IMG)
+    ax = plt.axes(projection=proj)
+    with pytest.warns(FutureWarning):
+        ax.imshow(img)
+
+
 @pytest.mark.xfail((5, 0, 0) <= ccrs.PROJ4_VERSION < (5, 1, 0),
                    reason='Proj Orthographic projection is buggy.',
                    strict=True)


### PR DESCRIPTION
Paving the way to changing the default in a subsequent release.

Addressing part of #1187 .