### PR TITLE
Improved the testability of trace.

### DIFF
--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -659,8 +659,7 @@ def project_linear(geometry not None, CRS src_crs not None,
 class _Testing:
     @staticmethod
     def straight_and_within(Point l_start, Point l_end,
-                            double t_start,
-                            double t_end,
+                            double t_start, double t_end,
                             Interpolator interpolator, double threshold,
                             domain):
         # This function is for testing/demonstration only.
@@ -675,7 +674,7 @@ class _Testing:
         gp_domain = GEOSPrepare_r(handle, g_domain)
         
         state = get_state(interpolator.project(l_start), gp_domain, handle)
-        cdef bool p_start_inside_domain = POINT_IN
+        cdef bool p_start_inside_domain = state == POINT_IN
 
         # l_end and l_start should be un-projected.
         interpolator.set_line(l_start, l_end)


### PR DESCRIPTION
## Rationale

I've been *deep* inside the ``project_segment`` (``trace.pyx`` / ``_trace.cpp``) codebase as part of #1039. Whilst twiddling with the algorithm is easy enough, twiddling with it in a *correct way* is *really* hard without an absolutely firm grasp of what is going on. Both myself and @QuLogic are close-ish to that, but I've long wanted to document the algorithm that was originally implemented by @rhattersley. 

@QuLogic's #1251 recently converted everything to Cython, thus it is now significantly easier to hack into the internals of the algorithm and to instrument it from the python interpreter. This PR is then the next logical step to give us diagnostic and testable entry points to some of the key pieces.

## Implications

 * No growth in public API
 * Adds some untested code (for now). Tests to follow gradually as required.
 * Makes it easier to document the project_segment algorithm. First attempt at this in: https://gist.github.com/pelson/bea59fafd7c1bebb3c04f38a515ed8ff
 * Instrumentation will make iteration on the algorithm easier (this was the original objective in order to solve #1039)
