### PR TITLE
Add desired_tile_form to Stamen.

### DIFF
--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -281,8 +281,8 @@ class Stamen(GoogleWTS):
     attribute this imagery.
 
     """
-    def __init__(self, style='toner'):
-        super(Stamen, self).__init__()
+    def __init__(self, style='toner', desired_tile_form='RGB'):
+        super(Stamen, self).__init__(desired_tile_form=desired_tile_form)
         self.style = style
 
     def _image_url(self, tile):


### PR DESCRIPTION
## Rationale

This is needed for *-lines tiles to specify RGBA, or else they end up covering everything else.

## Implications

Lines and text overlay can be placed on top of normal tiles.