### PR TITLE
Remove the shapely_from_geos performance workaround

### DIFF
--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2018, Met Office
+# (C) British Crown Copyright 2011 - 2019, Met Office
 #
 # This file is part of cartopy.
 #
@@ -84,15 +84,7 @@ cdef GEOSGeometry *geos_from_shapely(shapely_geom) except *:
 
 cdef shapely_from_geos(GEOSGeometry *geom):
     """Turn the given GEOS geometry pointer into a shapely geometry."""
-    # This is the "correct" way to do it...
-    #   return geom_factory(<ptr>geom)
-    # ... but it's quite slow, so we do it by hand.
-    multi_line_string = sgeom.base.BaseGeometry()
-    multi_line_string.__class__ = sgeom.MultiLineString
-    multi_line_string.__geom__ = <ptr>geom
-    multi_line_string.__parent__ = None
-    multi_line_string._ndim = 2
-    return multi_line_string
+    return sgeom.base.geom_factory(<ptr>geom)
 
 
 ctypedef struct Point:


### PR DESCRIPTION
## Rationale

``shapely_from_geos`` has a memory leak in v0.17 and less (#1033 refers).
The code originally worked around poor performance, but said poor performance can no longer be measured. Unfortunately, this code has existed since cartopy's initial commit, so no chance to go back and find the thing that demonstrated poor performance. **For all performance checks (admittedly quite few, as defined in #1256) that I ran, this change had no significant impact (py37)**.

## Implications

* Closes #1033 
* Memory leak no longer happens (untested, as valgrind not available on my platform yet [OSX Mojave])
* Given the right benchmark, it is plausible that we *could* measure the difference. In lieu of said benchmark (which may or may not exist) we should do the right thing and only then optimise if we are able to identify an appropriate case **complete with a benchmark added to the suite**.
