### PR TITLE
Add python_requires to help pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -399,6 +399,7 @@ setup(
     ],
 
     cmdclass=cmdclass,
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*',
     classifiers=[
             'Development Status :: 4 - Beta',
             'License :: OSI Approved :: GNU Lesser General Public License v3 '

--- a/setup.py
+++ b/setup.py
@@ -399,7 +399,7 @@ setup(
     ],
 
     cmdclass=cmdclass,
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     classifiers=[
             'Development Status :: 4 - Beta',
             'License :: OSI Approved :: GNU Lesser General Public License v3 '
@@ -414,9 +414,9 @@ setup(
             'Programming Language :: Python :: 2',
             'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.3',
-            'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
             'Topic :: Scientific/Engineering',
             'Topic :: Scientific/Engineering :: GIS',
             'Topic :: Scientific/Engineering :: Visualization',


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
When old Python versions are dropped, `python_requires` will help pip install the right version for people still running those old Python versions.
 
For more info on how this works:
* https://packaging.python.org/guides/dropping-older-python-versions/
* https://hackernoon.com/phasing-out-python-runtimes-gracefully-956f112f33c4


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

If people are using an old pip (<9) or setuptools (<24), the keyword has no effect and pip will try and install the very latest release of cartopy. But in this case, it's exactly the same as not including this keyword. It's inclusion won't cause any errors.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
