### PR TITLE
Refactor ellipse warnings and add tests for spherical-only projections

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1520,7 +1520,7 @@ class Orthographic(Projection):
 
         # To stabilise the projection of geometries, we reduce the boundary by
         # a tiny fraction at the cost of the extreme edges.
-        coords = _ellipse_boundary(a * 0.99999, b * 0.99999, n=61)
+        coords = _ellipse_boundary(a * 0.99999, a * 0.99999, n=61)
         self._boundary = sgeom.polygon.LinearRing(coords.T)
         mins = np.min(coords, axis=1)
         maxs = np.max(coords, axis=1)

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1364,6 +1364,8 @@ class RotatedPole(_CylindricalProjection):
 
 
 class Gnomonic(Projection):
+    _handles_ellipses = False
+
     def __init__(self, central_latitude=0.0,
                  central_longitude=0.0, globe=None):
         proj4_params = [('proj', 'gnom'), ('lat_0', central_latitude),

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -33,16 +33,13 @@ import shapely.geometry as sgeom
 from shapely.prepared import prep
 import six
 
-from cartopy._crs import CRS, Geodetic, Globe, PROJ4_VERSION
+from cartopy._crs import (CRS, Geodetic, Globe, PROJ4_VERSION,
+                          WGS84_SEMIMAJOR_AXIS, WGS84_SEMIMINOR_AXIS)
 from cartopy._crs import Geocentric  # noqa: F401 (flake8 = unused import)
 import cartopy.trace
 
 
 __document_these__ = ['CRS', 'Geocentric', 'Geodetic', 'Globe']
-
-
-WGS84_SEMIMAJOR_AXIS = 6378137.0
-WGS84_SEMIMINOR_AXIS = 6356752.3142
 
 
 class RotatedGeodetic(CRS):
@@ -1299,17 +1296,14 @@ class LambertAzimuthalEqualArea(Projection):
 
 
 class Miller(_RectangularProjection):
+    _handles_ellipses = False
+
     def __init__(self, central_longitude=0.0, globe=None):
         if globe is None:
             globe = Globe(semimajor_axis=math.degrees(1), ellipse=None)
 
         # TODO: Let the globe return the semimajor axis always.
         a = np.float(globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS)
-        b = np.float(globe.semiminor_axis or a)
-
-        if b != a or globe.ellipse is not None:
-            warnings.warn('The proj "mill" projection does not handle '
-                          'elliptical globes.')
 
         proj4_params = [('proj', 'mill'), ('lon_0', central_longitude)]
         # See Snyder, 1987. Eqs (11-1) and (11-2) substituting maximums of
@@ -1493,6 +1487,8 @@ class SouthPolarStereo(Stereographic):
 
 
 class Orthographic(Projection):
+    _handles_ellipses = False
+
     def __init__(self, central_longitude=0.0, central_latitude=0.0,
                  globe=None):
         if PROJ4_VERSION != ():
@@ -1512,11 +1508,6 @@ class Orthographic(Projection):
 
         # TODO: Let the globe return the semimajor axis always.
         a = np.float(self.globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS)
-        b = np.float(self.globe.semiminor_axis or a)
-
-        if b != a:
-            warnings.warn('The proj "ortho" projection does not appear to '
-                          'handle elliptical globes.')
 
         # To stabilise the projection of geometries, we reduce the boundary by
         # a tiny fraction at the cost of the extreme edges.
@@ -1597,6 +1588,8 @@ class _Eckert(six.with_metaclass(ABCMeta, _WarpedRectangularProjection)):
 
     """
 
+    _handles_ellipses = False
+
     def __init__(self, central_longitude=0, false_easting=None,
                  false_northing=None, globe=None):
         """
@@ -1615,17 +1608,6 @@ class _Eckert(six.with_metaclass(ABCMeta, _WarpedRectangularProjection)):
                 This projection does not handle elliptical globes.
 
         """
-        if globe is None:
-            globe = Globe(semimajor_axis=WGS84_SEMIMAJOR_AXIS, ellipse=None)
-
-        # TODO: Let the globe return the semimajor axis always.
-        a = globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS
-        b = globe.semiminor_axis or a
-
-        if b != a or globe.ellipse is not None:
-            warnings.warn('The proj "{}" projection does not handle '
-                          'elliptical globes.'.format(self._proj_name))
-
         proj4_params = [('proj', self._proj_name),
                         ('lon_0', central_longitude)]
         super(_Eckert, self).__init__(proj4_params, central_longitude,
@@ -1779,6 +1761,8 @@ class Mollweide(_WarpedRectangularProjection):
 
     """
 
+    _handles_ellipses = False
+
     def __init__(self, central_longitude=0, globe=None,
                  false_easting=None, false_northing=None):
         """
@@ -1797,17 +1781,6 @@ class Mollweide(_WarpedRectangularProjection):
                 This projection does not handle elliptical globes.
 
         """
-        if globe is None:
-            globe = Globe(semimajor_axis=WGS84_SEMIMAJOR_AXIS, ellipse=None)
-
-        # TODO: Let the globe return the semimajor axis always.
-        a = globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS
-        b = globe.semiminor_axis or a
-
-        if b != a or globe.ellipse is not None:
-            warnings.warn('The proj "moll" projection does not handle '
-                          'elliptical globes.')
-
         proj4_params = [('proj', 'moll'), ('lon_0', central_longitude)]
         super(Mollweide, self).__init__(proj4_params, central_longitude,
                                         false_easting=false_easting,
@@ -1830,6 +1803,8 @@ class Robinson(_WarpedRectangularProjection):
     It is commonly used for "visually-appealing" world maps.
 
     """
+
+    _handles_ellipses = False
 
     def __init__(self, central_longitude=0, globe=None,
                  false_easting=None, false_northing=None):
@@ -1862,17 +1837,6 @@ class Robinson(_WarpedRectangularProjection):
             warnings.warn('Cannot determine Proj version. The Robinson '
                           'projection may be unreliable and should be used '
                           'with caution.')
-
-        if globe is None:
-            globe = Globe(semimajor_axis=WGS84_SEMIMAJOR_AXIS, ellipse=None)
-
-        # TODO: Let the globe return the semimajor axis always.
-        a = globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS
-        b = globe.semiminor_axis or a
-
-        if b != a or globe.ellipse is not None:
-            warnings.warn('The proj "robin" projection does not handle '
-                          'elliptical globes.')
 
         proj4_params = [('proj', 'robin'), ('lon_0', central_longitude)]
         super(Robinson, self).__init__(proj4_params, central_longitude,
@@ -2126,6 +2090,9 @@ class NearsidePerspective(_Satellite):
     point (e.g. a satellite).
 
     """
+
+    _handles_ellipses = False
+
     def __init__(self, central_longitude=0.0, central_latitude=0.0,
                  satellite_height=35785831,
                  false_easting=0, false_northing=0, globe=None):
@@ -2150,17 +2117,6 @@ class NearsidePerspective(_Satellite):
                 This projection does not handle elliptical globes.
 
         """
-        if globe is None:
-            globe = Globe(semimajor_axis=WGS84_SEMIMAJOR_AXIS, ellipse=None)
-
-        # TODO: Let the globe return the semimajor axis always.
-        a = globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS
-        b = globe.semiminor_axis or a
-
-        if b != a or globe.ellipse is not None:
-            warnings.warn('The proj "nsper" projection does not handle '
-                          'elliptical globes.')
-
         super(NearsidePerspective, self).__init__(
             projection='nsper',
             satellite_height=satellite_height,
@@ -2169,6 +2125,9 @@ class NearsidePerspective(_Satellite):
             false_easting=false_easting,
             false_northing=false_northing,
             globe=globe)
+
+        # TODO: Let the globe return the semimajor axis always.
+        a = self.globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS
 
         h = np.float(satellite_height)
         max_x = a * np.sqrt(h / (2 * a + h))

--- a/lib/cartopy/tests/crs/helpers.py
+++ b/lib/cartopy/tests/crs/helpers.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2018, Met Office
+# (C) British Crown Copyright 2018, Met Office
 #
 # This file is part of cartopy.
 #
@@ -15,13 +15,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
 """
-Tests for specific Cartopy CRS subclasses.
+Helpers for Cartopy CRS subclass tests.
 
 """
 
 from __future__ import (absolute_import, division, print_function)
 
-import pytest
 
-
-pytest.register_assert_rewrite('cartopy.tests.crs.helpers')
+def check_proj_params(name, crs, other_args):
+    expected = other_args | {'proj=' + name, 'no_defs'}
+    proj_params = set(crs.proj4_init.lstrip('+').split(' +'))
+    assert expected == proj_params

--- a/lib/cartopy/tests/crs/test_albers_equal_area.py
+++ b/lib/cartopy/tests/crs/test_albers_equal_area.py
@@ -26,12 +26,7 @@ from numpy.testing import assert_almost_equal, assert_array_almost_equal
 import pytest
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=aea', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 class TestAlbersEqualArea(object):
@@ -39,7 +34,7 @@ class TestAlbersEqualArea(object):
         aea = ccrs.AlbersEqualArea()
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',
                       'y_0=0.0', 'lat_1=20.0', 'lat_2=50.0'}
-        check_proj4_params(aea, other_args)
+        check_proj_params('aea', aea, other_args)
 
         assert_almost_equal(np.array(aea.x_limits),
                             [-17702759.799178038, 17702759.799178038],
@@ -54,7 +49,7 @@ class TestAlbersEqualArea(object):
         aea = ccrs.AlbersEqualArea(globe=globe)
         other_args = {'a=1000', 'b=500', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',
                       'y_0=0.0', 'lat_1=20.0', 'lat_2=50.0'}
-        check_proj4_params(aea, other_args)
+        check_proj_params('aea', aea, other_args)
 
         assert_almost_equal(np.array(aea.x_limits),
                             [-2323.47073363411, 2323.47073363411],
@@ -69,7 +64,7 @@ class TestAlbersEqualArea(object):
 
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=1234',
                       'y_0=-4321', 'lat_1=20.0', 'lat_2=50.0'}
-        check_proj4_params(aea_offset, other_args)
+        check_proj_params('aea', aea_offset, other_args)
 
     @pytest.mark.parametrize('lon', [-10.0, 10.0])
     def test_central_longitude(self, lon):
@@ -77,7 +72,7 @@ class TestAlbersEqualArea(object):
         aea_offset = ccrs.AlbersEqualArea(central_longitude=lon)
         other_args = {'ellps=WGS84', 'lon_0={}'.format(lon), 'lat_0=0.0',
                       'x_0=0.0', 'y_0=0.0', 'lat_1=20.0', 'lat_2=50.0'}
-        check_proj4_params(aea_offset, other_args)
+        check_proj_params('aea', aea_offset, other_args)
 
         assert_array_almost_equal(aea_offset.boundary, aea.boundary,
                                   decimal=0)
@@ -86,17 +81,17 @@ class TestAlbersEqualArea(object):
         aea = ccrs.AlbersEqualArea(standard_parallels=(13, 37))
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',
                       'y_0=0.0', 'lat_1=13', 'lat_2=37'}
-        check_proj4_params(aea, other_args)
+        check_proj_params('aea', aea, other_args)
 
         aea = ccrs.AlbersEqualArea(standard_parallels=(13, ))
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',
                       'y_0=0.0', 'lat_1=13'}
-        check_proj4_params(aea, other_args)
+        check_proj_params('aea', aea, other_args)
 
         aea = ccrs.AlbersEqualArea(standard_parallels=13)
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',
                       'y_0=0.0', 'lat_1=13'}
-        check_proj4_params(aea, other_args)
+        check_proj_params('aea', aea, other_args)
 
     def test_sphere_transform(self):
         # USGS Professional Paper 1395, pg 291
@@ -112,7 +107,7 @@ class TestAlbersEqualArea(object):
 
         other_args = {'a=1.0', 'b=1.0', 'lon_0=-96.0', 'lat_0=23.0', 'x_0=0.0',
                       'y_0=0.0', 'lat_1=29.5', 'lat_2=45.5'}
-        check_proj4_params(aea, other_args)
+        check_proj_params('aea', aea, other_args)
 
         assert_almost_equal(np.array(aea.x_limits),
                             [-2.6525072042232, 2.6525072042232],
@@ -141,7 +136,7 @@ class TestAlbersEqualArea(object):
         other_args = {'a=6378206.4', 'f=0.003390076308689371', 'lon_0=-96.0',
                       'lat_0=23.0', 'x_0=0.0', 'y_0=0.0', 'lat_1=29.5',
                       'lat_2=45.5'}
-        check_proj4_params(aea, other_args)
+        check_proj_params('aea', aea, other_args)
 
         assert_almost_equal(np.array(aea.x_limits),
                             [-16900972.674607, 16900972.674607],

--- a/lib/cartopy/tests/crs/test_azimuthal_equidistant.py
+++ b/lib/cartopy/tests/crs/test_azimuthal_equidistant.py
@@ -21,12 +21,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=aeqd', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 class TestAzimuthalEquidistant(object):
@@ -34,7 +29,7 @@ class TestAzimuthalEquidistant(object):
         aeqd = ccrs.AzimuthalEquidistant()
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',
                       'y_0=0.0'}
-        check_proj4_params(aeqd, other_args)
+        check_proj_params('aeqd', aeqd, other_args)
 
         assert_almost_equal(np.array(aeqd.x_limits),
                             [-20037508.34278924, 20037508.34278924], decimal=6)
@@ -47,7 +42,7 @@ class TestAzimuthalEquidistant(object):
         aeqd = ccrs.AzimuthalEquidistant(globe=globe)
         other_args = {'a=1000', 'b=500', 'lon_0=0.0', 'lat_0=0.0',
                       'x_0=0.0', 'y_0=0.0'}
-        check_proj4_params(aeqd, other_args)
+        check_proj_params('aeqd', aeqd, other_args)
 
         assert_almost_equal(np.array(aeqd.x_limits),
                             [-3141.59265359, 3141.59265359], decimal=6)
@@ -60,7 +55,7 @@ class TestAzimuthalEquidistant(object):
 
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=1234',
                       'y_0=-4321'}
-        check_proj4_params(aeqd_offset, other_args)
+        check_proj_params('aeqd', aeqd_offset, other_args)
 
         assert_almost_equal(np.array(aeqd_offset.x_limits),
                             [-20036274.34278924, 20038742.34278924], decimal=6)
@@ -78,7 +73,7 @@ class TestAzimuthalEquidistant(object):
 
         other_args = {'a=1.0', 'b=1.0', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',
                       'y_0=0.0'}
-        check_proj4_params(aeqd, other_args)
+        check_proj_params('aeqd', aeqd, other_args)
 
         assert_almost_equal(np.array(aeqd.x_limits),
                             [-3.14159265, 3.14159265], decimal=6)
@@ -147,7 +142,7 @@ class TestAzimuthalEquidistant(object):
 
         other_args = {'a=3.0', 'b=3.0', 'lon_0=-100.0', 'lat_0=40.0',
                       'x_0=0.0', 'y_0=0.0'}
-        check_proj4_params(aeqd, other_args)
+        check_proj_params('aeqd', aeqd, other_args)
 
         assert_almost_equal(np.array(aeqd.x_limits),
                             [-9.42477796, 9.42477796], decimal=6)
@@ -169,7 +164,7 @@ class TestAzimuthalEquidistant(object):
 
         other_args = {'a=6378388.0', 'f=0.003367003355798981', 'lon_0=-100.0',
                       'lat_0=90.0', 'x_0=0.0', 'y_0=0.0'}
-        check_proj4_params(aeqd, other_args)
+        check_proj_params('aeqd', aeqd, other_args)
 
         assert_almost_equal(np.array(aeqd.x_limits),
                             [-20038296.88254529, 20038296.88254529], decimal=6)
@@ -199,7 +194,7 @@ class TestAzimuthalEquidistant(object):
         other_args = {'a=6378206.4', 'f=0.003390076308689371',
                       'lon_0=144.7487507055556', 'lat_0=13.47246635277778',
                       'x_0=50000.0', 'y_0=50000.0'}
-        check_proj4_params(aeqd, other_args)
+        check_proj_params('aeqd', aeqd, other_args)
 
         assert_almost_equal(np.array(aeqd.x_limits),
                             [-19987726.36931940, 20087726.36931940], decimal=6)
@@ -233,7 +228,7 @@ class TestAzimuthalEquidistant(object):
         other_args = {'a=6378206.4', 'f=0.003390076308689371',
                       'lon_0=145.7416588888889', 'lat_0=15.18491194444444',
                       'x_0=28657.52', 'y_0=67199.99000000001'}
-        check_proj4_params(aeqd, other_args)
+        check_proj_params('aeqd', aeqd, other_args)
 
         assert_almost_equal(np.array(aeqd.x_limits),
                             [-20009068.84931940, 20066383.88931940], decimal=6)

--- a/lib/cartopy/tests/crs/test_eckert.py
+++ b/lib/cartopy/tests/crs/test_eckert.py
@@ -26,12 +26,7 @@ from numpy.testing import assert_almost_equal
 import pytest
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(name, crs, other_args):
-    expected = other_args | {'proj=' + name, 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 @pytest.mark.parametrize('name, proj, lim', [
@@ -45,7 +40,7 @@ def check_proj4_params(name, crs, other_args):
 def test_default(name, proj, lim):
     eck = proj()
     other_args = {'a=6378137.0', 'lon_0=0'}
-    check_proj4_params(name, eck, other_args)
+    check_proj_params(name, eck, other_args)
 
     assert_almost_equal(eck.x_limits, [-lim, lim])
     assert_almost_equal(eck.y_limits, [-lim / 2, lim / 2])
@@ -63,7 +58,7 @@ def test_offset(name, proj):
     crs = proj()
     crs_offset = proj(false_easting=1234, false_northing=-4321)
     other_args = {'a=6378137.0', 'lon_0=0', 'x_0=1234', 'y_0=-4321'}
-    check_proj4_params(name, crs_offset, other_args)
+    check_proj_params(name, crs_offset, other_args)
     assert tuple(np.array(crs.x_limits) + 1234) == crs_offset.x_limits
     assert tuple(np.array(crs.y_limits) - 4321) == crs_offset.y_limits
 
@@ -80,7 +75,7 @@ def test_offset(name, proj):
 def test_central_longitude(name, proj, lim, lon):
     eck = proj(central_longitude=lon)
     other_args = {'a=6378137.0', 'lon_0={}'.format(lon)}
-    check_proj4_params(name, eck, other_args)
+    check_proj_params(name, eck, other_args)
 
     assert_almost_equal(eck.x_limits, [-lim, lim], decimal=5)
     assert_almost_equal(eck.y_limits, [-lim / 2, lim / 2])
@@ -114,7 +109,7 @@ def test_eckert_grid(name, proj, radius, expected_x, expected_y):
     geodetic = eck.as_geodetic()
 
     other_args = {'a={}'.format(radius), 'lon_0=0'}
-    check_proj4_params(name, eck, other_args)
+    check_proj_params(name, eck, other_args)
 
     assert_almost_equal(eck.x_limits, [-2, 2], decimal=5)
     assert_almost_equal(eck.y_limits, [-1, 1], decimal=5)
@@ -141,7 +136,7 @@ def test_eckert_sphere_transform(name, proj, lim, expected):
     geodetic = eck.as_geodetic()
 
     other_args = {'a=1.0', 'lon_0=-90.0'}
-    check_proj4_params(name, eck, other_args)
+    check_proj_params(name, eck, other_args)
 
     assert_almost_equal(eck.x_limits, [-lim, lim], decimal=2)
     assert_almost_equal(eck.y_limits, [-lim / 2, lim / 2])

--- a/lib/cartopy/tests/crs/test_eckert.py
+++ b/lib/cartopy/tests/crs/test_eckert.py
@@ -46,6 +46,71 @@ def test_default(name, proj, lim):
     assert_almost_equal(eck.y_limits, [-lim / 2, lim / 2])
 
 
+@pytest.mark.parametrize('name, proj, lim', [
+    pytest.param('eck1', ccrs.EckertI, 2894.4050182, id='EckertI'),
+    pytest.param('eck2', ccrs.EckertII, 2894.4050182, id='EckertII'),
+    pytest.param('eck3', ccrs.EckertIII, 2653.0008564, id='EckertIII'),
+    pytest.param('eck4', ccrs.EckertIV, 2653.0008564, id='EckertIV'),
+    pytest.param('eck5', ccrs.EckertV, 2770.9649676, id='EckertV'),
+    pytest.param('eck6', ccrs.EckertVI, 2770.9649676, id='EckertVI'),
+])
+def test_sphere_globe(name, proj, lim):
+    globe = ccrs.Globe(semimajor_axis=1000, ellipse=None)
+    eck = proj(globe=globe)
+    other_args = {'a=1000', 'lon_0=0'}
+    check_proj_params(name, eck, other_args)
+
+    assert_almost_equal(eck.x_limits, [-lim, lim])
+    assert_almost_equal(eck.y_limits, [-lim / 2, lim / 2])
+
+
+@pytest.mark.parametrize('name, proj, lim', [
+    # Limits are the same as default since ellipses are not supported.
+    pytest.param('eck1', ccrs.EckertI, 18460911.739778, id='EckertI'),
+    pytest.param('eck2', ccrs.EckertII, 18460911.739778, id='EckertII'),
+    pytest.param('eck3', ccrs.EckertIII, 16921202.9229432, id='EckertIII'),
+    pytest.param('eck4', ccrs.EckertIV, 16921202.9229432, id='EckertIV'),
+    pytest.param('eck5', ccrs.EckertV, 17673594.1854146, id='EckertV'),
+    pytest.param('eck6', ccrs.EckertVI, 17673594.1854146, id='EckertVI'),
+])
+def test_ellipse_globe(name, proj, lim):
+    globe = ccrs.Globe(ellipse='WGS84')
+    with pytest.warns(UserWarning,
+                      match='does not handle elliptical globes.') as w:
+        eck = proj(globe=globe)
+        assert len(w) == 1
+
+    other_args = {'ellps=WGS84', 'lon_0=0'}
+    check_proj_params(name, eck, other_args)
+
+    assert_almost_equal(eck.x_limits, [-lim, lim])
+    assert_almost_equal(eck.y_limits, [-lim / 2, lim / 2])
+
+
+@pytest.mark.parametrize('name, proj, lim', [
+    # Limits are the same as spheres since ellipses are not supported.
+    pytest.param('eck1', ccrs.EckertI, 2894.4050182, id='EckertI'),
+    pytest.param('eck2', ccrs.EckertII, 2894.4050182, id='EckertII'),
+    pytest.param('eck3', ccrs.EckertIII, 2653.0008564, id='EckertIII'),
+    pytest.param('eck4', ccrs.EckertIV, 2653.0008564, id='EckertIV'),
+    pytest.param('eck5', ccrs.EckertV, 2770.9649676, id='EckertV'),
+    pytest.param('eck6', ccrs.EckertVI, 2770.9649676, id='EckertVI'),
+])
+def test_eccentric_globe(name, proj, lim):
+    globe = ccrs.Globe(semimajor_axis=1000, semiminor_axis=500,
+                       ellipse=None)
+    with pytest.warns(UserWarning,
+                      match='does not handle elliptical globes.') as w:
+        eck = proj(globe=globe)
+        assert len(w) == 1
+
+    other_args = {'a=1000', 'b=500', 'lon_0=0'}
+    check_proj_params(name, eck, other_args)
+
+    assert_almost_equal(eck.x_limits, [-lim, lim])
+    assert_almost_equal(eck.y_limits, [-lim / 2, lim / 2])
+
+
 @pytest.mark.parametrize('name, proj', [
     pytest.param('eck1', ccrs.EckertI, id='EckertI'),
     pytest.param('eck2', ccrs.EckertII, id='EckertII'),

--- a/lib/cartopy/tests/crs/test_equal_earth.py
+++ b/lib/cartopy/tests/crs/test_equal_earth.py
@@ -26,22 +26,17 @@ from numpy.testing import assert_almost_equal
 import pytest
 
 import cartopy.crs as ccrs
+from .helpers import check_proj_params
 
 
 pytestmark = pytest.mark.skipif(ccrs.PROJ4_VERSION < (5, 2, 0),
                                 reason='Proj is too old.')
 
 
-def check_proj_params(crs, other_args):
-    expected = other_args | {'proj=eqearth', 'no_defs'}
-    proj_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == proj_params
-
-
 def test_default():
     eqearth = ccrs.EqualEarth()
     other_args = {'ellps=WGS84', 'lon_0=0'}
-    check_proj_params(eqearth, other_args)
+    check_proj_params('eqearth', eqearth, other_args)
 
     assert_almost_equal(eqearth.x_limits,
                         [-17243959.0622169, 17243959.0622169])
@@ -56,7 +51,7 @@ def test_offset():
     crs = ccrs.EqualEarth()
     crs_offset = ccrs.EqualEarth(false_easting=1234, false_northing=-4321)
     other_args = {'ellps=WGS84', 'lon_0=0', 'x_0=1234', 'y_0=-4321'}
-    check_proj_params(crs_offset, other_args)
+    check_proj_params('eqearth', crs_offset, other_args)
     assert tuple(np.array(crs.x_limits) + 1234) == crs_offset.x_limits
     assert tuple(np.array(crs.y_limits) - 4321) == crs_offset.y_limits
 
@@ -66,7 +61,7 @@ def test_eccentric_globe():
                        ellipse=None)
     eqearth = ccrs.EqualEarth(globe=globe)
     other_args = {'a=1000', 'b=500', 'lon_0=0'}
-    check_proj_params(eqearth, other_args)
+    check_proj_params('eqearth', eqearth, other_args)
 
     assert_almost_equal(eqearth.x_limits,
                         [-2248.43664092550, 2248.43664092550])
@@ -81,7 +76,7 @@ def test_eccentric_globe():
 def test_central_longitude(lon):
     eqearth = ccrs.EqualEarth(central_longitude=lon)
     other_args = {'ellps=WGS84', 'lon_0={}'.format(lon)}
-    check_proj_params(eqearth, other_args)
+    check_proj_params('eqearth', eqearth, other_args)
 
     assert_almost_equal(eqearth.x_limits,
                         [-17243959.0622169, 17243959.0622169], decimal=5)

--- a/lib/cartopy/tests/crs/test_equidistant_conic.py
+++ b/lib/cartopy/tests/crs/test_equidistant_conic.py
@@ -26,12 +26,7 @@ from numpy.testing import assert_almost_equal, assert_array_almost_equal
 import pytest
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=eqdc', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 class TestEquidistantConic(object):
@@ -39,7 +34,7 @@ class TestEquidistantConic(object):
         eqdc = ccrs.EquidistantConic()
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',
                       'y_0=0.0', 'lat_1=20.0', 'lat_2=50.0'}
-        check_proj4_params(eqdc, other_args)
+        check_proj_params('eqdc', eqdc, other_args)
 
         assert_almost_equal(np.array(eqdc.x_limits),
                             (-22784919.35600352, 22784919.35600352),
@@ -54,7 +49,7 @@ class TestEquidistantConic(object):
         eqdc = ccrs.EquidistantConic(globe=globe)
         other_args = {'a=1000', 'b=500', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',
                       'y_0=0.0', 'lat_1=20.0', 'lat_2=50.0'}
-        check_proj4_params(eqdc, other_args)
+        check_proj_params('eqdc', eqdc, other_args)
 
         assert_almost_equal(np.array(eqdc.x_limits),
                             (-3016.869847713461, 3016.869847713461),
@@ -69,7 +64,7 @@ class TestEquidistantConic(object):
 
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=1234',
                       'y_0=-4321', 'lat_1=20.0', 'lat_2=50.0'}
-        check_proj4_params(eqdc_offset, other_args)
+        check_proj_params('eqdc', eqdc_offset, other_args)
 
     @pytest.mark.parametrize('lon', [-10.0, 10.0])
     def test_central_longitude(self, lon):
@@ -77,7 +72,7 @@ class TestEquidistantConic(object):
         eqdc_offset = ccrs.EquidistantConic(central_longitude=lon)
         other_args = {'ellps=WGS84', 'lon_0={}'.format(lon), 'lat_0=0.0',
                       'x_0=0.0', 'y_0=0.0', 'lat_1=20.0', 'lat_2=50.0'}
-        check_proj4_params(eqdc_offset, other_args)
+        check_proj_params('eqdc', eqdc_offset, other_args)
 
         assert_array_almost_equal(eqdc_offset.boundary, eqdc.boundary,
                                   decimal=0)
@@ -86,17 +81,17 @@ class TestEquidistantConic(object):
         eqdc = ccrs.EquidistantConic(standard_parallels=(13, 37))
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',
                       'y_0=0.0', 'lat_1=13', 'lat_2=37'}
-        check_proj4_params(eqdc, other_args)
+        check_proj_params('eqdc', eqdc, other_args)
 
         eqdc = ccrs.EquidistantConic(standard_parallels=(13, ))
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',
                       'y_0=0.0', 'lat_1=13'}
-        check_proj4_params(eqdc, other_args)
+        check_proj_params('eqdc', eqdc, other_args)
 
         eqdc = ccrs.EquidistantConic(standard_parallels=13)
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',
                       'y_0=0.0', 'lat_1=13'}
-        check_proj4_params(eqdc, other_args)
+        check_proj_params('eqdc', eqdc, other_args)
 
     def test_sphere_transform(self):
         # USGS Professional Paper 1395, pg 298
@@ -112,7 +107,7 @@ class TestEquidistantConic(object):
 
         other_args = {'a=1.0', 'b=1.0', 'lon_0=-96.0', 'lat_0=23.0', 'x_0=0.0',
                       'y_0=0.0', 'lat_1=29.5', 'lat_2=45.5'}
-        check_proj4_params(eqdc, other_args)
+        check_proj_params('eqdc', eqdc, other_args)
 
         assert_almost_equal(np.array(eqdc.x_limits),
                             (-3.520038619089038, 3.520038619089038),
@@ -141,7 +136,7 @@ class TestEquidistantConic(object):
         other_args = {'a=6378206.4', 'f=0.003390076308689371', 'lon_0=-96.0',
                       'lat_0=23.0', 'x_0=0.0', 'y_0=0.0', 'lat_1=29.5',
                       'lat_2=45.5'}
-        check_proj4_params(eqdc, other_args)
+        check_proj_params('eqdc', eqdc, other_args)
 
         assert_almost_equal(np.array(eqdc.x_limits),
                             (-22421870.719894886, 22421870.719894886),

--- a/lib/cartopy/tests/crs/test_geostationary.py
+++ b/lib/cartopy/tests/crs/test_geostationary.py
@@ -24,12 +24,7 @@ from __future__ import (absolute_import, division, print_function)
 from numpy.testing import assert_almost_equal
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(name, crs, other_args):
-    expected = other_args | {'proj={}'.format(name), 'units=m', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 class TestGeostationary(object):
@@ -44,10 +39,10 @@ class TestGeostationary(object):
     def test_default(self):
         geos = self.test_class()
         other_args = {'ellps=WGS84', 'h=35785831', 'lat_0=0.0', 'lon_0=0.0',
-                      'x_0=0', 'y_0=0'}
+                      'units=m', 'x_0=0', 'y_0=0'}
         self.adjust_expected_params(other_args)
 
-        check_proj4_params(self.expected_proj_name, geos, other_args)
+        check_proj_params(self.expected_proj_name, geos, other_args)
 
         assert_almost_equal(geos.boundary.bounds,
                             (-5434177.81588539, -5434177.81588539,
@@ -56,11 +51,11 @@ class TestGeostationary(object):
 
     def test_low_orbit(self):
         geos = self.test_class(satellite_height=700000)
-        other_args = {'h=700000', 'lat_0=0.0', 'lon_0=0.0', 'x_0=0', 'y_0=0',
-                      'ellps=WGS84'}
+        other_args = {'ellps=WGS84', 'h=700000', 'lat_0=0.0', 'lon_0=0.0',
+                      'units=m', 'x_0=0', 'y_0=0'}
         self.adjust_expected_params(other_args)
 
-        check_proj4_params(self.expected_proj_name, geos, other_args)
+        check_proj_params(self.expected_proj_name, geos, other_args)
 
         assert_almost_equal(geos.boundary.bounds,
                             (-785616.1189, -785616.1189,
@@ -76,10 +71,10 @@ class TestGeostationary(object):
         geos = self.test_class(false_easting=5000000,
                                false_northing=-125000,)
         other_args = {'ellps=WGS84', 'h=35785831', 'lat_0=0.0', 'lon_0=0.0',
-                      'x_0=5000000', 'y_0=-125000'}
+                      'units=m', 'x_0=5000000', 'y_0=-125000'}
         self.adjust_expected_params(other_args)
 
-        check_proj4_params(self.expected_proj_name, geos, other_args)
+        check_proj_params(self.expected_proj_name, geos, other_args)
 
         assert_almost_equal(geos.boundary.bounds,
                             (-434177.81588539, -5559177.81588539,
@@ -89,9 +84,9 @@ class TestGeostationary(object):
     def test_sweep(self):
         geos = ccrs.Geostationary(sweep_axis='x')
         other_args = {'ellps=WGS84', 'h=35785831', 'lat_0=0.0', 'lon_0=0.0',
-                      'sweep=x', 'x_0=0', 'y_0=0'}
+                      'sweep=x', 'units=m', 'x_0=0', 'y_0=0'}
 
-        check_proj4_params(self.expected_proj_name, geos, other_args)
+        check_proj_params(self.expected_proj_name, geos, other_args)
 
         pt = geos.transform_point(-60, 25, ccrs.PlateCarree())
 

--- a/lib/cartopy/tests/crs/test_gnomonic.py
+++ b/lib/cartopy/tests/crs/test_gnomonic.py
@@ -40,6 +40,47 @@ def test_default():
                         [-5e7, 5e7])
 
 
+def test_sphere_globe():
+    globe = ccrs.Globe(semimajor_axis=1000, ellipse=None)
+    gnom = ccrs.Gnomonic(globe=globe)
+    other_args = {'a=1000', 'lon_0=0.0', 'lat_0=0.0'}
+    check_proj_params('gnom', gnom, other_args)
+
+    assert_almost_equal(gnom.x_limits, [-5e7, 5e7])
+    assert_almost_equal(gnom.y_limits, [-5e7, 5e7])
+
+
+def test_ellipse_globe():
+    globe = ccrs.Globe(ellipse='WGS84')
+    with pytest.warns(UserWarning,
+                      match='does not handle elliptical globes.') as w:
+        gnom = ccrs.Gnomonic(globe=globe)
+        assert len(w) == 1
+
+    other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0'}
+    check_proj_params('gnom', gnom, other_args)
+
+    # Limits are the same as default since ellipses are not supported.
+    assert_almost_equal(gnom.x_limits, [-5e7, 5e7])
+    assert_almost_equal(gnom.y_limits, [-5e7, 5e7])
+
+
+def test_eccentric_globe():
+    globe = ccrs.Globe(semimajor_axis=1000, semiminor_axis=500,
+                       ellipse=None)
+    with pytest.warns(UserWarning,
+                      match='does not handle elliptical globes.') as w:
+        gnom = ccrs.Gnomonic(globe=globe)
+        assert len(w) == 1
+
+    other_args = {'a=1000', 'b=500', 'lon_0=0.0', 'lat_0=0.0'}
+    check_proj_params('gnom', gnom, other_args)
+
+    # Limits are the same as spheres since ellipses are not supported.
+    assert_almost_equal(gnom.x_limits, [-5e7, 5e7])
+    assert_almost_equal(gnom.y_limits, [-5e7, 5e7])
+
+
 @pytest.mark.parametrize('lat', [-10, 0, 10])
 @pytest.mark.parametrize('lon', [-10, 0, 10])
 def test_central_params(lat, lon):

--- a/lib/cartopy/tests/crs/test_gnomonic.py
+++ b/lib/cartopy/tests/crs/test_gnomonic.py
@@ -26,18 +26,13 @@ from numpy.testing import assert_almost_equal
 import pytest
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=gnom', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 def test_default():
     gnom = ccrs.Gnomonic()
     other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0'}
-    check_proj4_params(gnom, other_args)
+    check_proj_params('gnom', gnom, other_args)
 
     assert_almost_equal(np.array(gnom.x_limits),
                         [-5e7, 5e7])
@@ -51,7 +46,7 @@ def test_central_params(lat, lon):
     gnom = ccrs.Gnomonic(central_latitude=lat, central_longitude=lon)
     other_args = {'lat_0={}'.format(lat), 'lon_0={}'.format(lon),
                   'ellps=WGS84'}
-    check_proj4_params(gnom, other_args)
+    check_proj_params('gnom', gnom, other_args)
 
     assert_almost_equal(np.array(gnom.x_limits),
                         [-5e7, 5e7])
@@ -67,7 +62,7 @@ def test_grid():
     geodetic = gnom.as_geodetic()
 
     other_args = {'a=1.0', 'b=1.0', 'lon_0=0.0', 'lat_0=0.0'}
-    check_proj4_params(gnom, other_args)
+    check_proj_params('gnom', gnom, other_args)
 
     assert_almost_equal(np.array(gnom.x_limits),
                         [-5e7, 5e7])
@@ -109,7 +104,7 @@ def test_sphere_transform():
     geodetic = gnom.as_geodetic()
 
     other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0'}
-    check_proj4_params(gnom, other_args)
+    check_proj_params('gnom', gnom, other_args)
 
     assert_almost_equal(np.array(gnom.x_limits),
                         [-5e7, 5e7])

--- a/lib/cartopy/tests/crs/test_gnomonic.py
+++ b/lib/cartopy/tests/crs/test_gnomonic.py
@@ -31,7 +31,7 @@ from .helpers import check_proj_params
 
 def test_default():
     gnom = ccrs.Gnomonic()
-    other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0'}
+    other_args = {'a=6378137.0', 'lon_0=0.0', 'lat_0=0.0'}
     check_proj_params('gnom', gnom, other_args)
 
     assert_almost_equal(np.array(gnom.x_limits),
@@ -45,7 +45,7 @@ def test_default():
 def test_central_params(lat, lon):
     gnom = ccrs.Gnomonic(central_latitude=lat, central_longitude=lon)
     other_args = {'lat_0={}'.format(lat), 'lon_0={}'.format(lon),
-                  'ellps=WGS84'}
+                  'a=6378137.0'}
     check_proj_params('gnom', gnom, other_args)
 
     assert_almost_equal(np.array(gnom.x_limits),

--- a/lib/cartopy/tests/crs/test_interrupted_goode_homolosine.py
+++ b/lib/cartopy/tests/crs/test_interrupted_goode_homolosine.py
@@ -26,18 +26,13 @@ from numpy.testing import assert_almost_equal
 import pytest
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=igh', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 def test_default():
     igh = ccrs.InterruptedGoodeHomolosine()
     other_args = {'ellps=WGS84', 'lon_0=0'}
-    check_proj4_params(igh, other_args)
+    check_proj_params('igh', igh, other_args)
 
     assert_almost_equal(np.array(igh.x_limits),
                         [-20037508.3427892, 20037508.3427892])
@@ -50,7 +45,7 @@ def test_eccentric_globe():
                        ellipse=None)
     igh = ccrs.InterruptedGoodeHomolosine(globe=globe)
     other_args = {'a=1000', 'b=500', 'lon_0=0'}
-    check_proj4_params(igh, other_args)
+    check_proj_params('igh', igh, other_args)
 
     assert_almost_equal(np.array(igh.x_limits),
                         [-3141.5926536, 3141.5926536])
@@ -62,7 +57,7 @@ def test_eccentric_globe():
 def test_central_longitude(lon):
     igh = ccrs.InterruptedGoodeHomolosine(central_longitude=lon)
     other_args = {'ellps=WGS84', 'lon_0={}'.format(lon)}
-    check_proj4_params(igh, other_args)
+    check_proj_params('igh', igh, other_args)
 
     assert_almost_equal(np.array(igh.x_limits),
                         [-20037508.3427892, 20037508.3427892],

--- a/lib/cartopy/tests/crs/test_lambert_azimuthal_equal_area.py
+++ b/lib/cartopy/tests/crs/test_lambert_azimuthal_equal_area.py
@@ -22,12 +22,7 @@ from numpy.testing import assert_almost_equal
 import pytest
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=laea', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 class TestLambertAzimuthalEqualArea(object):
@@ -35,7 +30,7 @@ class TestLambertAzimuthalEqualArea(object):
         crs = ccrs.LambertAzimuthalEqualArea()
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',
                       'y_0=0.0'}
-        check_proj4_params(crs, other_args)
+        check_proj_params('laea', crs, other_args)
 
         assert_almost_equal(np.array(crs.x_limits),
                             [-12755636.1863, 12755636.1863],
@@ -50,7 +45,7 @@ class TestLambertAzimuthalEqualArea(object):
         crs = ccrs.LambertAzimuthalEqualArea(globe=globe)
         other_args = {'a=1000', 'b=500', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',
                       'y_0=0.0'}
-        check_proj4_params(crs, other_args)
+        check_proj_params('laea', crs, other_args)
 
         assert_almost_equal(np.array(crs.x_limits),
                             [-1999.9, 1999.9], decimal=1)
@@ -63,7 +58,7 @@ class TestLambertAzimuthalEqualArea(object):
                                                     false_northing=-4321)
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=1234',
                       'y_0=-4321'}
-        check_proj4_params(crs_offset, other_args)
+        check_proj_params('laea', crs_offset, other_args)
         assert tuple(np.array(crs.x_limits) + 1234) == crs_offset.x_limits
         assert tuple(np.array(crs.y_limits) - 4321) == crs_offset.y_limits
 
@@ -72,4 +67,4 @@ class TestLambertAzimuthalEqualArea(object):
         crs = ccrs.LambertAzimuthalEqualArea(central_latitude=latitude)
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0={}'.format(latitude),
                       'x_0=0.0', 'y_0=0.0'}
-        check_proj4_params(crs, other_args)
+        check_proj_params('laea', crs, other_args)

--- a/lib/cartopy/tests/crs/test_lambert_conformal.py
+++ b/lib/cartopy/tests/crs/test_lambert_conformal.py
@@ -21,19 +21,14 @@ from numpy.testing import assert_array_almost_equal
 import pytest
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=lcc', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 def test_defaults():
     crs = ccrs.LambertConformal()
     other_args = {'ellps=WGS84', 'lon_0=-96.0', 'lat_0=39.0', 'x_0=0.0',
                   'y_0=0.0', 'lat_1=33', 'lat_2=45'}
-    check_proj4_params(crs, other_args)
+    check_proj_params('lcc', crs, other_args)
 
 
 def test_default_with_cutoff():
@@ -43,7 +38,7 @@ def test_default_with_cutoff():
 
     other_args = {'ellps=WGS84', 'lon_0=-96.0', 'lat_0=39.0', 'x_0=0.0',
                   'y_0=0.0', 'lat_1=33', 'lat_2=45'}
-    check_proj4_params(crs, other_args)
+    check_proj_params('lcc', crs, other_args)
 
     # Check the behaviour of !=, == and (not ==) for the different cutoffs.
     assert crs == crs2
@@ -66,7 +61,7 @@ def test_specific_lambert():
                                 globe=ccrs.Globe(ellipse='GRS80'))
     other_args = {'ellps=GRS80', 'lon_0=10', 'lat_0=52',
                   'x_0=4000000', 'y_0=2800000', 'lat_1=35', 'lat_2=65'}
-    check_proj4_params(crs, other_args)
+    check_proj_params('lcc', crs, other_args)
 
 
 class Test_LambertConformal_standard_parallels(object):
@@ -74,7 +69,7 @@ class Test_LambertConformal_standard_parallels(object):
         crs = ccrs.LambertConformal(standard_parallels=[1.])
         other_args = {'ellps=WGS84', 'lon_0=-96.0', 'lat_0=39.0',
                       'x_0=0.0', 'y_0=0.0', 'lat_1=1.0'}
-        check_proj4_params(crs, other_args)
+        check_proj_params('lcc', crs, other_args)
 
     def test_no_parallel(self):
         with pytest.raises(ValueError, message='1 or 2 standard parallels'):

--- a/lib/cartopy/tests/crs/test_mercator.py
+++ b/lib/cartopy/tests/crs/test_mercator.py
@@ -21,19 +21,14 @@ from numpy.testing import assert_almost_equal
 import pytest
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=merc', 'units=m', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 def test_default():
     crs = ccrs.Mercator()
 
-    other_args = {'ellps=WGS84', 'lon_0=0.0', 'x_0=0.0', 'y_0=0.0'}
-    check_proj4_params(crs, other_args)
+    other_args = {'ellps=WGS84', 'lon_0=0.0', 'x_0=0.0', 'y_0=0.0', 'units=m'}
+    check_proj_params('merc', crs, other_args)
     assert_almost_equal(crs.boundary.bounds,
                         [-20037508, -15496571, 20037508, 18764656], decimal=0)
 
@@ -42,8 +37,9 @@ def test_eccentric_globe():
     globe = ccrs.Globe(semimajor_axis=10000, semiminor_axis=5000,
                        ellipse=None)
     crs = ccrs.Mercator(globe=globe, min_latitude=-40, max_latitude=40)
-    other_args = {'a=10000', 'b=5000', 'lon_0=0.0', 'x_0=0.0', 'y_0=0.0'}
-    check_proj4_params(crs, other_args)
+    other_args = {'a=10000', 'b=5000', 'lon_0=0.0', 'x_0=0.0', 'y_0=0.0',
+                  'units=m'}
+    check_proj_params('merc', crs, other_args)
 
     assert_almost_equal(crs.boundary.bounds,
                         [-31415.93, -2190.5, 31415.93, 2190.5], decimal=2)
@@ -67,8 +63,9 @@ def test_equality():
 @pytest.mark.parametrize('lon', [-10.0, 10.0])
 def test_central_longitude(lon):
     crs = ccrs.Mercator(central_longitude=lon)
-    other_args = {'ellps=WGS84', 'lon_0={}'.format(lon), 'x_0=0.0', 'y_0=0.0'}
-    check_proj4_params(crs, other_args)
+    other_args = {'ellps=WGS84', 'lon_0={}'.format(lon), 'x_0=0.0', 'y_0=0.0',
+                  'units=m'}
+    check_proj_params('merc', crs, other_args)
 
     assert_almost_equal(crs.boundary.bounds,
                         [-20037508, -15496570, 20037508, 18764656], decimal=0)
@@ -77,9 +74,9 @@ def test_central_longitude(lon):
 def test_latitude_true_scale():
     lat_ts = 20.0
     crs = ccrs.Mercator(latitude_true_scale=lat_ts)
-    other_args = {'ellps=WGS84', 'lon_0=0.0', 'x_0=0.0', 'y_0=0.0',
+    other_args = {'ellps=WGS84', 'lon_0=0.0', 'x_0=0.0', 'y_0=0.0', 'units=m',
                   'lat_ts={}'.format(lat_ts)}
-    check_proj4_params(crs, other_args)
+    check_proj_params('merc', crs, other_args)
 
     assert_almost_equal(crs.boundary.bounds,
                         [-18836475, -14567718, 18836475, 17639917], decimal=0)
@@ -91,8 +88,8 @@ def test_easting_northing():
     crs = ccrs.Mercator(false_easting=false_easting,
                         false_northing=false_northing)
     other_args = {'ellps=WGS84', 'lon_0=0.0', 'x_0={}'.format(false_easting),
-                  'y_0={}'.format(false_northing)}
-    check_proj4_params(crs, other_args)
+                  'y_0={}'.format(false_northing), 'units=m'}
+    check_proj_params('merc', crs, other_args)
 
     assert_almost_equal(crs.boundary.bounds,
                         [-19037508, -17496571, 21037508, 16764656], decimal=0)
@@ -103,9 +100,9 @@ def test_scale_factor():
     scale_factor = 0.939692620786
     crs = ccrs.Mercator(scale_factor=scale_factor,
                         globe=ccrs.Globe(ellipse='sphere'))
-    other_args = {'ellps=sphere', 'lon_0=0.0', 'x_0=0.0', 'y_0=0.0',
+    other_args = {'ellps=sphere', 'lon_0=0.0', 'x_0=0.0', 'y_0=0.0', 'units=m',
                   'k_0={:.12f}'.format(scale_factor)}
-    check_proj4_params(crs, other_args)
+    check_proj_params('merc', crs, other_args)
 
     assert_almost_equal(crs.boundary.bounds,
                         [-18808021, -14585266, 18808021, 17653216], decimal=0)

--- a/lib/cartopy/tests/crs/test_miller.py
+++ b/lib/cartopy/tests/crs/test_miller.py
@@ -26,18 +26,13 @@ from numpy.testing import assert_almost_equal
 import pytest
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=mill', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 def test_default():
     mill = ccrs.Miller()
     other_args = {'a=57.29577951308232', 'lon_0=0.0'}
-    check_proj4_params(mill, other_args)
+    check_proj_params('mill', mill, other_args)
 
     assert_almost_equal(np.array(mill.x_limits),
                         [-180, 180])
@@ -49,7 +44,7 @@ def test_default():
 def test_central_longitude(lon):
     mill = ccrs.Miller(central_longitude=lon)
     other_args = {'a=57.29577951308232', 'lon_0={}'.format(lon)}
-    check_proj4_params(mill, other_args)
+    check_proj_params('mill', mill, other_args)
 
     assert_almost_equal(np.array(mill.x_limits),
                         [-180, 180])
@@ -64,7 +59,7 @@ def test_grid():
     geodetic = mill.as_geodetic()
 
     other_args = {'a=1.0', 'lon_0=0.0'}
-    check_proj4_params(mill, other_args)
+    check_proj_params('mill', mill, other_args)
 
     assert_almost_equal(np.array(mill.x_limits),
                         [-3.14159265, 3.14159265])
@@ -91,7 +86,7 @@ def test_sphere_transform():
     geodetic = mill.as_geodetic()
 
     other_args = {'a=1.0', 'lon_0=0.0'}
-    check_proj4_params(mill, other_args)
+    check_proj_params('mill', mill, other_args)
 
     assert_almost_equal(np.array(mill.x_limits),
                         [-3.14159265, 3.14159265])

--- a/lib/cartopy/tests/crs/test_miller.py
+++ b/lib/cartopy/tests/crs/test_miller.py
@@ -40,6 +40,51 @@ def test_default():
                         [-131.9758172, 131.9758172])
 
 
+def test_sphere_globe():
+    globe = ccrs.Globe(semimajor_axis=1000, ellipse=None)
+    mill = ccrs.Miller(globe=globe)
+    other_args = {'a=1000', 'lon_0=0.0'}
+    check_proj_params('mill', mill, other_args)
+
+    assert_almost_equal(mill.x_limits, [-3141.5926536, 3141.5926536])
+    assert_almost_equal(mill.y_limits, [-2303.4125434, 2303.4125434])
+
+
+def test_ellipse_globe():
+    globe = ccrs.Globe(ellipse='WGS84')
+    with pytest.warns(UserWarning,
+                      match='does not handle elliptical globes.') as w:
+        mill = ccrs.Miller(globe=globe)
+        assert len(w) == 1
+
+    other_args = {'ellps=WGS84', 'lon_0=0.0'}
+    check_proj_params('mill', mill, other_args)
+
+    # Limits are the same as spheres (but not the default radius) since
+    # ellipses are not supported.
+    mill_sph = ccrs.Miller(
+        globe=ccrs.Globe(semimajor_axis=ccrs.WGS84_SEMIMAJOR_AXIS,
+                         ellipse=None))
+    assert_almost_equal(mill.x_limits, mill_sph.x_limits)
+    assert_almost_equal(mill.y_limits, mill_sph.y_limits)
+
+
+def test_eccentric_globe():
+    globe = ccrs.Globe(semimajor_axis=1000, semiminor_axis=500,
+                       ellipse=None)
+    with pytest.warns(UserWarning,
+                      match='does not handle elliptical globes.') as w:
+        mill = ccrs.Miller(globe=globe)
+        assert len(w) == 1
+
+    other_args = {'a=1000', 'b=500', 'lon_0=0.0'}
+    check_proj_params('mill', mill, other_args)
+
+    # Limits are the same as spheres since ellipses are not supported.
+    assert_almost_equal(mill.x_limits, [-3141.5926536, 3141.5926536])
+    assert_almost_equal(mill.y_limits, [-2303.4125434, 2303.4125434])
+
+
 @pytest.mark.parametrize('lon', [-10.0, 10.0])
 def test_central_longitude(lon):
     mill = ccrs.Miller(central_longitude=lon)

--- a/lib/cartopy/tests/crs/test_mollweide.py
+++ b/lib/cartopy/tests/crs/test_mollweide.py
@@ -26,18 +26,13 @@ from numpy.testing import assert_almost_equal
 import pytest
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=moll', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 def test_default():
     moll = ccrs.Mollweide()
     other_args = {'a=6378137.0', 'lon_0=0'}
-    check_proj4_params(moll, other_args)
+    check_proj_params('moll', moll, other_args)
 
     assert_almost_equal(np.array(moll.x_limits),
                         [-18040095.6961473, 18040095.6961473])
@@ -49,7 +44,7 @@ def test_offset():
     crs = ccrs.Mollweide()
     crs_offset = ccrs.Mollweide(false_easting=1234, false_northing=-4321)
     other_args = {'a=6378137.0', 'lon_0=0', 'x_0=1234', 'y_0=-4321'}
-    check_proj4_params(crs_offset, other_args)
+    check_proj_params('moll', crs_offset, other_args)
     assert tuple(np.array(crs.x_limits) + 1234) == crs_offset.x_limits
     assert tuple(np.array(crs.y_limits) - 4321) == crs_offset.y_limits
 
@@ -58,7 +53,7 @@ def test_offset():
 def test_central_longitude(lon):
     moll = ccrs.Mollweide(central_longitude=lon)
     other_args = {'a=6378137.0', 'lon_0={}'.format(lon)}
-    check_proj4_params(moll, other_args)
+    check_proj_params('moll', moll, other_args)
 
     assert_almost_equal(np.array(moll.x_limits),
                         [-18040095.6961473, 18040095.6961473],
@@ -75,7 +70,7 @@ def test_grid():
     geodetic = moll.as_geodetic()
 
     other_args = {'a=0.7071067811865476', 'b=0.7071067811865476', 'lon_0=0'}
-    check_proj4_params(moll, other_args)
+    check_proj_params('moll', moll, other_args)
 
     assert_almost_equal(np.array(moll.x_limits),
                         [-2, 2])
@@ -110,7 +105,7 @@ def test_sphere_transform():
     geodetic = moll.as_geodetic()
 
     other_args = {'a=1.0', 'b=1.0', 'lon_0=-90.0'}
-    check_proj4_params(moll, other_args)
+    check_proj_params('moll', moll, other_args)
 
     assert_almost_equal(np.array(moll.x_limits),
                         [-2.8284271247461903, 2.8284271247461903],

--- a/lib/cartopy/tests/crs/test_mollweide.py
+++ b/lib/cartopy/tests/crs/test_mollweide.py
@@ -40,6 +40,47 @@ def test_default():
                         [-9020047.8480736, 9020047.8480736])
 
 
+def test_sphere_globe():
+    globe = ccrs.Globe(semimajor_axis=1000, ellipse=None)
+    moll = ccrs.Mollweide(globe=globe)
+    other_args = {'a=1000', 'lon_0=0'}
+    check_proj_params('moll', moll, other_args)
+
+    assert_almost_equal(moll.x_limits, [-2828.4271247, 2828.4271247])
+    assert_almost_equal(moll.y_limits, [-1414.2135624, 1414.2135624])
+
+
+def test_ellipse_globe():
+    globe = ccrs.Globe(ellipse='WGS84')
+    with pytest.warns(UserWarning,
+                      match='does not handle elliptical globes.') as w:
+        moll = ccrs.Mollweide(globe=globe)
+        assert len(w) == 1
+
+    other_args = {'ellps=WGS84', 'lon_0=0'}
+    check_proj_params('moll', moll, other_args)
+
+    # Limits are the same as default since ellipses are not supported.
+    assert_almost_equal(moll.x_limits, [-18040095.6961473, 18040095.6961473])
+    assert_almost_equal(moll.y_limits, [-9020047.8480736, 9020047.8480736])
+
+
+def test_eccentric_globe():
+    globe = ccrs.Globe(semimajor_axis=1000, semiminor_axis=500,
+                       ellipse=None)
+    with pytest.warns(UserWarning,
+                      match='does not handle elliptical globes.') as w:
+        moll = ccrs.Mollweide(globe=globe)
+        assert len(w) == 1
+
+    other_args = {'a=1000', 'b=500', 'lon_0=0'}
+    check_proj_params('moll', moll, other_args)
+
+    # Limits are the same as spheres since ellipses are not supported.
+    assert_almost_equal(moll.x_limits, [-2828.4271247, 2828.4271247])
+    assert_almost_equal(moll.y_limits, [-1414.2135624, 1414.2135624])
+
+
 def test_offset():
     crs = ccrs.Mollweide()
     crs_offset = ccrs.Mollweide(false_easting=1234, false_northing=-4321)

--- a/lib/cartopy/tests/crs/test_nearside_perspective.py
+++ b/lib/cartopy/tests/crs/test_nearside_perspective.py
@@ -23,17 +23,16 @@ from __future__ import (absolute_import, division, print_function)
 
 from numpy.testing import assert_almost_equal
 
-from cartopy.tests.crs.test_geostationary import check_proj4_params
-
 import cartopy.crs as ccrs
+from .helpers import check_proj_params
 
 
 def test_default():
     geos = ccrs.NearsidePerspective()
     other_args = {'a=6378137.0', 'h=35785831', 'lat_0=0.0', 'lon_0=0.0',
-                  'x_0=0', 'y_0=0'}
+                  'units=m', 'x_0=0', 'y_0=0'}
 
-    check_proj4_params('nsper', geos, other_args)
+    check_proj_params('nsper', geos, other_args)
 
     assert_almost_equal(geos.boundary.bounds,
                         (-5476336.098, -5476336.098,
@@ -45,9 +44,9 @@ def test_offset():
     geos = ccrs.NearsidePerspective(false_easting=5000000,
                                     false_northing=-123000,)
     other_args = {'a=6378137.0', 'h=35785831', 'lat_0=0.0', 'lon_0=0.0',
-                  'x_0=5000000', 'y_0=-123000'}
+                  'units=m', 'x_0=5000000', 'y_0=-123000'}
 
-    check_proj4_params('nsper', geos, other_args)
+    check_proj_params('nsper', geos, other_args)
 
     assert_almost_equal(geos.boundary.bounds,
                         (-476336.098, -5599336.098,
@@ -59,8 +58,8 @@ def test_central_latitude():
     # Check the effect of the added 'central_latitude' key.
     geos = ccrs.NearsidePerspective(central_latitude=53.7)
     other_args = {'a=6378137.0', 'h=35785831', 'lat_0=53.7', 'lon_0=0.0',
-                  'x_0=0', 'y_0=0'}
-    check_proj4_params('nsper', geos, other_args)
+                  'units=m', 'x_0=0', 'y_0=0'}
+    check_proj_params('nsper', geos, other_args)
 
     assert_almost_equal(geos.boundary.bounds,
                         (-5476336.098, -5476336.098,

--- a/lib/cartopy/tests/crs/test_orthographic.py
+++ b/lib/cartopy/tests/crs/test_orthographic.py
@@ -31,7 +31,7 @@ from .helpers import check_proj_params
 
 def test_default():
     ortho = ccrs.Orthographic()
-    other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0'}
+    other_args = {'a=6378137.0', 'lon_0=0.0', 'lat_0=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     # WGS84 radius * 0.99999
@@ -46,7 +46,7 @@ def test_default():
 def test_central_params(lat, lon):
     ortho = ccrs.Orthographic(central_latitude=lat, central_longitude=lon)
     other_args = {'lat_0={}'.format(lat), 'lon_0={}'.format(lon),
-                  'ellps=WGS84'}
+                  'a=6378137.0'}
     check_proj_params('ortho', ortho, other_args)
 
     # WGS84 radius * 0.99999

--- a/lib/cartopy/tests/crs/test_orthographic.py
+++ b/lib/cartopy/tests/crs/test_orthographic.py
@@ -26,18 +26,13 @@ from numpy.testing import assert_almost_equal
 import pytest
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=ortho', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 def test_default():
     ortho = ccrs.Orthographic()
     other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0'}
-    check_proj4_params(ortho, other_args)
+    check_proj_params('ortho', ortho, other_args)
 
     # WGS84 radius * 0.99999
     assert_almost_equal(np.array(ortho.x_limits),
@@ -52,7 +47,7 @@ def test_central_params(lat, lon):
     ortho = ccrs.Orthographic(central_latitude=lat, central_longitude=lon)
     other_args = {'lat_0={}'.format(lat), 'lon_0={}'.format(lon),
                   'ellps=WGS84'}
-    check_proj4_params(ortho, other_args)
+    check_proj_params('ortho', ortho, other_args)
 
     # WGS84 radius * 0.99999
     assert_almost_equal(np.array(ortho.x_limits),
@@ -69,7 +64,7 @@ def test_grid():
     geodetic = ortho.as_geodetic()
 
     other_args = {'a=1.0', 'b=1.0', 'lon_0=0.0', 'lat_0=0.0'}
-    check_proj4_params(ortho, other_args)
+    check_proj_params('ortho', ortho, other_args)
 
     assert_almost_equal(np.array(ortho.x_limits),
                         [-0.99999, 0.99999])
@@ -122,7 +117,7 @@ def test_sphere_transform():
     geodetic = ortho.as_geodetic()
 
     other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0'}
-    check_proj4_params(ortho, other_args)
+    check_proj_params('ortho', ortho, other_args)
 
     assert_almost_equal(np.array(ortho.x_limits),
                         [-0.99999, 0.99999])

--- a/lib/cartopy/tests/crs/test_orthographic.py
+++ b/lib/cartopy/tests/crs/test_orthographic.py
@@ -41,6 +41,47 @@ def test_default():
                         [-6378073.21863, 6378073.21863])
 
 
+def test_sphere_globe():
+    globe = ccrs.Globe(semimajor_axis=1000, ellipse=None)
+    ortho = ccrs.Orthographic(globe=globe)
+    other_args = {'a=1000', 'lon_0=0.0', 'lat_0=0.0'}
+    check_proj_params('ortho', ortho, other_args)
+
+    assert_almost_equal(ortho.x_limits, [-999.99, 999.99])
+    assert_almost_equal(ortho.y_limits, [-999.99, 999.99])
+
+
+def test_ellipse_globe():
+    globe = ccrs.Globe(ellipse='WGS84')
+    with pytest.warns(UserWarning,
+                      match='does not handle elliptical globes.') as w:
+        ortho = ccrs.Orthographic(globe=globe)
+        assert len(w) == 1
+
+    other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0'}
+    check_proj_params('ortho', ortho, other_args)
+
+    # Limits are the same as default since ellipses are not supported.
+    assert_almost_equal(ortho.x_limits, [-6378073.21863, 6378073.21863])
+    assert_almost_equal(ortho.y_limits, [-6378073.21863, 6378073.21863])
+
+
+def test_eccentric_globe():
+    globe = ccrs.Globe(semimajor_axis=1000, semiminor_axis=500,
+                       ellipse=None)
+    with pytest.warns(UserWarning,
+                      match='does not handle elliptical globes.') as w:
+        ortho = ccrs.Orthographic(globe=globe)
+        assert len(w) == 1
+
+    other_args = {'a=1000', 'b=500', 'lon_0=0.0', 'lat_0=0.0'}
+    check_proj_params('ortho', ortho, other_args)
+
+    # Limits are the same as spheres since ellipses are not supported.
+    assert_almost_equal(ortho.x_limits, [-999.99, 999.99])
+    assert_almost_equal(ortho.y_limits, [-999.99, 999.99])
+
+
 @pytest.mark.parametrize('lat', [-10, 0, 10])
 @pytest.mark.parametrize('lon', [-10, 0, 10])
 def test_central_params(lat, lon):

--- a/lib/cartopy/tests/crs/test_robinson.py
+++ b/lib/cartopy/tests/crs/test_robinson.py
@@ -26,6 +26,7 @@ from numpy.testing import assert_almost_equal, assert_array_almost_equal
 import pytest
 
 import cartopy.crs as ccrs
+from .helpers import check_proj_params
 
 
 _CRS_PC = ccrs.PlateCarree()
@@ -36,16 +37,10 @@ _TOL = -1 if ccrs.PROJ4_VERSION < (4, 9) else 7
 _LIMIT_TOL = -1  # if ccrs.PROJ4_VERSION < (5, 2, 0) else 7
 
 
-def check_proj_params(crs, other_args):
-    expected = other_args | {'proj=robin', 'no_defs'}
-    proj_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == proj_params
-
-
 def test_default():
     robin = ccrs.Robinson()
     other_args = {'a=6378137.0', 'lon_0=0'}
-    check_proj_params(robin, other_args)
+    check_proj_params('robin', robin, other_args)
 
     assert_almost_equal(robin.x_limits,
                         [-17005833.3305252, 17005833.3305252])
@@ -57,7 +52,7 @@ def test_offset():
     crs = ccrs.Robinson()
     crs_offset = ccrs.Robinson(false_easting=1234, false_northing=-4321)
     other_args = {'a=6378137.0', 'lon_0=0', 'x_0=1234', 'y_0=-4321'}
-    check_proj_params(crs_offset, other_args)
+    check_proj_params('robin', crs_offset, other_args)
     assert tuple(np.array(crs.x_limits) + 1234) == crs_offset.x_limits
     assert tuple(np.array(crs.y_limits) - 4321) == crs_offset.y_limits
 
@@ -66,7 +61,7 @@ def test_offset():
 def test_central_longitude(lon):
     robin = ccrs.Robinson(central_longitude=lon)
     other_args = {'a=6378137.0', 'lon_0={}'.format(lon)}
-    check_proj_params(robin, other_args)
+    check_proj_params('robin', robin, other_args)
 
     assert_almost_equal(robin.x_limits,
                         [-17005833.3305252, 17005833.3305252],

--- a/lib/cartopy/tests/crs/test_robinson.py
+++ b/lib/cartopy/tests/crs/test_robinson.py
@@ -48,6 +48,50 @@ def test_default():
                         [-8625154.6651000, 8625154.6651000], _LIMIT_TOL)
 
 
+def test_sphere_globe():
+    globe = ccrs.Globe(semimajor_axis=1000, ellipse=None)
+    robin = ccrs.Robinson(globe=globe)
+    other_args = {'a=1000', 'lon_0=0'}
+    check_proj_params('robin', robin, other_args)
+
+    assert_almost_equal(robin.x_limits, [-2666.2696851, 2666.2696851])
+    assert_almost_equal(robin.y_limits, [-1352.3000000, 1352.3000000],
+                        _LIMIT_TOL)
+
+
+def test_ellipse_globe():
+    globe = ccrs.Globe(ellipse='WGS84')
+    with pytest.warns(UserWarning,
+                      match='does not handle elliptical globes.') as w:
+        robin = ccrs.Robinson(globe=globe)
+        assert len(w) == 1
+
+    other_args = {'ellps=WGS84', 'lon_0=0'}
+    check_proj_params('robin', robin, other_args)
+
+    # Limits are the same as default since ellipses are not supported.
+    assert_almost_equal(robin.x_limits, [-17005833.3305252, 17005833.3305252])
+    assert_almost_equal(robin.y_limits, [-8625154.6651000, 8625154.6651000],
+                        _LIMIT_TOL)
+
+
+def test_eccentric_globe():
+    globe = ccrs.Globe(semimajor_axis=1000, semiminor_axis=500,
+                       ellipse=None)
+    with pytest.warns(UserWarning,
+                      match='does not handle elliptical globes.') as w:
+        robin = ccrs.Robinson(globe=globe)
+        assert len(w) == 1
+
+    other_args = {'a=1000', 'b=500', 'lon_0=0'}
+    check_proj_params('robin', robin, other_args)
+
+    # Limits are the same as spheres since ellipses are not supported.
+    assert_almost_equal(robin.x_limits, [-2666.2696851, 2666.2696851])
+    assert_almost_equal(robin.y_limits, [-1352.3000000, 1352.3000000],
+                        _LIMIT_TOL)
+
+
 def test_offset():
     crs = ccrs.Robinson()
     crs_offset = ccrs.Robinson(false_easting=1234, false_northing=-4321)

--- a/lib/cartopy/tests/crs/test_rotated_geodetic.py
+++ b/lib/cartopy/tests/crs/test_rotated_geodetic.py
@@ -22,16 +22,14 @@ Tests for the Transverse Mercator projection, including OSGB and OSNI.
 from __future__ import (absolute_import, division, print_function)
 
 import cartopy.crs as ccrs
+from .helpers import check_proj_params
 
 
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=ob_tran', 'o_proj=latlon',
-                             'to_meter=0.0174532925199433', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+common_other_args = {'o_proj=latlon', 'to_meter=0.0174532925199433'}
 
 
 def test_default():
     geos = ccrs.RotatedPole(60, 50, 80)
-    other_args = {'ellps=WGS84', 'lon_0=240', 'o_lat_p=50', 'o_lon_p=80'}
-    check_proj4_params(geos, other_args)
+    other_args = common_other_args | {'ellps=WGS84', 'lon_0=240', 'o_lat_p=50',
+                                      'o_lon_p=80'}
+    check_proj_params('ob_tran', geos, other_args)

--- a/lib/cartopy/tests/crs/test_rotated_pole.py
+++ b/lib/cartopy/tests/crs/test_rotated_pole.py
@@ -22,17 +22,14 @@ Tests for the Rotated Geodetic coordinate system.
 from __future__ import (absolute_import, division, print_function)
 
 import cartopy.crs as ccrs
+from .helpers import check_proj_params
 
 
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=ob_tran', 'o_proj=latlon',
-                             'to_meter=0.0174532925199433', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+common_other_args = {'o_proj=latlon', 'to_meter=0.0174532925199433'}
 
 
 def test_default():
     geos = ccrs.RotatedGeodetic(30, 15, 27)
     other_args = {'datum=WGS84', 'ellps=WGS84', 'lon_0=210', 'o_lat_p=15',
-                  'o_lon_p=27'}
-    check_proj4_params(geos, other_args)
+                  'o_lon_p=27'} | common_other_args
+    check_proj_params('ob_tran', geos, other_args)

--- a/lib/cartopy/tests/crs/test_sinusoidal.py
+++ b/lib/cartopy/tests/crs/test_sinusoidal.py
@@ -22,19 +22,14 @@ from numpy.testing import assert_almost_equal
 import pytest
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=sinu', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 class TestSinusoidal(object):
     def test_default(self):
         crs = ccrs.Sinusoidal()
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'x_0=0.0', 'y_0=0.0'}
-        check_proj4_params(crs, other_args)
+        check_proj_params('sinu', crs, other_args)
 
         assert_almost_equal(np.array(crs.x_limits),
                             [-20037508.3428, 20037508.3428],
@@ -48,7 +43,7 @@ class TestSinusoidal(object):
                            ellipse=None)
         crs = ccrs.Sinusoidal(globe=globe)
         other_args = {'a=1000', 'b=500', 'lon_0=0.0', 'x_0=0.0', 'y_0=0.0'}
-        check_proj4_params(crs, other_args)
+        check_proj_params('sinu', crs, other_args)
 
         assert_almost_equal(np.array(crs.x_limits),
                             [-3141.59, 3141.59], decimal=2)
@@ -60,7 +55,7 @@ class TestSinusoidal(object):
         crs_offset = ccrs.Sinusoidal(false_easting=1234,
                                      false_northing=-4321)
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'x_0=1234', 'y_0=-4321'}
-        check_proj4_params(crs_offset, other_args)
+        check_proj_params('sinu', crs_offset, other_args)
         assert tuple(np.array(crs.x_limits) + 1234) == crs_offset.x_limits
         assert tuple(np.array(crs.y_limits) - 4321) == crs_offset.y_limits
 
@@ -69,7 +64,7 @@ class TestSinusoidal(object):
         crs = ccrs.Sinusoidal(central_longitude=lon)
         other_args = {'ellps=WGS84', 'lon_0={}'.format(lon),
                       'x_0=0.0', 'y_0=0.0'}
-        check_proj4_params(crs, other_args)
+        check_proj_params('sinu', crs, other_args)
 
         assert_almost_equal(np.array(crs.x_limits),
                             [-20037508.3428, 20037508.3428],

--- a/lib/cartopy/tests/crs/test_stereographic.py
+++ b/lib/cartopy/tests/crs/test_stereographic.py
@@ -21,12 +21,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=stere', 'no_defs'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 class TestStereographic(object):
@@ -34,7 +29,7 @@ class TestStereographic(object):
         stereo = ccrs.Stereographic()
         other_args = {'ellps=WGS84', 'lat_0=0.0', 'lon_0=0.0', 'x_0=0.0',
                       'y_0=0.0'}
-        check_proj4_params(stereo, other_args)
+        check_proj_params('stere', stereo, other_args)
 
         assert_almost_equal(np.array(stereo.x_limits),
                             [-5e7, 5e7], decimal=4)
@@ -47,7 +42,7 @@ class TestStereographic(object):
         stereo = ccrs.Stereographic(globe=globe)
         other_args = {'a=1000', 'b=500', 'lat_0=0.0', 'lon_0=0.0', 'x_0=0.0',
                       'y_0=0.0'}
-        check_proj4_params(stereo, other_args)
+        check_proj_params('stere', stereo, other_args)
 
         # The limits in this test are sensible values, but are by no means
         # a "correct" answer - they mean that plotting the crs results in a
@@ -66,7 +61,7 @@ class TestStereographic(object):
         stereo = ccrs.NorthPolarStereo(true_scale_latitude=30, globe=globe)
         other_args = {'ellps=sphere', 'lat_0=90', 'lon_0=0.0', 'lat_ts=30',
                       'x_0=0.0', 'y_0=0.0'}
-        check_proj4_params(stereo, other_args)
+        check_proj_params('stere', stereo, other_args)
 
     def test_scale_factor(self):
         # See #455
@@ -79,7 +74,7 @@ class TestStereographic(object):
                                     globe=globe)
         other_args = {'ellps=sphere', 'lat_0=90.0', 'lon_0=0.0', 'k_0=0.75',
                       'x_0=0.0', 'y_0=0.0'}
-        check_proj4_params(stereo, other_args)
+        check_proj_params('stere', stereo, other_args)
 
         # Now test projections
         lon, lat = 10, 10
@@ -101,6 +96,6 @@ class TestStereographic(object):
 
         other_args = {'ellps=WGS84', 'lat_0=0.0', 'lon_0=0.0', 'x_0=1234',
                       'y_0=-4321'}
-        check_proj4_params(stereo_offset, other_args)
+        check_proj_params('stere', stereo_offset, other_args)
         assert (tuple(np.array(stereo.x_limits) + 1234) ==
                 stereo_offset.x_limits)

--- a/lib/cartopy/tests/crs/test_utm.py
+++ b/lib/cartopy/tests/crs/test_utm.py
@@ -26,22 +26,17 @@ from numpy.testing import assert_almost_equal
 import pytest
 
 import cartopy.crs as ccrs
-
-
-def check_proj4_params(crs, other_args):
-    expected = other_args | {'proj=utm', 'no_defs', 'units=m'}
-    pro4_params = set(crs.proj4_init.lstrip('+').split(' +'))
-    assert expected == pro4_params
+from .helpers import check_proj_params
 
 
 @pytest.mark.parametrize('south', [False, True])
 def test_default(south):
     zone = 1  # Limits are fixed, so don't bother checking other zones.
     utm = ccrs.UTM(zone, southern_hemisphere=south)
-    other_args = {'ellps=WGS84', 'zone={}'.format(zone)}
+    other_args = {'ellps=WGS84', 'units=m', 'zone={}'.format(zone)}
     if south:
         other_args |= {'south'}
-    check_proj4_params(utm, other_args)
+    check_proj_params('utm', utm, other_args)
 
     assert_almost_equal(np.array(utm.x_limits),
                         [-250000, 1250000])
@@ -55,8 +50,8 @@ def test_ellipsoid_transform():
     utm = ccrs.UTM(zone=18, globe=globe)
     geodetic = utm.as_geodetic()
 
-    other_args = {'ellps=clrk66', 'zone=18'}
-    check_proj4_params(utm, other_args)
+    other_args = {'ellps=clrk66', 'units=m', 'zone=18'}
+    check_proj_params('utm', utm, other_args)
 
     assert_almost_equal(np.array(utm.x_limits),
                         [-250000, 1250000])


### PR DESCRIPTION
## Rationale

The warnings and fallback to a spherical globe occur in several projections. This moves that check down to the base class so it does need to be repeated so many times. Some projections did not correctly handle said fallback or were missing a warning. Also, move the `check_proj_params` into one place so it doesn't have to be copied to every projection's tests.

## Implications
* Warnings about ellipses are consistent.
* `Orthographic` boundaries are now correct for eccentric globes (even though the projection doesn't support it.)
* `Gnomonic` now also warns that it doesn't support ellipses.
* Projections that don't support ellipses are now tested for not supporting ellipses (using a non-default sphere, an ellipse, and an eccentric ellipse, the latter two of which should warn.)