### PR TITLE
wip: no quick transform, when there is no vertices

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1250,7 +1250,7 @@ class Projection(CRS, metaclass=ABCMeta):
         if vertices.size == 0:
             return vertices
 
-        if self == src_crs:
+        if self == src_crs and len(vertices) > 0:
             x = vertices[:, 0]
             y = vertices[:, 1]
             # Extend the limits a tiny amount to allow for precision mistakes
@@ -1371,6 +1371,10 @@ class PlateCarree(_CylindricalProjection):
 
     def quick_vertices_transform(self, vertices, src_crs):
         return_value = super().quick_vertices_transform(vertices, src_crs)
+
+        # if there is no vertices
+        if len(vertices) == 0:
+            return return_value
 
         # Optimise the PlateCarree -> PlateCarree case where no
         # wrapping or interpolation needs to take place.


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
The tricontourf fails with the dataset I have, because the `vertices` parameter in `quick_vertices_transform` is empty.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
-->

## Checklist

 * [ ] If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 
 * [ ] Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

      I am not able to run the tests.

     ```
         ImportError while importing test module 
         '../Python/cartopy/lib/cartopy/tests/mpl/test_web_services.py'.
         Hint: make sure your test modules/packages have valid Python names.
        Traceback:
          __init__.py:95: in <module>
         import cartopy.crs
         crs.py:36: in <module>
        from cartopy._crs import (CRS, Geodetic, Globe, PROJ4_VERSION,
      E   ModuleNotFoundError: No module named 'cartopy._crs'
     ```


