### PR TITLE
Enable appveyor builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,46 @@
+environment:
+    matrix:
+        - PYTHON_VERSION: "3.6"
+          CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
+          PACKAGES: "cython numpy matplotlib-base proj4 pykdtree scipy"
+        - PYTHON_VERSION: "2.7"
+          CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
+          PACKAGES: "cython=0.17 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 mock msinttypes"
+
+install:
+  # Install miniconda
+  # -----------------
+  - set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%;
+
+  # Create the testing environment
+  # ------------------------------
+  - conda config --set always_yes yes --set changeps1 no --set show_channel_urls yes
+  - conda config --add channels conda-forge
+  - conda config --add channels conda-forge/label/testing
+  - set ENV_NAME=test-environment
+  - set PACKAGES=%PACKAGES% pillow pytest filelock pep8 pyshp shapely six requests pyepsg owslib
+  - conda create -n %ENV_NAME% python=%PYTHON_VERSION% %PACKAGES%
+  - activate %ENV_NAME%
+  - set INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%
+  - set LIB=%CONDA_PREFIX%\Library\lib;%LIB%
+
+  # Conda debug
+  # -----------
+  - conda list -n %ENV_NAME%
+  - conda list -n %ENV_NAME% --explicit
+  - conda info -a
+
+build_script:
+  # Install cartopy
+  # ---------------
+  - pip install --no-deps .
+  - python -c "import cartopy; print('Version ', cartopy.__version__)"
+
+test_script:
+  - set MPLBACKEND=Agg
+  - pytest --pyargs cartopy
+
+artifacts:
+  - path: cartopy_test_output
+    name: cartopy_test_output
+    type: zip

--- a/lib/cartopy/io/img_nest.py
+++ b/lib/cartopy/io/img_nest.py
@@ -142,7 +142,7 @@ class Img(collections.namedtuple('Img', _img_class_attrs)):
                 result = ['{}.{}'.format(froot, ext) for ext in fext_types]
 
         def _convert_basename(name):
-            dirname, basename = os.path.dirname(name), os.path.basename(name)
+            dirname, basename = os.path.split(name)
             base, ext = os.path.splitext(basename)
             if base == base.upper():
                 result = base.lower() + ext

--- a/lib/cartopy/tests/test_coding_standards.py
+++ b/lib/cartopy/tests/test_coding_standards.py
@@ -19,6 +19,7 @@ from __future__ import (absolute_import, division, print_function)
 
 from datetime import datetime
 from fnmatch import fnmatch
+import io
 from itertools import chain
 import os
 import re
@@ -146,7 +147,7 @@ class TestLicenseHeaders(object):
             if ext in ('.py', '.pyx', '.c', '.cpp', '.h') and \
                     os.path.isfile(full_fname) and \
                     not any(fnmatch(fname, pat) for pat in exclude_patterns):
-                with open(full_fname) as fh:
+                with io.open(full_fname, encoding='utf-8') as fh:
                     years = TestLicenseHeaders.years_of_license_in_file(fh)
                     if years is None:
                         print('The file {} has no valid header license and '
@@ -196,7 +197,7 @@ class TestFutureImports(object):
                 if any(fnmatch(full_fname, pat) for pat in self.excluded):
                     continue
 
-                with open(full_fname, "r") as fh:
+                with io.open(full_fname, "r", encoding='utf-8') as fh:
                     content = fh.read()
 
                     if re.search(self.future_imports_pattern, content) is None:

--- a/lib/cartopy/tests/test_img_nest.py
+++ b/lib/cartopy/tests/test_img_nest.py
@@ -20,6 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 import io
 import os
 import shutil
+import sys
 import warnings
 
 import numpy as np
@@ -41,35 +42,31 @@ _TEST_DATA_DIR = os.path.join(config["data_dir"],
                               'wmts', 'aerial')
 
 
-def test_world_files():
-    func = cimg_nest.Img.world_files
-    fname = 'one'
-    expected = ['one.w', 'one.W', 'ONE.w', 'ONE.W']
-    assert func(fname) == expected
+@pytest.mark.parametrize('fname, expected', [
+    ('one', ['one.w', 'one.W', 'ONE.w', 'ONE.W']),
+    ('one.png',
+     ['one.pngw', 'one.pgw', 'one.PNGW', 'one.PGW', 'ONE.pngw', 'ONE.pgw',
+      'ONE.PNGW', 'ONE.PGW']),
+    ('/one.png',
+     ['/one.pngw', '/one.pgw', '/one.PNGW', '/one.PGW', '/ONE.pngw',
+      '/ONE.pgw', '/ONE.PNGW', '/ONE.PGW']),
+    ('/one/two.png',
+     ['/one/two.pngw', '/one/two.pgw', '/one/two.PNGW', '/one/two.PGW',
+      '/one/TWO.pngw', '/one/TWO.pgw', '/one/TWO.PNGW', '/one/TWO.PGW']),
+    ('/one/two/THREE.png',
+     ['/one/two/THREE.pngw', '/one/two/THREE.pgw', '/one/two/THREE.PNGW',
+      '/one/two/THREE.PGW', '/one/two/three.pngw', '/one/two/three.pgw',
+      '/one/two/three.PNGW', '/one/two/three.PGW']),
+])
+def test_world_files(fname, expected):
+    if sys.platform == 'win32':
+        fname = fname.replace('/', '\\')
+        expected = [f.replace('/', '\\') for f in expected]
+        if fname.startswith('\\'):
+            fname = 'c:' + fname
+            expected = ['c:' + f for f in expected]
 
-    fname = 'one.png'
-    expected = ['one.pngw', 'one.pgw', 'one.PNGW', 'one.PGW',
-                'ONE.pngw', 'ONE.pgw', 'ONE.PNGW', 'ONE.PGW']
-    assert func(fname) == expected
-
-    fname = '/one.png'
-    expected = ['/one.pngw', '/one.pgw', '/one.PNGW', '/one.PGW',
-                '/ONE.pngw', '/ONE.pgw', '/ONE.PNGW', '/ONE.PGW']
-    assert func(fname) == expected
-
-    fname = '/one/two.png'
-    expected = ['/one/two.pngw', '/one/two.pgw',
-                '/one/two.PNGW', '/one/two.PGW',
-                '/one/TWO.pngw', '/one/TWO.pgw',
-                '/one/TWO.PNGW', '/one/TWO.PGW']
-    assert func(fname) == expected
-
-    fname = '/one/two/THREE.png'
-    expected = ['/one/two/THREE.pngw', '/one/two/THREE.pgw',
-                '/one/two/THREE.PNGW', '/one/two/THREE.PGW',
-                '/one/two/three.pngw', '/one/two/three.pgw',
-                '/one/two/three.PNGW', '/one/two/three.PGW']
-    assert func(fname) == expected
+    assert cimg_nest.Img.world_files(fname) == expected
 
 
 def _save_world(fname, args):

--- a/setup.py
+++ b/setup.py
@@ -172,10 +172,7 @@ except (OSError, ValueError, subprocess.CalledProcessError):
 
     geos_includes = []
     geos_library_dirs = []
-    if sys.platform.startswith('win'):
-        geos_libraries = ['geos']
-    else:
-        geos_libraries = ['geos_c']
+    geos_libraries = ['geos_c']
 else:
     if geos_version < GEOS_MIN_VERSION:
         print('GEOS version %s is installed, but cartopy requires at least '


### PR DESCRIPTION
## Rationale

#1221 

## Implications

This tests Python 3.6 latest everything and Python 2.7 oldest everything, on 64-bit ~~, then 32-bit~~. Because builds do not run in parallel, I ordered it from most relevant to least (as I see it.) It seems like conda-forge may no longer do 32-bit builds, so we may not need to check those. I also left out a few things that are already tested on Travis.