### PR TITLE
Add raster caching to smooth pan/zoom

### DIFF
--- a/lib/cartopy/mpl/slippy_image_artist.py
+++ b/lib/cartopy/mpl/slippy_image_artist.py
@@ -41,6 +41,20 @@ class SlippyImageArtist(AxesImage):
         self.raster_source = raster_source
         super(SlippyImageArtist, self).__init__(ax, **kwargs)
         self.set_clip_path(ax.outline_patch)
+        self.cache = []
+
+        ax.figure.canvas.mpl_connect('button_press_event', self.on_press)
+        ax.figure.canvas.mpl_connect('button_release_event', self.on_release)
+
+        self.on_release()
+
+    def on_press(self, event=None):
+        self.user_is_interacting = True
+        self.stale = True
+
+    def on_release(self, event=None):
+        self.user_is_interacting = False
+        self.stale = True
 
     @matplotlib.artist.allow_rasterization
     def draw(self, renderer, *args, **kwargs):
@@ -50,11 +64,13 @@ class SlippyImageArtist(AxesImage):
         ax = self.axes
         window_extent = ax.get_window_extent()
         [x1, y1], [x2, y2] = ax.viewLim.get_points()
-        located_images = self.raster_source.fetch_raster(
-            ax.projection, extent=[x1, x2, y1, y2],
-            target_resolution=(window_extent.width, window_extent.height))
+        if not self.user_is_interacting:
+            located_images = self.raster_source.fetch_raster(
+                ax.projection, extent=[x1, x2, y1, y2],
+                target_resolution=(window_extent.width, window_extent.height))
+            self.cache = located_images
 
-        for img, extent in located_images:
+        for img, extent in self.cache:
             self.set_array(img)
             with ax.hold_limits():
                 self.set_extent(extent)


### PR DESCRIPTION
## Rationale

Allow SlippyImageArtist to cache images to be re-drawn while interacting with the figure.
This makes slow rendering images (such as those going to the net, or images that need reprojecting) not lock up the interactivity of pan/zoom and to only trigger the re-fetch once we have finished interacting.

Note: Implementation from @kaedonkers. I've just lifted a commit from #1192 (@dkillick's  PR). 

## Implications

Adds a cache to SlippyImageArtist that is invalidated each full redraw request.