### PR TITLE
ensure the setup.py directory is in sys.path because of PEP 517

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,17 @@ import subprocess
 import sys
 import warnings
 
+# ensure the current directory is in sys.path so versioneer can be imported
+# this is needed because PEP 517 makes the directory of setup.py not included
+# in sys.path
+HERE = os.path.dirname(__file__)
+sys.path.append(HERE)
+
 import versioneer
 
 
 # The existence of a PKG-INFO directory is enough to tell us whether this is a
 # source installation or not (sdist).
-HERE = os.path.dirname(__file__)
 IS_SDIST = os.path.exists(os.path.join(HERE, 'PKG-INFO'))
 
 if not IS_SDIST:


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

Currently cartopy is failing to build on e.g. Travis with the following traceback:

```
 Traceback (most recent call last):
    File "/home/travis/build/ngoldbaum/yt/venv/lib/python2.7/site-packages/pip/_vendor/pep517/_in_process.py", line 207, in <module>
      main()
    File "/home/travis/build/ngoldbaum/yt/venv/lib/python2.7/site-packages/pip/_vendor/pep517/_in_process.py", line 197, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/home/travis/build/ngoldbaum/yt/venv/lib/python2.7/site-packages/pip/_vendor/pep517/_in_process.py", line 54, in get_requires_for_build_wheel
      return hook(config_settings)
    File "/tmp/pip-build-env-dD1vz4/overlay/lib/python2.7/site-packages/setuptools/build_meta.py", line 130, in get_requires_for_build_wheel
      return self._get_build_requires(config_settings, requirements=['wheel'])
    File "/tmp/pip-build-env-dD1vz4/overlay/lib/python2.7/site-packages/setuptools/build_meta.py", line 112, in _get_build_requires
      self.run_setup()
    File "/tmp/pip-build-env-dD1vz4/overlay/lib/python2.7/site-packages/setuptools/build_meta.py", line 126, in run_setup
      exec(compile(code, __file__, 'exec'), locals())
    File "setup.py", line 36, in <module>
      import versioneer
  ImportError: No module named versioneer
```

The issue is that in the latest version of pip, they enabled PEP 517 and PEP 518 support, which means that the directory of setup.py is no longer included in `sys.path`. Since cartopy uses versioneer and we *want* that behavior, the fix is to explicitly add the path to the `setup.py` directory to `sys.path`.

This was suggested to me by @pganssle on IRC.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

I think this is harmless for older setuptools and pip verisons, because `.` is already in sys.path.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
