### PR TITLE
Add support for querying Ordnance Survey map image tiles

### DIFF
--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -528,14 +528,16 @@ class OrdnanceSurvey(GoogleWTS):
 
     def _image_url(self, tile):
         x, y, z = tile
-        url = 'https://api2.ordnancesurvey.co.uk/'\
-              'mapping_api/v1/service/wmts?'\
-              'key={apikey}&height=256&width=256&tilematrixSet=EPSG:3857&'\
-              'version=1.0.0&style={style}&layer={layer} 3857&'\
-              'SERVICE=WMTS&REQUEST=GetTile&format=image/png&'\
-              'TileMatrix=EPSG:3857:{z}&TileRow={y}&TileCol={x}'.format(
-            apikey=self.apikey, style=self.style,
-            layer=self.layer, z=z, y=y, x=x)
+        url = ('https://api2.ordnancesurvey.co.uk/'
+               'mapping_api/v1/service/wmts?'
+               'key={apikey}&height=256&width=256&tilematrixSet=EPSG:3857&'
+               'version=1.0.0&style={style}&layer={layer} 3857&'
+               'SERVICE=WMTS&REQUEST=GetTile&format=image/png&'
+               'TileMatrix=EPSG:3857:{z}&TileRow={y}&TileCol={x}'
+               .format(z=z, y=y, x=x,
+                       apikey=self.apikey,
+                       style=self.style,
+                       layer=self.layer))
         return url
 
 

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -497,6 +497,40 @@ class QuadtreeTiles(GoogleWTS):
                 yield self.tms_to_quadkey(tile, google=True)
 
 
+class OrdnanceSurvey(GoogleWTS):
+    # https://developer.ordnancesurvey.co.uk/os-api-framework-agreement = for terms of use
+    # https://apidocs.os.uk/docs/os-maps-wmts
+
+    def __init__(self, apikey, layer='Road', style=True, desired_tile_form='RGB'):
+        """
+        Parameters
+        ----------
+        apikey: required
+            The authentication key provided by OS to query the maps API
+        layer: optional
+            The style of the OS map tiles. One of 'Outdoor', 'Road',
+            'Light', 'Night', 'Leisure'. Defaults to 'Road'.
+        style: optional
+            Indicates if the map should be styled. Defaults to True.
+        desired_tile_form: optional
+            Defaults to 'RGB'.
+        """
+        super(OrdnanceSurvey, self).__init__(desired_tile_form=desired_tile_form)
+        self.apikey = apikey
+        self.style = 'true' if style else 'false'
+
+        if layer not in {'Outdoor', 'Road', 'Light', 'Night', 'Leisure'}:
+            raise ValueError('Invalid layer {}'.format(layer))
+
+        self.layer = layer
+
+    def _image_url(self, tile):
+        x, y, z = tile
+        url =  'https://api2.ordnancesurvey.co.uk/mapping_api/v1/service/wmts?key={apikey}&height=256&width=256&tilematrixSet=EPSG:3857&version=1.0.0&style={style}&layer={layer} 3857&SERVICE=WMTS&REQUEST=GetTile&format=image/png&TileMatrix=EPSG:3857:{z}&TileRow={y}&TileCol={x}'.format(
+            apikey=self.apikey, style=self.style, layer=self.layer, z=z, y=y, x=x)
+        return url
+
+
 def _merge_tiles(tiles):
     """Return a single image, merging the given images."""
     if not tiles:

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -501,8 +501,7 @@ class OrdnanceSurvey(GoogleWTS):
     # https://developer.ordnancesurvey.co.uk/os-api-framework-agreement
     # https://apidocs.os.uk/docs/os-maps-wmts
 
-    def __init__(self, apikey, layer='Road', style=True,
-                 desired_tile_form='RGB'):
+    def __init__(self, apikey, layer='Road', desired_tile_form='RGB'):
         """
         Parameters
         ----------
@@ -511,17 +510,17 @@ class OrdnanceSurvey(GoogleWTS):
         layer: optional
             The style of the OS map tiles. One of 'Outdoor', 'Road',
             'Light', 'Night', 'Leisure'. Defaults to 'Road'.
-        style: optional
-            Indicates if the map should be styled. Defaults to True.
+            Details about the style of layer can be found at:
+             - https://apidocs.os.uk/docs/layer-information
+             - https://apidocs.os.uk/docs/map-styles
         desired_tile_form: optional
-            Defaults to 'RGB'.
+            Defaults to 'RGB'.        
         """
         super(OrdnanceSurvey, self).__init__(
             desired_tile_form=desired_tile_form)
         self.apikey = apikey
-        self.style = 'true' if style else 'false'
 
-        if layer not in {'Outdoor', 'Road', 'Light', 'Night', 'Leisure'}:
+        if layer not in ['Outdoor', 'Road', 'Light', 'Night', 'Leisure']:
             raise ValueError('Invalid layer {}'.format(layer))
 
         self.layer = layer
@@ -530,15 +529,13 @@ class OrdnanceSurvey(GoogleWTS):
         x, y, z = tile
         url = ('https://api2.ordnancesurvey.co.uk/'
                'mapping_api/v1/service/wmts?'
-               'key={apikey}&height=256&width=256&tilematrixSet=EPSG:3857&'
-               'version=1.0.0&style={style}&layer={layer} 3857&'
-               'SERVICE=WMTS&REQUEST=GetTile&format=image/png&'
-               'TileMatrix=EPSG:3857:{z}&TileRow={y}&TileCol={x}'
-               .format(z=z, y=y, x=x,
-                       apikey=self.apikey,
-                       style=self.style,
-                       layer=self.layer))
-        return url
+               'key={apikey}&height=256&width=256&tilematrixSet=EPSG%3A3857&'
+               'version=1.0.0&style=true&layer={layer}%203857&'
+               'SERVICE=WMTS&REQUEST=GetTile&format=image%2Fpng&'
+               'TileMatrix=EPSG%3A3857%3A{z}&TileRow={y}&TileCol={x}')
+        return url.format(z=z, y=y, x=x,
+                          apikey=self.apikey,
+                          layer=self.layer)
 
 
 def _merge_tiles(tiles):

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -498,10 +498,11 @@ class QuadtreeTiles(GoogleWTS):
 
 
 class OrdnanceSurvey(GoogleWTS):
-    # https://developer.ordnancesurvey.co.uk/os-api-framework-agreement = for terms of use
+    # https://developer.ordnancesurvey.co.uk/os-api-framework-agreement
     # https://apidocs.os.uk/docs/os-maps-wmts
 
-    def __init__(self, apikey, layer='Road', style=True, desired_tile_form='RGB'):
+    def __init__(self, apikey, layer='Road', style=True,
+                 desired_tile_form='RGB'):
         """
         Parameters
         ----------
@@ -515,7 +516,8 @@ class OrdnanceSurvey(GoogleWTS):
         desired_tile_form: optional
             Defaults to 'RGB'.
         """
-        super(OrdnanceSurvey, self).__init__(desired_tile_form=desired_tile_form)
+        super(OrdnanceSurvey, self).__init__(
+            desired_tile_form=desired_tile_form)
         self.apikey = apikey
         self.style = 'true' if style else 'false'
 
@@ -526,8 +528,14 @@ class OrdnanceSurvey(GoogleWTS):
 
     def _image_url(self, tile):
         x, y, z = tile
-        url =  'https://api2.ordnancesurvey.co.uk/mapping_api/v1/service/wmts?key={apikey}&height=256&width=256&tilematrixSet=EPSG:3857&version=1.0.0&style={style}&layer={layer} 3857&SERVICE=WMTS&REQUEST=GetTile&format=image/png&TileMatrix=EPSG:3857:{z}&TileRow={y}&TileCol={x}'.format(
-            apikey=self.apikey, style=self.style, layer=self.layer, z=z, y=y, x=x)
+        url = 'https://api2.ordnancesurvey.co.uk/'\
+              'mapping_api/v1/service/wmts?'\
+              'key={apikey}&height=256&width=256&tilematrixSet=EPSG:3857&'\
+              'version=1.0.0&style={style}&layer={layer} 3857&'\
+              'SERVICE=WMTS&REQUEST=GetTile&format=image/png&'\
+              'TileMatrix=EPSG:3857:{z}&TileRow={y}&TileCol={x}'.format(
+            apikey=self.apikey, style=self.style,
+            layer=self.layer, z=z, y=y, x=x)
         return url
 
 

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -498,9 +498,18 @@ class QuadtreeTiles(GoogleWTS):
 
 
 class OrdnanceSurvey(GoogleWTS):
-    # https://developer.ordnancesurvey.co.uk/os-api-framework-agreement
-    # https://apidocs.os.uk/docs/os-maps-wmts
+    """
+    Implement web tile retrieval from Ordnance Survey map data.
+    To use this tile image source you will need to obtain an
+    API key from Ordnance Survey.
 
+    For more details on Ordnance Survey layer styles, see
+    https://apidocs.os.uk/docs/map-styles.
+
+    For the API framework agreement, see
+    https://developer.ordnancesurvey.co.uk/os-api-framework-agreement.
+    """
+    # API Documentation: https://apidocs.os.uk/docs/os-maps-wmts
     def __init__(self, apikey, layer='Road', desired_tile_form='RGB'):
         """
         Parameters
@@ -508,8 +517,8 @@ class OrdnanceSurvey(GoogleWTS):
         apikey: required
             The authentication key provided by OS to query the maps API
         layer: optional
-            The style of the OS map tiles. One of 'Outdoor', 'Road',
-            'Light', 'Night', 'Leisure'. Defaults to 'Road'.
+            The style of the Ordnance Survey map tiles. One of 'Outdoor',
+            'Road', 'Light', 'Night', 'Leisure'. Defaults to 'Road'.
             Details about the style of layer can be found at:
              - https://apidocs.os.uk/docs/layer-information
              - https://apidocs.os.uk/docs/map-styles

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -514,7 +514,7 @@ class OrdnanceSurvey(GoogleWTS):
              - https://apidocs.os.uk/docs/layer-information
              - https://apidocs.os.uk/docs/map-styles
         desired_tile_form: optional
-            Defaults to 'RGB'.        
+            Defaults to 'RGB'.
         """
         super(OrdnanceSurvey, self).__init__(
             desired_tile_form=desired_tile_form)

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -278,7 +278,8 @@ def test_ordnance_survey_tile_styles():
 
 @pytest.mark.network
 def test_ordnance_survey_get_image():
-    # In order to test fetching map images from OS an API key needs to be provided
+    # In order to test fetching map images from OS
+    # an API key needs to be provided
     try:
         api_key = os.environ['ORDNANCE_SURVEY_API_KEY']
     except KeyError:

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -17,6 +17,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+import os
 import types
 
 import numpy as np
@@ -26,9 +27,6 @@ import shapely.geometry as sgeom
 
 import cartopy.crs as ccrs
 import cartopy.io.img_tiles as cimgt
-
-# In order to test fetching map images from OS an API key needs to be provided
-ORDNANCE_SURVEY_API_KEY = None
 
 #: Maps Google tile coordinates to native mercator coordinates as defined
 #: by https://goo.gl/pgJi.
@@ -279,11 +277,15 @@ def test_ordnance_survey_tile_styles():
 
 
 @pytest.mark.network
-@pytest.mark.skipif(ORDNANCE_SURVEY_API_KEY is None,
-                    reason="No Ordnance Survey API available to test with")
 def test_ordnance_survey_get_image():
-    os1 = cimgt.OrdnanceSurvey(ORDNANCE_SURVEY_API_KEY, layer="Outdoor")
-    os2 = cimgt.OrdnanceSurvey(ORDNANCE_SURVEY_API_KEY, layer="Night")
+    # In order to test fetching map images from OS an API key needs to be provided
+    try:
+        api_key = os.environ['ORDNANCE_SURVEY_API_KEY']
+    except KeyError:
+        pytest.skip('ORDNANCE_SURVEY_API_KEY environment variable is unset.')
+
+    os1 = cimgt.OrdnanceSurvey(api_key, layer="Outdoor")
+    os2 = cimgt.OrdnanceSurvey(api_key, layer="Night")
 
     tile = (500, 300, 10)
 

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -27,6 +27,8 @@ import shapely.geometry as sgeom
 import cartopy.crs as ccrs
 import cartopy.io.img_tiles as cimgt
 
+# In order to test fetching map images from OS an API key needs to be provided
+ORDNANCE_SURVEY_API_KEY = None
 
 #: Maps Google tile coordinates to native mercator coordinates as defined
 #: by https://goo.gl/pgJi.
@@ -240,3 +242,54 @@ def test_mapbox_style_tiles_api_url():
     mapbox_sample = cimgt.MapboxStyleTiles(token, username, map_id)
     url_str = mapbox_sample._image_url(tile)
     assert url_str == exp_url
+
+
+def test_ordnance_survey_tile_styles():
+    """
+    Tests that setting the Ordnance Survey tile style works as expected.
+
+    This is essentially just assures information is properly propagated through
+    the class structure.
+    """
+    dummy_apikey = "None"
+
+    ref_url = ('https://api2.ordnancesurvey.co.uk/'
+               'mapping_api/v1/service/wmts?'
+               'key=None&height=256&width=256&tilematrixSet=EPSG%3A3857&'
+               'version=1.0.0&style=true&layer={layer}%203857&'
+               'SERVICE=WMTS&REQUEST=GetTile&format=image%2Fpng&'
+               'TileMatrix=EPSG%3A3857%3A{z}&TileRow={y}&TileCol={x}')
+    tile = ["1", "2", "3"]
+
+    # Default is Road.
+    os = cimgt.OrdnanceSurvey(dummy_apikey)
+    url = os._image_url(tile)
+    assert url == ref_url.format(layer="Road",
+                                 z=tile[2], y=tile[1], x=tile[0])
+
+    for layer in ['Outdoor', 'Light', 'Night', 'Leisure']:
+      os = cimgt.OrdnanceSurvey(dummy_apikey, layer=layer)
+      url = os._image_url(tile)
+      assert url == ref_url.format(layer=layer,
+                                   z=tile[2], y=tile[1], x=tile[0])
+
+    # Exception is raised if unknown style is passed.
+    with pytest.raises(ValueError):
+        cimgt.OrdnanceSurvey(dummy_apikey, layer="random_style")
+
+@pytest.mark.network
+@pytest.mark.skipif(ORDNANCE_SURVEY_API_KEY is None, reason="No Ordnance Survey API available to test with")
+def test_ordnance_survey_get_image():
+    os_outdoor = cimgt.OrdnanceSurvey(ORDNANCE_SURVEY_API_KEY, layer="Outdoor")
+    os_night = cimgt.OrdnanceSurvey(ORDNANCE_SURVEY_API_KEY, layer="Night")
+
+    tile = (500, 300, 10)
+
+    img_outdoor, extent_outdoor, _ = os_outdoor.get_image(tile)
+    img_night, extent_night, _ = os_night.get_image(tile)
+
+    # Different images for different layers
+    assert img_outdoor != img_night
+
+    # The extent is the same though
+    assert extent_outdoor == extent_night

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -268,28 +268,30 @@ def test_ordnance_survey_tile_styles():
                                  z=tile[2], y=tile[1], x=tile[0])
 
     for layer in ['Outdoor', 'Light', 'Night', 'Leisure']:
-      os = cimgt.OrdnanceSurvey(dummy_apikey, layer=layer)
-      url = os._image_url(tile)
-      assert url == ref_url.format(layer=layer,
-                                   z=tile[2], y=tile[1], x=tile[0])
+        os = cimgt.OrdnanceSurvey(dummy_apikey, layer=layer)
+        url = os._image_url(tile)
+        assert url == ref_url.format(layer=layer,
+                                     z=tile[2], y=tile[1], x=tile[0])
 
     # Exception is raised if unknown style is passed.
     with pytest.raises(ValueError):
         cimgt.OrdnanceSurvey(dummy_apikey, layer="random_style")
 
+
 @pytest.mark.network
-@pytest.mark.skipif(ORDNANCE_SURVEY_API_KEY is None, reason="No Ordnance Survey API available to test with")
+@pytest.mark.skipif(ORDNANCE_SURVEY_API_KEY is None,
+                    reason="No Ordnance Survey API available to test with")
 def test_ordnance_survey_get_image():
-    os_outdoor = cimgt.OrdnanceSurvey(ORDNANCE_SURVEY_API_KEY, layer="Outdoor")
-    os_night = cimgt.OrdnanceSurvey(ORDNANCE_SURVEY_API_KEY, layer="Night")
+    os1 = cimgt.OrdnanceSurvey(ORDNANCE_SURVEY_API_KEY, layer="Outdoor")
+    os2 = cimgt.OrdnanceSurvey(ORDNANCE_SURVEY_API_KEY, layer="Night")
 
     tile = (500, 300, 10)
 
-    img_outdoor, extent_outdoor, _ = os_outdoor.get_image(tile)
-    img_night, extent_night, _ = os_night.get_image(tile)
+    img1, extent1, _ = os1.get_image(tile)
+    img2, extent2, _ = os2.get_image(tile)
 
     # Different images for different layers
-    assert img_outdoor != img_night
+    assert img1 != img2
 
     # The extent is the same though
-    assert extent_outdoor == extent_night
+    assert extent1 == extent2


### PR DESCRIPTION
## Rationale

This adds support for generating maps that use Ordnance Survey data.

## Testing

I have tested that this works locally, but an API key will be needed from OS to perform regular tests.