### PR TITLE
Fix geometry_length method

### DIFF
--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -39,6 +39,7 @@ the package wouldn't be as rich or diverse as it is today:
  * Robert Redl
  * Greg Lucas
  * Sadie Bartholomew
+ * Kacper Makuch
 
 Thank you!
 

--- a/lib/cartopy/geodesic/_geodesic.pyx
+++ b/lib/cartopy/geodesic/_geodesic.pyx
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2018, Met Office
+# (C) British Crown Copyright 2015 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -271,13 +271,8 @@ cdef class Geodesic:
             # Polygon.
             result = self.geometry_length(geometry.exterior)
 
-        elif hasattr(geometry, 'coords'):
+        elif hasattr(geometry, 'coords') and not isinstance(geometry, sgeom.Point):
             coords = np.array(geometry.coords)
-
-            # LinearRings are (N, 2), whereas LineStrings are (2, N).
-            if not isinstance(geometry, sgeom.LinearRing):
-                coords = coords.T
-
             result = self.geometry_length(coords)
 
         elif isinstance(geometry, np.ndarray):

--- a/lib/cartopy/tests/test_geodesic.py
+++ b/lib/cartopy/tests/test_geodesic.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2019, Met Office
+# (C) British Crown Copyright 2015 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -151,7 +151,7 @@ def test_geometry_length_ndarray():
 
 def test_geometry_length_linestring():
     geod = geodesic.Geodesic()
-    geom = sgeom.LineString(np.array([lhr, jfk, lhr]).T)
+    geom = sgeom.LineString(np.array([lhr, jfk, lhr]))
     expected = pytest.approx(lhr_to_jfk * 2, abs=1)
     assert geod.geometry_length(geom) == expected
 
@@ -159,8 +159,8 @@ def test_geometry_length_linestring():
 def test_geometry_length_multilinestring():
     geod = geodesic.Geodesic()
     geom = sgeom.MultiLineString(
-        [sgeom.LineString(np.array([lhr, jfk]).T),
-         sgeom.LineString(np.array([tul, jfk]).T)])
+        [sgeom.LineString(np.array([lhr, jfk])),
+         sgeom.LineString(np.array([tul, jfk]))])
     expected = pytest.approx(lhr_to_jfk + jfk_to_tul, abs=1)
     assert geod.geometry_length(geom) == expected
 
@@ -182,5 +182,5 @@ def test_geometry_length_polygon():
 def test_geometry_length_point():
     geod = geodesic.Geodesic()
     geom = sgeom.Point(lhr)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         geod.geometry_length(geom)


### PR DESCRIPTION

The problem has been reported in #1349. There was no possibility to calculate geometry_length using LineStrings. [Here](https://github.com/SciTools/cartopy/compare/master...kacmak7:i/1349?expand=1#diff-17926c715aee1d1dd5bb6e4e1529575dL277) LineStrings as well as LinearRings are (N, 2), also unit tests [here](https://github.com/SciTools/cartopy/compare/master...kacmak7:i/1349?expand=1#diff-58baff09f6513ec2ea387c6686574169L154) had inappropriate usage of LineString - it wouldn't work for more than 3 points e.g.: `geom = sgeom.LineString(np.array([lhr, jfk, lhr, jfk]).T)`