### PR TITLE
TST: Update Natural Earth pytest markers.

### DIFF
--- a/lib/cartopy/tests/mpl/test_nightshade.py
+++ b/lib/cartopy/tests/mpl/test_nightshade.py
@@ -27,6 +27,7 @@ from cartopy.feature.nightshade import Nightshade
 from cartopy.tests.mpl import ImageTesting
 
 
+@pytest.mark.natural_earth
 @ImageTesting(['nightshade_platecarree'])
 def test_nightshade_image():
     # Test the actual creation of the image

--- a/lib/cartopy/tests/test_shapereader.py
+++ b/lib/cartopy/tests/test_shapereader.py
@@ -26,7 +26,6 @@ import pytest
 import cartopy.io.shapereader as shp
 
 
-@pytest.mark.natural_earth
 class TestLakes(object):
     def setup_class(self):
         LAKES_PATH = os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
## Rationale

TestLakes no longer uses NE download data as it uses a version stored in the repo already; the nightshade test uses coastlines and should be marked.

## Implications

Fixes #1206.