### PR TITLE
fix issue #1341 by adding a user_agent when requesting tiles from a provider.

### DIFF
--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -39,6 +39,7 @@ import shapely.geometry as sgeom
 import numpy as np
 import six
 
+import cartopy
 import cartopy.crs as ccrs
 
 
@@ -51,7 +52,8 @@ class GoogleWTS(six.with_metaclass(ABCMeta, object)):
     """
     _MAX_THREADS = 24
 
-    def __init__(self, desired_tile_form='RGB', user_agent='cartopybot/1.0'):
+    def __init__(self, desired_tile_form='RGB',
+                 user_agent='CartoPy/' + cartopy.__version__):
         self.imgs = []
         self.crs = ccrs.Mercator.GOOGLE
         self.desired_tile_form = desired_tile_form
@@ -185,7 +187,7 @@ class GoogleWTS(six.with_metaclass(ABCMeta, object)):
 
         url = self._image_url(tile)
         try:
-            request = Request(url, headers={"user-agent": self.user_agent})
+            request = Request(url, headers={"User-Agent": self.user_agent})
             fh = urlopen(request)
             im_data = six.BytesIO(fh.read())
             fh.close()


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

It was no more possible to get tiles from OSM with the current code, as OSM was expecting a user agent in the tile request.
Furthermore, when the server could not be reached for network issue for example, the error would stop the program.
## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

There is a variable for the user agent and the possibility to set it at init, so there is a new parameter.


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->