### PR TITLE
Made image tile fetching multi-threaded

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ environment:
           PACKAGES: "cython numpy matplotlib-base proj4 pykdtree scipy"
         - PYTHON_VERSION: "2.7"
           CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
-          PACKAGES: "cython=0.17 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 mock msinttypes"
+          PACKAGES: "cython=0.17 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 mock msinttypes futures"
 
 install:
   # Install miniconda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,7 @@ jobs:
           <<: *env-setup
           environment:
             PYTHON_VERSION: 2
+            EXTRA_PACKAGES: "futures"
       - run: *deps-install
       - run: *cp-install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
         # These ancient versions are linked to an old libgfortran, but that version
         # isn't pinned in the package metadata
         - PYTHON_VERSION=2.7
-          PACKAGES="cython=0.17 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 libgfortran=1 mock"
+          PACKAGES="cython=0.17 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 libgfortran=1 mock futures"
         - PYTHON_VERSION=3.5
           PACKAGES="cython=0.23.1 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 libgfortran=1"
           PYTHONHASHSEED=0  # So pytest-xdist works.
@@ -14,7 +14,7 @@ env:
           PACKAGES="cython numpy matplotlib-base proj4 pykdtree scipy fiona"
         - NAME="Latest everything (py2k)."
           PYTHON_VERSION=2
-          PACKAGES="cython numpy matplotlib proj4 scipy mock"
+          PACKAGES="cython numpy matplotlib proj4 scipy mock futures"
 
 
 sudo: false

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -31,9 +31,9 @@ using tiles in this way can be found at the
 from __future__ import (absolute_import, division, print_function)
 
 from abc import ABCMeta, abstractmethod
+import concurrent.futures
 import warnings
 
-import concurrent.futures
 from PIL import Image
 import shapely.geometry as sgeom
 import numpy as np

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -33,6 +33,7 @@ from __future__ import (absolute_import, division, print_function)
 from abc import ABCMeta, abstractmethod
 import warnings
 
+import concurrent.futures
 from PIL import Image
 import shapely.geometry as sgeom
 import numpy as np
@@ -48,6 +49,8 @@ class GoogleWTS(six.with_metaclass(ABCMeta, object)):
     A "tile" in this class refers to the coordinates (x, y, z).
 
     """
+    _MAX_THREADS = 24
+
     def __init__(self, desired_tile_form='RGB'):
         self.imgs = []
         self.crs = ccrs.Mercator.GOOGLE
@@ -55,15 +58,30 @@ class GoogleWTS(six.with_metaclass(ABCMeta, object)):
 
     def image_for_domain(self, target_domain, target_z):
         tiles = []
-        for tile in self.find_images(target_domain, target_z):
+
+        def fetch_tile(tile):
             try:
                 img, extent, origin = self.get_image(tile)
             except IOError:
-                continue
+                # Some services 404 for tiles that aren't supposed to be
+                # there (e.g. out of range).
+                raise
             img = np.array(img)
             x = np.linspace(extent[0], extent[1], img.shape[1])
             y = np.linspace(extent[2], extent[3], img.shape[0])
-            tiles.append([img, x, y, origin])
+            return img, x, y, origin
+
+        with concurrent.futures.ThreadPoolExecutor(
+                max_workers=self._MAX_THREADS) as executor:
+            futures = []
+            for tile in self.find_images(target_domain, target_z):
+                futures.append(executor.submit(fetch_tile, tile))
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    img, x, y, origin = future.result()
+                    tiles.append([img, x, y, origin])
+                except IOError:
+                    pass
 
         img, extent, origin = _merge_tiles(tiles)
         return img, extent, origin

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -3,3 +3,4 @@ shapely>=1.5.6
 pyshp>=1.1.4
 six>=1.3.0
 setuptools>=0.7.2
+futures; python_version == "2.7"


### PR DESCRIPTION
Constant pool size of 24 threads currently defined, but can be monkey-patched on the GoogleWTS class if necessary (``cartopy.io.img_tiles.GoogleWTS._MAX_THREADS = 1``).

## Rationale

Why do all of that IO in serial when we can get significant speedups by doing it in multiple threads?
Not sure why I didn't implement this in the first place, but the performance improvement is pretty substantial. 

For example, before:

```
$ time python eyja_volcano.py 

real	0m5.722s
user	0m1.070s
sys	0m0.226s
```

After:

```
time python eyja_volcano.py 

real	0m1.414s
user	0m1.043s
sys	0m0.220s
```

This is a typical speedup I've seen in development.

## Implications

* All image tile fetching is now done in parallel, with a pool size of 24. Still no caching (my original way in via #732, but I wanted to speed up straight-line first - evidence suggests that I can squeeze another 2x speedup with caching, but I need to figure out what I actually want there).

* Adds concurrent.futures to the python 2 dependencies.

* Image tiles are often between 5x-10x faster to draw very modest coverings. The bigger the extent, the greater the speedup (upto a theoretical 24x) 