### PR TITLE
Fix calls to pytest.raises.

### DIFF
--- a/lib/cartopy/tests/io/test_ogc_clients.py
+++ b/lib/cartopy/tests/io/test_ogc_clients.py
@@ -74,8 +74,8 @@ class TestWMSRasterSource(object):
         assert source.layers == self.layers
 
     def test_no_layers(self):
-        msg = 'One or more layers must be defined.'
-        with pytest.raises(ValueError, match=msg):
+        match = r'One or more layers must be defined\.'
+        with pytest.raises(ValueError, match=match):
             ogc.WMSRasterSource(self.URI, [])
 
     def test_extra_kwargs_empty(self):
@@ -174,8 +174,8 @@ class TestWMTSRasterSource(object):
     def test_unsupported_projection(self):
         source = ogc.WMTSRasterSource(self.URI, self.layer_name)
         with mock.patch('cartopy.io.ogc_clients._URN_TO_CRS', {}):
-            msg = 'Unable to find tile matrix for projection.'
-            with pytest.raises(ValueError, match=msg):
+            match = r'Unable to find tile matrix for projection\.'
+            with pytest.raises(ValueError, match=match):
                 source.validate_projection(ccrs.Miller())
 
     def test_fetch_img(self):

--- a/lib/cartopy/tests/io/test_srtm.py
+++ b/lib/cartopy/tests/io/test_srtm.py
@@ -116,8 +116,8 @@ class TestRetrieve(object):
 class TestSRTMSource__single_tile(object):
     def test_out_of_range(self, Source):
         source = Source()
-        msg = 'No srtm tile found for those coordinates.'
-        with pytest.raises(ValueError, match=msg):
+        match = r'No srtm tile found for those coordinates\.'
+        with pytest.raises(ValueError, match=match):
             source.single_tile(-25, 50)
 
     def test_in_range(self, Source):

--- a/lib/cartopy/tests/mpl/test_ticker.py
+++ b/lib/cartopy/tests/mpl/test_ticker.py
@@ -37,32 +37,32 @@ ONE_SEC = 1 / 3600.
 def test_LatitudeFormatter_bad_axes():
     formatter = LatitudeFormatter()
     formatter.axis = Mock(axes=Mock(Axes, projection=ccrs.PlateCarree()))
-    message = 'This formatter can only be used with cartopy GeoAxes.'
-    with pytest.raises(TypeError, message=message):
+    match = r'This formatter can only be used with cartopy GeoAxes\.'
+    with pytest.raises(TypeError, match=match):
         formatter(0)
 
 
 def test_LatitudeFormatter_bad_projection():
     formatter = LatitudeFormatter()
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=ccrs.Orthographic()))
-    message = 'This formatter cannot be used with non-rectangular projections.'
-    with pytest.raises(TypeError, match=message):
+    match = r'This formatter cannot be used with non-rectangular projections\.'
+    with pytest.raises(TypeError, match=match):
         formatter(0)
 
 
 def test_LongitudeFormatter_bad_axes():
     formatter = LongitudeFormatter()
     formatter.axis = Mock(axes=Mock(Axes, projection=ccrs.PlateCarree()))
-    message = 'This formatter can only be used with cartopy GeoAxes.'
-    with pytest.raises(TypeError, message=message):
+    match = r'This formatter can only be used with cartopy GeoAxes\.'
+    with pytest.raises(TypeError, match=match):
         formatter(0)
 
 
 def test_LongitudeFormatter_bad_projection():
     formatter = LongitudeFormatter()
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=ccrs.Orthographic()))
-    message = 'This formatter cannot be used with non-rectangular projections.'
-    with pytest.raises(TypeError, match=message):
+    match = r'This formatter cannot be used with non-rectangular projections\.'
+    with pytest.raises(TypeError, match=match):
         formatter(0)
 
 


### PR DESCRIPTION
## Rationale

The `message` argument is the output if the check fails, not the message to check. Also, it's a regex, so escape special characters.

## Implications

Fixes deprecation warnings;
```
lib/cartopy/tests/mpl/test_ticker.py:41
  /home/elliott/code/cartopy/lib/cartopy/tests/mpl/test_ticker.py:41: PytestDeprecationWarning: The 'message' parameter is deprecated.
  (did you mean to use `match='some regex'` to check the exception message?)
  Please comment on https://github.com/pytest-dev/pytest/issues/3974 if you have concerns about removal of this parameter.
    with pytest.raises(TypeError, message=message):
```