### PR TITLE
FIX: remove unused default_params

### DIFF
--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -467,12 +467,14 @@ class LongitudeLocator(MaxNLocator):
     dms: bool
         Allow the locator to stop on on minutes and seconds (False by default)
     """
+    def __init__(self, *args, **kwargs):
+        nbins = kwargs.pop('nbins', 8)
+        super().__init__(*args, nbins=nbins, **kwargs)
 
     def set_params(self, **kwargs):
         """Set parameters within this locator."""
-        nbins = kwargs.pop('nbins', 8)
         self._dms = kwargs.pop('dms', False)
-        MaxNLocator.set_params(self, nbins=nbins, **kwargs)
+        MaxNLocator.set_params(self, **kwargs)
 
     def _guess_steps(self, vmin, vmax):
 

--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -469,7 +469,7 @@ class LongitudeLocator(MaxNLocator):
     """
     def __init__(self, *args, **kwargs):
         nbins = kwargs.pop('nbins', 8)
-        MaxNLocator(*args, nbins=nbins, **kwargs)
+        MaxNLocator.__init__(*args, nbins=nbins, **kwargs)
 
     def set_params(self, **kwargs):
         """Set parameters within this locator."""

--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -470,9 +470,9 @@ class LongitudeLocator(MaxNLocator):
 
     def set_params(self, **kwargs):
         """Set parameters within this locator."""
-        MaxNLocator.set_params(self, **kwargs)
-        if 'dms' in kwargs:
-            self._dms = kwargs['dms']
+        nbins = kwargs.pop('nbins', 8)
+        self._dms = kwargs.pop('dms', False)
+        MaxNLocator.set_params(self, nbins=nbins, **kwargs)
 
     def _guess_steps(self, vmin, vmax):
 

--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -469,7 +469,7 @@ class LongitudeLocator(MaxNLocator):
     """
     def __init__(self, *args, **kwargs):
         nbins = kwargs.pop('nbins', 8)
-        MaxNLocator.__init__(*args, nbins=nbins, **kwargs)
+        MaxNLocator.__init__(self, *args, nbins=nbins, **kwargs)
 
     def set_params(self, **kwargs):
         """Set parameters within this locator."""

--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -468,9 +468,6 @@ class LongitudeLocator(MaxNLocator):
         Allow the locator to stop on on minutes and seconds (False by default)
     """
 
-    default_params = MaxNLocator.default_params.copy()
-    default_params.update(nbins=8, dms=False)
-
     def set_params(self, **kwargs):
         """Set parameters within this locator."""
         MaxNLocator.set_params(self, **kwargs)

--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -469,7 +469,7 @@ class LongitudeLocator(MaxNLocator):
     """
     def __init__(self, *args, **kwargs):
         nbins = kwargs.pop('nbins', 8)
-        super().__init__(*args, nbins=nbins, **kwargs)
+        super(MaxNLocator, self).__init__(*args, nbins=nbins, **kwargs)
 
     def set_params(self, **kwargs):
         """Set parameters within this locator."""

--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -469,7 +469,7 @@ class LongitudeLocator(MaxNLocator):
     """
     def __init__(self, *args, **kwargs):
         nbins = kwargs.pop('nbins', 8)
-        super(MaxNLocator, self).__init__(*args, nbins=nbins, **kwargs)
+        MaxNLocator(*args, nbins=nbins, **kwargs)
 
     def set_params(self, **kwargs):
         """Set parameters within this locator."""


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

The copy of the default_params causes an error on matplotlib master.  
```
~/Cartopy/lib/cartopy/mpl/ticker.py in LongitudeLocator()
    469     """
    470 
--> 471     default_params = MaxNLocator.default_params.copy()
    472     default_params.update(nbins=8, dms=False)
    473 

AttributeError: '_deprecated_property' object has no attribute 'copy'
```

This change avoids using `default_params` at all.  


<!-- Please provide detail as to *why* you are making this change. -->


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->