### PR TITLE
Initializing axis with a global extent

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -323,6 +323,10 @@ class GeoAxes(matplotlib.axes.Axes):
         self.img_factories = []
         self._done_img_factory = False
 
+        # Initialize to a global extent, which will set the proper
+        # limits of the axis
+        self.set_global()
+
     @property
     def outline_patch(self):
         """


### PR DESCRIPTION

## Rationale

Tight layout/constrained layout currently needs two draw calls to size the axes approriately.
Closes #1207 
Closes https://github.com/matplotlib/matplotlib/issues/13430

## Implications

Figures with tight_layout or constrained_layout applied will behave as expected and without any warnings.