### PR TITLE
Add a number of timing benchmarks that can be tracked with ASV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ lib/cartopy/siteconfig.py
 
 cartopy_test_output
 
+
+benchmarks/results/
+benchmarks/envs/
+
 # pydev files
 .project
 .pydevproject

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -1,0 +1,70 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "cartopy",
+
+    // The project's homepage
+    "project_url": "https://github.com/scitools/cartopy",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": "../",
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "default" (for mercurial).
+    // "branches": ["master"], // for git
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "conda",
+
+    // the base URL to show a commit for the project.
+    // "show_commit_url": "http://github.com/owner/project/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    // "pythons": ["2.7", "3.6"],
+
+    // The list of conda channel names to be searched for benchmark
+    // dependency packages in the specified order
+    //"conda_channels": ["conda-forge", "defaults"],
+
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list or empty string indicates to just test against the default
+    // (latest) version. null indicates that the package is to not be
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed via
+    // pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
+    //
+    "matrix": {
+        "numpy": [""],
+        "cython": [""],
+        "matplotlib": [""],
+        "proj4": [""],
+        "pykdtree": [""],
+        "scipy": [""],
+        "fiona": [""]
+    },
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    "benchmark_dir": "cases",
+    "env_dir": "envs",
+
+    // The number of characters to retain in the commit hashes.
+    "hash_length": 12
+
+    // `asv` will cache results of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // the number of builds to keep, per environment.
+    // "build_cache_size": 2,
+}

--- a/benchmarks/cases/__init__.py
+++ b/benchmarks/cases/__init__.py
@@ -1,0 +1,18 @@
+# (C) British Crown Copyright 2019, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)

--- a/benchmarks/cases/mpl_redraw.py
+++ b/benchmarks/cases/mpl_redraw.py
@@ -1,0 +1,49 @@
+# (C) British Crown Copyright 2019, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+import io
+
+
+# No need for anything other than the agg backend, and we don't want
+# windows popping up as we are running these tests.
+plt.switch_backend('agg')
+
+
+def create_pc_png():
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
+    ax.coastlines()
+    ax.stock_img()
+    plt.savefig(io.BytesIO(), format='png')
+    plt.close(fig)
+
+
+def time_basic_draw_speed():
+    create_pc_png()
+
+
+def time_second_figure():
+    # Successive figures with Axes of the same projection
+    # could have various caching mechanisms in place.
+    # At the time of writing, there is no
+    # noticable performance speedup during the second figure :(
+    create_pc_png()
+    create_pc_png()

--- a/benchmarks/cases/project_linear.py
+++ b/benchmarks/cases/project_linear.py
@@ -1,0 +1,64 @@
+# (C) British Crown Copyright 2019, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+
+import cartopy.io.shapereader as shpreader
+import cartopy.crs as ccrs
+import shapely.geometry as sgeom
+
+
+class Oceans:
+    def prepare(self):
+        shpfilename = shpreader.natural_earth(
+            resolution='50m', category='physical', name='ocean')
+        reader = shpreader.Reader(shpfilename)
+        oceans = reader.geometries()
+        oceans = sgeom.MultiPolygon(oceans)
+        self.geoms = oceans
+
+
+OCEAN = Oceans()
+
+
+def use_setup(setup_fn):
+    # A decorator to create a decorator...
+    def decorator(test_func):
+        # This decorator attaches the setup function to the test.
+        test_func.setup = setup_fn
+        return test_func
+    return decorator
+
+
+@use_setup(OCEAN.prepare)
+def time_ocean_pc():
+    ccrs.PlateCarree().project_geometry(OCEAN.geoms)
+
+
+@use_setup(OCEAN.prepare)
+def time_ocean_np():
+    ccrs.NorthPolarStereo().project_geometry(OCEAN.geoms)
+
+
+@use_setup(OCEAN.prepare)
+def time_ocean_rob():
+    ccrs.Robinson().project_geometry(OCEAN.geoms)
+
+
+@use_setup(OCEAN.prepare)
+def time_ocean_igh():
+    ccrs.InterruptedGoodeHomolosine().project_geometry(OCEAN.geoms)


### PR DESCRIPTION
## Rationale

I've been hacking around with ``cartopy.trace`` recently, which is an extremely performance sensitive part of the cartopy codebase. You can't really be comfortable changing that code unless you measure the impact on performance. Therefore it makes sense to start building a set of performance metrics that we can run with [asv](https://github.com/airspeed-velocity/asv).

``asv`` is a little bit of a sledgehammer to crack a nut here, but it does provide some really convenient tools to do some of the basic stuff simply. TBH, all I've been doing so far is ``asv run --config=benchmarks/asv.conf.json``. This is the kind of result I'd be expecting:

```
$ asv run --conf=benchmarks/asv.conf.json 
· Creating environments
· Discovering benchmarks
· Running 4 total benchmarks (1 commits * 1 environments * 4 benchmarks)
[  0.00%] · For cartopy commit 427de4f5 <master>:
[  0.00%] ·· Benchmarking conda-py3.7-cython-fiona-matplotlib-numpy-proj4-pykdtree-scipy
[ 12.50%] ··· Running (mpl_redraw.time_draw_speed--)....
[ 62.50%] ··· mpl_redraw.time_draw_speed                           485±9ms
[ 75.00%] ··· mpl_redraw.time_redraw                               963±5ms
[ 87.50%] ··· project_linear.time_ocean_project_pc                66.1±1ms
[100.00%] ··· project_linear.time_ocean_project_stereo            70.3±1ms
```

If you want to run the benchmarks on your current environment, then
``asv dev --conf=benchmarks/asv.conf.json`` would be the magic.

## Implications

* Allows us to have a standard set of performance metrics that we can reference when updating performance critical code 
* No automation, nor public tracking of changes just yet (I don't plan on doing this at all) - if you want to track changes in performance you will need to run asv yourself
* No changes to cartopy codebase required
* Not yet testing a matrix of depdendencies (proj v4/v5, fiona vs no fiona, etc.) 