### PR TITLE
Change default im_show origin to 'upper'

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1212,7 +1212,7 @@ class GeoAxes(matplotlib.axes.Axes):
         origin: {'lower', 'upper'}
             The origin of the vertical pixels. See
             :func:`matplotlib.pyplot.imshow` for further details.
-            Default is ``'lower'``.
+            Default is ``'upper'``. Prior to 0.18, it was ``'lower'``.
 
         """
         if 'update_datalim' in kwargs:
@@ -1222,7 +1222,7 @@ class GeoAxes(matplotlib.axes.Axes):
 
         transform = kwargs.pop('transform')
         extent = kwargs.get('extent', None)
-        kwargs.setdefault('origin', 'lower')
+        kwargs.setdefault('origin', 'upper')
 
         same_projection = (isinstance(transform, ccrs.Projection) and
                            self.projection == transform)

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -133,7 +133,7 @@ def test_imshow():
     # form that JPG images would be loaded with imread.
     img = (img * 255).astype('uint8')
     ax = plt.axes(projection=ccrs.Orthographic())
-    ax.imshow(img, origin='upper', transform=source_proj,
+    ax.imshow(img, transform=source_proj,
               extent=[-180, 180, -90, 90])
 
 
@@ -148,7 +148,7 @@ def test_imshow_projected():
     ax = plt.axes(projection=ccrs.LambertConformal())
     ax.set_extent(img_extent, crs=source_proj)
     ax.coastlines(resolution='50m')
-    ax.imshow(img, extent=img_extent, origin='upper', transform=source_proj)
+    ax.imshow(img, extent=img_extent, transform=source_proj)
 
 
 def test_imshow_wrapping():
@@ -180,7 +180,7 @@ def test_pil_Image():
     img = Image.open(NATURAL_EARTH_IMG)
     source_proj = ccrs.PlateCarree()
     ax = plt.axes(projection=ccrs.Orthographic())
-    ax.imshow(img, origin='upper', transform=source_proj,
+    ax.imshow(img, transform=source_proj,
               extent=[-180, 180, -90, 90])
 
 


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale
Change default origin to 'upper' for `im_show` to match matplotlib.


## Checklist
- [x] Closes #1187 


