### PR TITLE
Add get_* and set_* methods for the FeatureArtist

### DIFF
--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -227,3 +227,30 @@ class FeatureArtist(matplotlib.artist.Artist):
 
         # n.b. matplotlib.collection.Collection.draw returns None
         return None
+
+
+# Put setters, getters and properties that one would expect on a matplotlib
+# artist.
+def _attach_setters_and_getters(prop):
+    getter_name = 'get_{}'.format(prop)
+    if not getattr(FeatureArtist, getter_name, None):
+        # Attach a getter for the prop.
+        def getter_meth(self):
+            return self._kwargs.get(prop, None)
+        setattr(FeatureArtist, getter_name, getter_meth)
+
+    setter_name = 'set_{}'.format(prop)
+    if not getattr(FeatureArtist, setter_name, None):
+        def setter_meth(self, v):
+            return self._kwargs.__setitem__(prop, v)
+        setattr(FeatureArtist, setter_name, setter_meth)
+
+
+# Use the standard matplotlib machinery to find out what we should be setting
+# for a PathCollection.
+_inspector = matplotlib.artist.ArtistInspector(
+    matplotlib.collections.PathCollection)
+
+# Attach the actual set_* and get_* methods.
+for _prop in _inspector.get_setters():
+    _attach_setters_and_getters(_prop)

--- a/lib/cartopy/tests/mpl/test_feature_artist.py
+++ b/lib/cartopy/tests/mpl/test_feature_artist.py
@@ -135,3 +135,12 @@ def test_feature_artist_draw_styler(path_collection_cls, feature):
         assert expected_call['paths'] == actual_args
         assert transform == actual_kwargs.pop('transform')
         assert expected_call['style'] == actual_kwargs
+
+
+def test_feature_artist_getp(feature):
+    fa = FeatureArtist(feature, facecolor='red')
+    assert fa._kwargs == {'facecolor': 'red'}
+    assert fa.get_facecolor() == 'red'
+    fa.set_facecolor('pink')
+    assert fa._kwargs == {'facecolor': 'pink'}
+    assert fa.get_facecolor() == 'pink'


### PR DESCRIPTION
## Rationale

Support standard matplotlib setters and getters. But not their respective properties (because they have hiddeous details, such as ``artist.figure`` being the actual data that is stored on the artist, whereas artist.facecolor is just an alias to ``artist._facecolor``).

## Implications

One can use standard matplotlib machinery for stylisation, including:

```
feature_artist.set_facecolor('red')
plt.setp(feature_artist, 'facecolor', 'red')
```

Closes #1226.