### PR TITLE
Amend linked GH Issue label so known bugs show up

### DIFF
--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -38,6 +38,7 @@ the package wouldn't be as rich or diverse as it is today:
  * Daryl Herzmann
  * Robert Redl
  * Greg Lucas
+ * Sadie Bartholomew
 
 Thank you!
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -83,8 +83,8 @@ There are many ways to get involved in the development of cartopy:
    bugs which cover the issue before making a new one).
  * Help others with cartopy questions on `StackOverflow <https://stackoverflow.com/questions/tagged/cartopy>`_.
  * Contribute to the documentation fixing typos, adding examples, explaining things more clearly, or even
-   re-designing its layout/logos etc.. The `documentation source <https://github.com/SciTools/cartopy>`_ is kept in the same repository as the source code.
- * Contribute bug fixes (:issues:`a list of outstanding bugs can be found on github <bug>`).
+   re-designing its layout/logos etc. The `documentation source <https://github.com/SciTools/cartopy>`_ is kept in the same repository as the source code.
+ * Contribute bug fixes (:issues:`a list of outstanding bugs can be found on GitHub <Type%3A%20bug>`).
  * Contribute enhancements and new features on the issue tracker.
  * Chat with users and developers in the `Gitter chat room <https://gitter.im/SciTools/cartopy>`_.
 


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
The documentation contains some links to the GitHub Issue Tracker for the project, & on the homepage there's one intended to go to known bugs where there is a pre-populated label of "bug". However, following that link, no bugs (open or closed) appear in the query return table.

I thought this seemed strange given there were OOM ~100 generic Issues up, so I looked at current labels & there is not one called "bug"; it turns out, the label corresponding to Issues that are considered bugs is (now) "Type: bug". So I think the current URL link is the incorrect one to that intended, & I have amended it to what seems correct.

In short, compare the:

* [old (built docs / processed) link](https://github.com/SciTools/cartopy/labels/bug);
* [proposed new (built docs / processed) link](https://github.com/SciTools/cartopy/labels/Type%3A%20bug).

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

The relevant link in the documentation will take the reader to a query result page containing a listing of all the known bugs as Issues  (~150 at time of writing this up), rather than zero Issues.

In turn, there is no chance anyone following the link might mistakenly think there are no bugs registered for the project, & therefore perhaps lead to less duplicate reports!

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
