### PR TITLE
Update img_transform.py: regrid to fix issue #1398

### DIFF
--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -267,13 +267,21 @@ def regrid(array, source_x_coords, source_y_coords, source_cs, target_proj,
 
     # XXX NB. target_x and target_y must currently be rectangular (i.e.
     # be a 2d np array)
-    geo_cent = source_cs.as_geocentric()
-    xyz = geo_cent.transform_points(source_cs,
-                                    source_x_coords.flatten(),
-                                    source_y_coords.flatten())
-    target_xyz = geo_cent.transform_points(target_proj,
-                                           target_x_points.flatten(),
-                                           target_y_points.flatten())
+
+    # previously regrid was done in geocentric, but it would transform
+    # straight lines in source projection in geodesic circles
+    # to avoid that, the regrid values need to be calculated in the source
+    # projection
+
+    xyz = np.stack((
+        source_x_coords.flatten(),
+        source_y_coords.flatten()),
+        axis=-1)
+    target_xyz = source_cs.transform_points(target_proj,
+                                            target_x_points.flatten(),
+                                            target_y_points.flatten())
+    target_xyz = target_xyz[:, :2]
+    # drop z
 
     if _is_pykdtree:
         kdtree = pykdtree.kdtree.KDTree(xyz)

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -122,8 +122,7 @@ def _warped_located_image(image, source_projection, source_extent,
     else:
         # Convert Image to numpy array (flipping so that origin
         # is 'lower').
-        # convert to RGBA to keep the color palette
-        img, extent = warp_array(np.asanyarray(image.convert('RGBA'))[::-1],
+        img, extent = warp_array(np.asanyarray(image)[::-1],
                                  source_proj=source_projection,
                                  source_extent=source_extent,
                                  target_proj=output_projection,

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -122,7 +122,8 @@ def _warped_located_image(image, source_projection, source_extent,
     else:
         # Convert Image to numpy array (flipping so that origin
         # is 'lower').
-        img, extent = warp_array(np.asanyarray(image)[::-1],
+        # convert to RGBA to keep the color palette
+        img, extent = warp_array(np.asanyarray(image.convert('RGBA'))[::-1],
                                  source_proj=source_projection,
                                  source_extent=source_extent,
                                  target_proj=output_projection,


### PR DESCRIPTION
Regrid of image was done in geocentric coordinates. It transformed straight lines in great circle which was not the expected behaviour.
In the new version, regrid is done in the source projection and it preserves the straight lines.

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

Regrid for image in img_transform is supposed to transform an image from a source projection, the coordinate system in which the given image is rectangular, to a target projection.
The regrid was done in geocentric coordinates, so straight lines were transformed in great circles and the image was not kept rectangular in the source projection (with different longitude).
So I have modified regrid to do it in the source projection.


## Implications

I have tested it with imshow on all projections and it worked well, with the exception of UTM, but probably due to the zonage of UTM.
I don't know of an other usage than imshow.


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
I did't know where to put the example so here it is
```
import numpy as np
import matplotlib.pyplot as plt
import matplotlib.path as mpath
import cartopy.crs as ccrs

INTERVAL = 30
MINLAT = -75
MAXLAT = 75
MINLON = -165
MAXLON = 75

PROJ_DATA = {}
PROJ_DATA[0] = ccrs.PlateCarree(central_longitude=0)
PROJS = {}
PROJS[0] = {}
PROJS[0]['Plate Carre 180'] = ccrs.PlateCarree(central_longitude=180)
PROJS[0]['Plate Carre 0'] = ccrs.PlateCarree(central_longitude=0)
PROJS[0]['Plate Carre 225'] = ccrs.PlateCarree(central_longitude=225)
PROJS[0]['Mollweide 180'] = ccrs.Mollweide(central_longitude=180)
PROJS[0]['Polar -45'] = ccrs.NorthPolarStereo(central_longitude=-45)
PROJS[0]['AlbersEqualArea'] = ccrs.AlbersEqualArea()
PROJS[0]['AzimuthalEquidistant'] = ccrs.AzimuthalEquidistant()
PROJS[0]['EckertI'] = ccrs.EckertI()
PROJS[0]['EckertII'] = ccrs.EckertII()
PROJS[0]['EckertIII'] = ccrs.EckertIII()
PROJS[0]['EckertIV'] = ccrs.EckertIV()
PROJS[0]['EckertV'] = ccrs.EckertV()
PROJS[0]['EckertVI'] = ccrs.EckertVI()
PROJS[0]['EqualEarth'] = ccrs.EqualEarth()
PROJS[0]['EquidistantConic'] = ccrs.EquidistantConic()
PROJS[0]['EuroPP'] = ccrs.EuroPP()
PROJS[0]['Geostationary'] = ccrs.Geostationary()
PROJS[0]['Gnomonic'] = ccrs.Gnomonic()
PROJS[0]['InterruptedGoodeHomolosine'] = ccrs.InterruptedGoodeHomolosine()
PROJS[0]['LambertCylindrical'] = ccrs.LambertCylindrical()
PROJS[0]['LambertConformal'] = ccrs.LambertConformal()
PROJS[0]['LambertAzimuthalEqualArea'] = ccrs.LambertAzimuthalEqualArea()
PROJS[0]['Mercator'] = ccrs.Mercator()
PROJS[0]['Miller'] = ccrs.Miller()
PROJS[0]['NearsidePerspective'] = ccrs.NearsidePerspective()
PROJS[0]['OSGB'] = ccrs.OSGB()
PROJS[0]['OSNI'] = ccrs.OSNI()
PROJS[0]['Orthographic'] = ccrs.Orthographic()
PROJS[0]['Robinson'] = ccrs.Robinson()
PROJS[0]['RotatedPole'] = ccrs.RotatedPole(
    pole_latitude=37.5,
    pole_longitude=177.5)  # issue with extent
PROJS[0]['Sinusoidal'] = ccrs.Sinusoidal()
PROJS[0]['SouthPolarStereo'] = ccrs.SouthPolarStereo()
PROJS[0]['Stereographic'] = ccrs.Stereographic()
PROJS[0]['TransverseMercator'] = ccrs.TransverseMercator()
PROJS[0]['UTM'] = ccrs.UTM(zone=31)

PROJS[1] = {}
PROJS[1]['Polar -45'] = ccrs.NorthPolarStereo(central_longitude=-45)
PROJS[1]['Polar 0'] = ccrs.NorthPolarStereo(central_longitude=0)
PROJS[1]['Plate Carre 180'] = ccrs.PlateCarree(central_longitude=180)
PROJ_DATA[1] = PROJS[1]['Polar -45']

# set the longitudes and latitudes to span 0-360 and 90 to -90.
LAT = np.linspace(MAXLAT, MINLAT, (MAXLAT-MINLAT) / INTERVAL + 1)
LON = np.linspace(MINLON, MAXLON, (MAXLON-MINLON) / INTERVAL + 1)
LONGRID, LATGRID = np.meshgrid(LON, LAT)

# make a grid of DATA that representats the function sin(lon)*cos(lat)
DATA = {}
DATA[0] = np.sin(np.deg2rad(LONGRID)) + np.cos(np.deg2rad(LATGRID))+\
    0.2 * np.cos(np.deg2rad(LONGRID)) + 0.2 * np.sin(np.deg2rad(LATGRID))
DATA[1] = DATA[0][:, :5]
# set the extent of the DATA coordinates: the boundaries are extended by half a pixel in
# all directions since the function uses gridline coordinates.
EXTENT = {}
EXTENT[0] = (LON[0]-INTERVAL/2, LON[-1]+INTERVAL/2, LAT[-1]-INTERVAL/2,
             LAT[0]+INTERVAL/2)

# in polar
EXTENT[1] = [-12500000, 12500000, -12500000, 12500000]

CMAP = {}
CMAP[0] = 'viridis'
CMAP[1] = 'cool'

# circle to make the boundary in polar stereographic
THETA = np.linspace(0, 2 * np.pi, 100)
CENTER, RADIUS = [0, 0], 12500000
VERTS = np.vstack([np.sin(THETA), np.cos(THETA)]).T
CIRCLE = mpath.Path(VERTS * RADIUS + CENTER)

# Plot from PROJ_DATA to other PROJS
# ipr : 2 from stero to others
for ipr in range(2):
    for proj in PROJS[ipr]:
        print(proj)
        fig = plt.figure(figsize=(10, 6), dpi=100)
        axe = fig.add_subplot(111, projection=PROJS[ipr][proj])
        if 'Polar' in proj:
            axe.set_xlim(-12500000, 12500000)
            axe.set_ylim(-12500000, 12500000)
            axe.set_boundary(CIRCLE)
        elif 'RotatedPole' in proj:
            axe.set_xlim(-np.pi * 1.001, np.pi * 1.001)
            axe.set_ylim(-np.pi / 2., np.pi / 2.)
        elif 'UTM' in proj:
            axe.set_extent((0, 6, 20, 80))
            # the colors are not as expected, something is wrong
            # probably due to the wrapping of UTM
        else:
            axe.set_global()
        axe.imshow(DATA[ipr], transform=PROJ_DATA[ipr], extent=EXTENT[ipr],
                   origin='upper', cmap=CMAP[ipr])
        axe.set_title(proj)
        axe.coastlines()

```