### PR TITLE
Fix some warnings in tests

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2018, Met Office
+# (C) British Crown Copyright 2011 - 2019, Met Office
 #
 # This file is part of cartopy.
 #
@@ -1177,7 +1177,7 @@ class LambertConformal(Projection):
         self.cutoff = cutoff
         n = 91
         lons = np.empty(n + 2)
-        lats = np.full(n + 2, cutoff)
+        lats = np.full(n + 2, float(cutoff))
         lons[0] = lons[-1] = 0
         lats[0] = lats[-1] = plat
         if plat == 90:

--- a/lib/cartopy/tests/crs/test_lambert_conformal.py
+++ b/lib/cartopy/tests/crs/test_lambert_conformal.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2018, Met Office
+# (C) British Crown Copyright 2011 - 2019, Met Office
 #
 # This file is part of cartopy.
 #
@@ -72,11 +72,11 @@ class Test_LambertConformal_standard_parallels(object):
         check_proj_params('lcc', crs, other_args)
 
     def test_no_parallel(self):
-        with pytest.raises(ValueError, message='1 or 2 standard parallels'):
+        with pytest.raises(ValueError, match='1 or 2 standard parallels'):
             ccrs.LambertConformal(standard_parallels=[])
 
     def test_too_many_parallel(self):
-        with pytest.raises(ValueError, message='1 or 2 standard parallels'):
+        with pytest.raises(ValueError, match='1 or 2 standard parallels'):
             ccrs.LambertConformal(standard_parallels=[1, 2, 3])
 
     def test_single_spole(self):

--- a/lib/cartopy/tests/io/test_ogc_clients.py
+++ b/lib/cartopy/tests/io/test_ogc_clients.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2018, Met Office
+# (C) British Crown Copyright 2011 - 2019, Met Office
 #
 # This file is part of cartopy.
 #
@@ -75,7 +75,7 @@ class TestWMSRasterSource(object):
 
     def test_no_layers(self):
         msg = 'One or more layers must be defined.'
-        with pytest.raises(ValueError, message=msg):
+        with pytest.raises(ValueError, match=msg):
             ogc.WMSRasterSource(self.URI, [])
 
     def test_extra_kwargs_empty(self):
@@ -106,7 +106,7 @@ class TestWMSRasterSource(object):
                              {ccrs.OSNI(): 'EPSG:29901'},
                              clear=True):
             msg = 'not available'
-            with pytest.raises(ValueError, message=msg):
+            with pytest.raises(ValueError, match=msg):
                 source.validate_projection(ccrs.Miller())
 
     def test_fetch_img(self):
@@ -175,7 +175,7 @@ class TestWMTSRasterSource(object):
         source = ogc.WMTSRasterSource(self.URI, self.layer_name)
         with mock.patch('cartopy.io.ogc_clients._URN_TO_CRS', {}):
             msg = 'Unable to find tile matrix for projection.'
-            with pytest.raises(ValueError, message=msg):
+            with pytest.raises(ValueError, match=msg):
                 source.validate_projection(ccrs.Miller())
 
     def test_fetch_img(self):
@@ -246,7 +246,7 @@ class TestWFSGeometrySource(object):
     def test_unsupported_projection(self):
         source = ogc.WFSGeometrySource(self.URI, self.typename)
         msg = 'Geometries are only available in projection'
-        with pytest.raises(ValueError, message=msg):
+        with pytest.raises(ValueError, match=msg):
             source.fetch_geometries(ccrs.PlateCarree(), [-180, 180, -90, 90])
 
     def test_fetch_geometries(self):

--- a/lib/cartopy/tests/io/test_srtm.py
+++ b/lib/cartopy/tests/io/test_srtm.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2018, Met Office
+# (C) British Crown Copyright 2011 - 2019, Met Office
 #
 # This file is part of cartopy.
 #
@@ -117,7 +117,7 @@ class TestSRTMSource__single_tile(object):
     def test_out_of_range(self, Source):
         source = Source()
         msg = 'No srtm tile found for those coordinates.'
-        with pytest.raises(ValueError, message=msg):
+        with pytest.raises(ValueError, match=msg):
             source.single_tile(-25, 50)
 
     def test_in_range(self, Source):

--- a/lib/cartopy/tests/mpl/test_ticker.py
+++ b/lib/cartopy/tests/mpl/test_ticker.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2019, Met Office
 #
 # This file is part of cartopy.
 #
@@ -33,7 +33,7 @@ def test_LatitudeFormatter_bad_axes():
     formatter = LatitudeFormatter()
     formatter.axis = Mock(axes=Mock(Axes, projection=ccrs.PlateCarree()))
     message = 'This formatter can only be used with cartopy axes.'
-    with pytest.raises(TypeError, message=message):
+    with pytest.raises(TypeError, match=message):
         formatter(0)
 
 
@@ -41,7 +41,7 @@ def test_LatitudeFormatter_bad_projection():
     formatter = LatitudeFormatter()
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=ccrs.Orthographic()))
     message = 'This formatter cannot be used with non-rectangular projections.'
-    with pytest.raises(TypeError, message=message):
+    with pytest.raises(TypeError, match=message):
         formatter(0)
 
 
@@ -49,7 +49,7 @@ def test_LongitudeFormatter_bad_axes():
     formatter = LongitudeFormatter()
     formatter.axis = Mock(axes=Mock(Axes, projection=ccrs.PlateCarree()))
     message = 'This formatter can only be used with cartopy axes.'
-    with pytest.raises(TypeError, message=message):
+    with pytest.raises(TypeError, match=message):
         formatter(0)
 
 
@@ -57,7 +57,7 @@ def test_LongitudeFormatter_bad_projection():
     formatter = LongitudeFormatter()
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=ccrs.Orthographic()))
     message = 'This formatter cannot be used with non-rectangular projections.'
-    with pytest.raises(TypeError, message=message):
+    with pytest.raises(TypeError, match=message):
         formatter(0)
 
 


### PR DESCRIPTION
Fixes error in calls to `pytest.raises` that now triggers warnings, and some NumPy FutureWarning about `np.full`.