### PR TITLE
fix of typo in cartopy.io.ogc_clients._URN_TO_CRS

### DIFF
--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -81,7 +81,7 @@ METERS_PER_UNIT = {
     'urn:ogc:def:crs:EPSG::3031': 1,
     'urn:ogc:def:crs:EPSG::3413': 1,
     'urn:ogc:def:crs:EPSG::3857': 1,
-    'urn:ogc:def:crs:EPSG:6.18:3:3857': 1
+    'urn:ogc:def:crs:EPSG:6.18.3:3857': 1
 }
 
 _URN_TO_CRS = collections.OrderedDict(
@@ -97,7 +97,7 @@ _URN_TO_CRS = collections.OrderedDict(
          central_latitude=90,
          true_scale_latitude=70)),
      ('urn:ogc:def:crs:EPSG::3857', ccrs.GOOGLE_MERCATOR),
-     ('urn:ogc:def:crs:EPSG:6.18:3:3857', ccrs.GOOGLE_MERCATOR)
+     ('urn:ogc:def:crs:EPSG:6.18.3:3857', ccrs.GOOGLE_MERCATOR)
      ])
 
 # XML namespace definitions


### PR DESCRIPTION
## Rationale

<!-- Please provide detail as to *why* you are making this change. -->


while trying to add a wmts-service from `https://www.basemap.at/wmts/1.0.0/WMTSCapabilities.xml` I've got the following error... (see #1049)
```python
>>> ValueError: Unable to find tile matrix for projection.
    Projection: _EPSGProjection(3857)
    Available tile CRS URNs:
        urn:ogc:def:crs:EPSG:6.18.3:3857
```

I found that the reason for this is a remaining typo in the `_URN_TO_CRS` dictionary of `cartopy.io.ogc_clients`


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

Wmts-services using `EPSG:6.18.3:3857` find their associated crs object

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
