### PR TITLE
Add coverage reporting.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,19 @@
+#
+# .coveragerc to control coverage.py
+#
+
+[run]
+branch = True
+omit = 
+    lib/cartopy/examples/*
+    lib/cartopy/sphinxext/*
+    lib/cartopy/tests/*
+    lib/cartopy/_version.py
+    *.pxd
+plugins = Cython.Coverage
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if __name__ == .__main__.:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ install:
   # Customise the testing environment
   # ---------------------------------
   - PACKAGES="$PACKAGES pillow pytest pytest-xdist filelock pep8 pyshp shapely six requests pyepsg owslib"
+  - if [[ "$NAME" == "Latest everything"* ]]; then
+        PACKAGES="$PACKAGES pytest-cov coveralls";
+        export CYTHON_COVERAGE=1;
+    fi
   - conda install --quiet $PACKAGES
 
   # Conda debug
@@ -69,9 +73,15 @@ script:
   - python $TRAVIS_BUILD_DIR/tools/feature_download.py gshhs physical --dry-run
 
   - if [[ "$NAME" == "Latest everything"* ]]; then
-      CARTOPY_GIT_DIR=$TRAVIS_BUILD_DIR pytest -n 4 --doctest-modules --pyargs cartopy;
+      CARTOPY_GIT_DIR=$TRAVIS_BUILD_DIR pytest -n 4 --doctest-modules --pyargs cartopy --cov=cartopy -ra;
     else
       CARTOPY_GIT_DIR=$TRAVIS_BUILD_DIR pytest -n 4 --pyargs cartopy;
+    fi
+
+
+after_success:
+  - if [[ "$NAME" == "Latest everything"* ]]; then
+      coveralls;
     fi
 
 after_failure:

--- a/setup.py
+++ b/setup.py
@@ -334,6 +334,12 @@ with open(os.path.join(HERE, 'README.md'), 'r') as fh:
     description = ''.join(fh.readlines())
 
 
+cython_coverage_enabled = os.environ.get('CYTHON_COVERAGE', None)
+if cython_coverage_enabled:
+    extra_cython_args = {'define_macros': [('CYTHON_TRACE_NOGIL', '1')]}
+    extra_extension_args.update(extra_cython_args)
+
+
 extensions = [
     Extension(
         'cartopy.trace',
@@ -360,6 +366,16 @@ extensions = [
         library_dirs=[library_dir] + proj_library_dirs,
         **extra_extension_args),
 ]
+
+
+if cython_coverage_enabled:
+    # We need to explicitly cythonize the extension in order
+    # to control the Cython compiler_directives.
+    from Cython.Build import cythonize
+
+    directives = {'linetrace': True,
+                  'binding': True}
+    extensions = cythonize(extensions, compiler_directives=directives)
 
 
 def decythonize(extensions, **_ignore):


### PR DESCRIPTION
Adds coverage testing on travis, to be tracked with coveralls.io.

This is an update to #1114 after a review, so happy to self-assign this.

Closes #1114.
