### PR TITLE
TST: Disable build isolation during testing.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ install:
 build_script:
   # Install cartopy
   # ---------------
-  - pip install --no-deps .
+  - pip install --no-build-isolation --no-deps .
   - python -c "import cartopy; print('Version ', cartopy.__version__)"
 
 test_script:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ cp-run: &cp-install
   name: Install Cartopy
   command: |
     source activate test-environment
-    pip install -ve .
+    pip install --no-build-isolation --no-deps -ve .
 
 doc-run: &doc-build
   name: Build documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
 
   # Install cartopy
   # ---------------
-  - pip install --no-deps .
+  - pip install --no-build-isolation --no-deps .
   - python -c "import cartopy; print('Version ', cartopy.__version__)" && python setup.py version
 
 script:


### PR DESCRIPTION
Build isolation seems to install a new version of build dependencies in an isolated spot, which then may not actually be testing against the versions we want.

I _think_ this will fix some of the NumPy ufunc build errors we're seeing. It _may_ be building against a newer NumPy than we get from conda, which then fails when running against the installed copy.