### PR TITLE
bugfix for shape file reading

### DIFF
--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -163,9 +163,10 @@ class BasicReader(object):
 
         """
         for i in range(self._reader.numRecords):
-            # Skip the shape that can not bee be represented as geometry.
+            shape = self._reader.shape(i)
+            # Skips the shape can not bee be represented as geometry.
             if shape.shapeType != shapefile.NULL:
-                yield sgeom.shape(self._reader.shape(i))
+                yield sgeom.shape(shape)
 
     def records(self):
         """

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -163,7 +163,9 @@ class BasicReader(object):
 
         """
         for i in range(self._reader.numRecords):
-            yield sgeom.shape(self._reader.shape(i))
+            # Skip the shape that can not bee be represented as geometry.
+            if shape.shapeType != shapefile.NULL:
+                yield sgeom.shape(self._reader.shape(i))
 
     def records(self):
         """


### PR DESCRIPTION
## Rationale

Some of the shapefiles have shapes that can not be represented as geometry, for example, Natural Earth Rivers-Lake-Centerlines shapefiles **after version 4.0.0**.

```python
import shapefile

sf = shapefile.Reader("ne_50m_rivers_lake_centerlines.shp")
assert(0 == sf.shapes()[-2].shapeType)
```
This shape can cause an exception when the feature is added to axes.

```python
import cartopy
import cartopy.crs as ccrs
import cartopy.feature as cfeat

proj = ccrs.PlateCarree()  
fig = plt.figure(figsize=(9, 8))

ax = fig.subplots(1, 1, subplot_kw={'projection': proj})
ax.add_feature(cfeat.RIVERS.with_scale('50m'))
```

