### PR TITLE
SlippyImageArtist redraw on mouse down

### DIFF
--- a/lib/cartopy/mpl/slippy_image_artist.py
+++ b/lib/cartopy/mpl/slippy_image_artist.py
@@ -50,7 +50,6 @@ class SlippyImageArtist(AxesImage):
 
     def on_press(self, event=None):
         self.user_is_interacting = True
-        self.stale = True
 
     def on_release(self, event=None):
         self.user_is_interacting = False


### PR DESCRIPTION
## Rationale

Based on the observation in https://github.com/SciTools/cartopy/pull/1195#discussion_r234094025, there really is no need to force a re-draw when the mouse goes down.

## Implications

For expensive RasterSources, improved interaction experience.