### PR TITLE
Always use cythonized files in sdist.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ environment:
           PACKAGES: "cython numpy matplotlib-base proj4 pykdtree scipy"
         - PYTHON_VERSION: "2.7"
           CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
-          PACKAGES: "cython numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 mock msinttypes futures"
+          PACKAGES: "cython=0.28 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 mock msinttypes futures"
 
 install:
   # Install miniconda

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ environment:
           PACKAGES: "cython numpy matplotlib-base proj4 pykdtree scipy"
         - PYTHON_VERSION: "2.7"
           CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
-          PACKAGES: "cython=0.17 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 mock msinttypes futures"
+          PACKAGES: "cython numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 mock msinttypes futures"
 
 install:
   # Install miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ env:
         # These ancient versions are linked to an old libgfortran, but that version
         # isn't pinned in the package metadata
         - PYTHON_VERSION=2.7
-          PACKAGES="cython=0.17 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 libgfortran=1 mock futures"
+          PACKAGES="cython=0.* numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 libgfortran=1 mock futures"
         - PYTHON_VERSION=3.5
-          PACKAGES="cython=0.23.1 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 libgfortran=1"
+          PACKAGES="cython=0.* numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 libgfortran=1"
           PYTHONHASHSEED=0  # So pytest-xdist works.
         - NAME="Latest everything."
           PYTHON_VERSION=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ env:
         # These ancient versions are linked to an old libgfortran, but that version
         # isn't pinned in the package metadata
         - PYTHON_VERSION=2.7
-          PACKAGES="cython=0.* numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 libgfortran=1 mock futures"
+          PACKAGES="cython=0.28 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 libgfortran=1 mock futures"
         - PYTHON_VERSION=3.5
-          PACKAGES="cython=0.* numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 libgfortran=1"
+          PACKAGES="cython=0.28 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 libgfortran=1"
           PYTHONHASHSEED=0  # So pytest-xdist works.
         - NAME="Latest everything."
           PYTHON_VERSION=3.6

--- a/INSTALL
+++ b/INSTALL
@@ -56,7 +56,7 @@ The recipes for these can be found at https://github.com/conda-forge/feedstocks.
 **Python** 2.7 or later (https://www.python.org/)
     Cartopy requires Python 2.7 or later.
 
-**Cython** 0.29 or later (https://pypi.python.org/pypi/Cython/)
+**Cython** 0.28 or later (https://pypi.python.org/pypi/Cython/)
 
 **NumPy** 1.10 or later (http://www.numpy.org/)
     Python package for scientific computing including a powerful N-dimensional

--- a/INSTALL
+++ b/INSTALL
@@ -56,7 +56,7 @@ The recipes for these can be found at https://github.com/conda-forge/feedstocks.
 **Python** 2.7 or later (https://www.python.org/)
     Cartopy requires Python 2.7 or later.
 
-**Cython** 0.17 or later (https://pypi.python.org/pypi/Cython/)
+**Cython** 0.29 or later (https://pypi.python.org/pypi/Cython/)
 
 **NumPy** 1.10 or later (http://www.numpy.org/)
     Python package for scientific computing including a powerful N-dimensional

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,5 +9,5 @@ include lib/cartopy/data/*
 include lib/cartopy/io/srtm.npz
 include lib/cartopy/tests/lakes_shapefile/*
 recursive-include lib *.py
-recursive-include lib *.pyx *.pxd *.h
+recursive-include lib *.pyx *.pxd *.h *.c *.cpp
 include versioneer.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@ include CHANGES
 include COPYING*
 include INSTALL
 include README.rst
-include pyproject.toml
 include requirements/*.txt
 include lib/cartopy/data/*
 include lib/cartopy/io/srtm.npz

--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2018, Met Office
+# (C) British Crown Copyright 2011 - 2019, Met Office
 #
 # This file is part of cartopy.
 #
@@ -170,7 +170,7 @@ cdef class LineAccumulator:
                                                &geoms[0], geoms.size())
         return geom
 
-    cdef list[Line].size_type size(self):
+    cdef size_t size(self):
         return self.lines.size()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy>=1.10", "Cython>=0.17"]
+requires = ["setuptools", "wheel", "numpy>=1.10"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[build-system]
-requires = ["setuptools", "wheel", "numpy>=1.10"]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2018, Met Office
+# (C) British Crown Copyright 2011 - 2019, Met Office
 #
 # This file is part of cartopy.
 #
@@ -43,9 +43,9 @@ IS_SDIST = os.path.exists(os.path.join(HERE, 'PKG-INFO'))
 
 if not IS_SDIST:
     import Cython
-    if Cython.__version__ < '0.29':
+    if Cython.__version__ < '0.28':
         raise ImportError(
-            "Cython 0.29+ is required to install cartopy from source.")
+            "Cython 0.28+ is required to install cartopy from source.")
 
     from Cython.Distutils import build_ext as cy_build_ext
 

--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,13 @@ HERE = os.path.dirname(__file__)
 IS_SDIST = os.path.exists(os.path.join(HERE, 'PKG-INFO'))
 
 if not IS_SDIST:
-    try:
-        from Cython.Distutils import build_ext
-    except ImportError:
+    import Cython
+    if Cython.__version__ < '0.29':
         raise ImportError(
-            "Cython 0.17+ is required to install cartopy from source.")
+            "Cython 0.29+ is required to install cartopy from source.")
+
+    from Cython.Distutils import build_ext as cy_build_ext
+
 
 try:
     import numpy as np
@@ -383,7 +385,7 @@ cmdclass = versioneer.get_cmdclass()
 if IS_SDIST:
     extensions = decythonize(extensions)
 else:
-    cmdclass.update({'build_ext': build_ext})
+    cmdclass.update({'build_ext': cy_build_ext})
 
 
 # Main setup


### PR DESCRIPTION
## Rationale

In #1258 @scoder suggested that we should consider making recompilation of pyx files optional. I can see some pros/cons to this approach, but it does mean that Cython is removed as an installation dependency, and would close #1258. The approach I've taken mimics numpy's - it only recompiles the Cythonized c++/c if we are not in a sdist (i.e. there is no [PKG-INFO](https://www.python.org/dev/peps/pep-0314/#including-metadata-in-packages)).

## Implications

 * Changes to the pyx files will be ignored when running setup.py **IFF** there is a PKG-INFO file at the same level as the ``setup.py`` (no for github source, yes for sdist).
 * sdist now need to ship the Cythonized files as well as the pyx. 
