### PR TITLE
Fix bug causing interior polygons to be ignored

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -543,10 +543,17 @@ class Projection(six.with_metaclass(ABCMeta, CRS)):
                                            're-added. Please raise an issue.')
 
         # filter out any non-valid linear rings
+        def ring_validity(linear_ring):
+            if len(linear_ring.coords) == 3:
+                coords = list(linear_ring.coords)
+                return coords[0] != coords[-1] and linear_ring.is_valid
+            else:
+                return len(linear_ring.coords) > 3 and linear_ring.is_valid
+
         linear_rings = [
             sgeom.LinearRing(linear_ring)
             for linear_ring in processed_ls
-            if len(linear_ring.coords) > 2 and linear_ring.is_valid]
+            if ring_validity(linear_ring)]
 
         if debug:
             print('   DONE')

--- a/lib/cartopy/mpl/patch.py
+++ b/lib/cartopy/mpl/patch.py
@@ -191,7 +191,11 @@ def path_to_geos(path, force_ccw=False):
                 isinstance(geom, sgeom.Polygon) and
                 collection[-1][0].contains(geom.exterior)):
             collection[-1][1].append(geom.exterior)
-        elif isinstance(geom, sgeom.Point):
+        elif (isinstance(geom, sgeom.Point) or
+                (len(collection) > 0 and
+                isinstance(collection[-1][0], sgeom.Polygon) and
+                isinstance(geom, sgeom.LineString) and
+                collection[-1][0].contains(geom))):
             other_result_geoms.append(geom)
         else:
             collection.append((geom, []))

--- a/lib/cartopy/mpl/patch.py
+++ b/lib/cartopy/mpl/patch.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2018, Met Office
+# (C) British Crown Copyright 2011 - 2019, Met Office
 #
 # This file is part of cartopy.
 #
@@ -193,13 +193,13 @@ def path_to_geos(path, force_ccw=False):
             collection[-1][1].append(geom.exterior)
         # Sometimes Points and LineStrings will be passed while looking
         # for interior Polygons, these must be ignored. Failing to do so
-        # here would cause subsequent internal polygons to be read as 
+        # here would cause subsequent internal polygons to be read as
         # external instead.
         elif (isinstance(geom, sgeom.Point) or
                 (len(collection) > 0 and
-                isinstance(collection[-1][0], sgeom.Polygon) and
-                isinstance(geom, sgeom.LineString) and
-                collection[-1][0].contains(geom))):
+                 isinstance(collection[-1][0], sgeom.Polygon) and
+                 isinstance(geom, sgeom.LineString) and
+                 collection[-1][0].contains(geom))):
             other_result_geoms.append(geom)
         else:
             collection.append((geom, []))

--- a/lib/cartopy/mpl/patch.py
+++ b/lib/cartopy/mpl/patch.py
@@ -191,6 +191,10 @@ def path_to_geos(path, force_ccw=False):
                 isinstance(geom, sgeom.Polygon) and
                 collection[-1][0].contains(geom.exterior)):
             collection[-1][1].append(geom.exterior)
+        # Sometimes Points and LineStrings will be passed while looking
+        # for interior Polygons, these must be ignored. Failing to do so
+        # here would cause subsequent internal polygons to be read as 
+        # external instead.
         elif (isinstance(geom, sgeom.Point) or
                 (len(collection) > 0 and
                 isinstance(collection[-1][0], sgeom.Polygon) and

--- a/lib/cartopy/tests/mpl/test_patch.py
+++ b/lib/cartopy/tests/mpl/test_patch.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2018, Met Office
+# (C) British Crown Copyright 2015 - 2019, Met Office
 #
 # This file is part of cartopy.
 #
@@ -52,4 +52,15 @@ class Test_path_to_geos(object):
                  codes=[1, 2, 2, 2, 79, 1, 2, 2, 2, 79, 1, 2, 2, 2, 79])
         geoms = cpatch.path_to_geos(p)
         assert [type(geom) for geom in geoms] == [sgeom.Polygon, sgeom.Point]
+        assert len(geoms[0].interiors) == 1
+
+    def test_polygon_with_interior_and_short_path(self):
+        p = Path([[0, 0], [10, 0], [10, 10], [0, 10], [0, 0],
+                  [1, 1], [1, 1], [1, 2],
+                  [2, 2], [3, 2], [3, 3], [2, 3], [2, 2]],
+                 codes=[1, 2, 2, 2, 79,
+                        1, 2, 79,
+                        1, 2, 2, 2, 79])
+        geoms = cpatch.path_to_geos(p)
+        assert [type(geom) for geom in geoms] == [sgeom.Polygon, sgeom.LineString]
         assert len(geoms[0].interiors) == 1

--- a/lib/cartopy/tests/mpl/test_patch.py
+++ b/lib/cartopy/tests/mpl/test_patch.py
@@ -62,5 +62,6 @@ class Test_path_to_geos(object):
                         1, 2, 79,
                         1, 2, 2, 2, 79])
         geoms = cpatch.path_to_geos(p)
-        assert [type(geom) for geom in geoms] == [sgeom.Polygon, sgeom.LineString]
+        assert ([type(geom) for geom in geoms] ==
+                [sgeom.Polygon, sgeom.LineString])
         assert len(geoms[0].interiors) == 1


### PR DESCRIPTION
When path_to_geos read a path with the codes ...,1,2,79,... it would create a LineString which would be appended to collection. This would cause further path_codes to be ignored. This was causing a bug with contourf where occasionally these codes will be passed. This fix would cause these LineStrings to be added to other_result_geoms instead. I have not yet explored the possible consequences of passing LineStrings to other_result_geoms.

