### PR TITLE
Updating shapereader to use shapely to create the geometries

### DIFF
--- a/lib/cartopy/tests/test_coastline.py
+++ b/lib/cartopy/tests/test_coastline.py
@@ -38,6 +38,5 @@ class TestCoastline(object):
         # geometries += all_geometries[48:52] # Aus & Taz
         # geometries += all_geometries[72:73] # GB
         # for geometry in geometries:
-        for i, geometry in enumerate(geometries[93:]):
-            for line_string in geometry:
-                projection.project_geometry(line_string)
+        for geometry in geometries[93:]:
+            projection.project_geometry(geometry)

--- a/lib/cartopy/tests/test_shapereader.py
+++ b/lib/cartopy/tests/test_shapereader.py
@@ -43,10 +43,9 @@ class TestLakes(object):
 
     def test_geometry(self):
         lake_geometry = self.test_lake_geometry
-        assert lake_geometry.type == 'MultiPolygon'
-        assert len(lake_geometry) == 1
+        assert lake_geometry.type == 'Polygon'
 
-        polygon = lake_geometry[0]
+        polygon = lake_geometry
 
         expected = np.array([(-84.85548682324658, 11.147898667846633),
                              (-85.29013729525353, 11.176165676310276),
@@ -99,10 +98,9 @@ class TestRivers(object):
 
     def test_geometry(self):
         geometry = self.test_river_geometry
-        assert geometry.type == 'MultiLineString'
-        assert len(geometry) == 1
+        assert geometry.type == 'LineString'
 
-        linestring = geometry[0]
+        linestring = geometry
         coords = linestring.coords
         assert round(abs(coords[0][0] - -124.83563045947423), 7) == 0
         assert round(abs(coords[0][1] - 56.75692352968272), 7) == 0


### PR DESCRIPTION
## Rationale

This is to address the issues discovered in #1204 and #1205 

When making the Fiona reader, I used 'shapely.geometry.shape' to create the geometries, rather than the previous Reader's method that had its own geometry factory. The old geometry factory **always** produced 'Multi'- geometries, whereas shapely returns a singular version if appropriate. All of the 110m natural earth shapefiles have singular geometries, but if you load the 10m resolution ones you can see that shapely does indeed return 'Multi'- geometries when appropriate.

@pelson was there a reason for the old shapereaders geometry factory method? Another solution to this problem would be update the FionaReader to use the old geometry factory methods. But, I'd be inclined to let shapely do the work, rather than have these methods within Cartopy.

## Implications

- The 'test_bounds' still fails when Fiona is installed due to loading all the geometries.

- There could be issues with reading in shapefiles that contain shapeTypes that aren't checked now that I've gotten rid of the various factories and relied on the 'shapely.geometry.shape()' function.

