### PR TITLE
Update ogc_clients.py issue #1386 color palette

### DIFF
--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -137,19 +137,10 @@ def _warped_located_image(image, source_projection, source_extent,
         # This avoids unsightly grey boundaries appearing when the
         # extent is limited (i.e. not global).
         if np.ma.is_masked(img):
-            if img.shape[2:3] == (3,):
-                # RGB
-                old_img = img
-                img = np.zeros(img.shape[:2] + (4,), dtype=img.dtype)
-                img[:, :, 0:3] = old_img
-                img[:, :, 3] = ~ np.any(old_img.mask, axis=2)
-                if img.dtype.kind == 'u':
-                    img[:, :, 3] *= 255
-            elif img.shape[2:3] == (4,):
-                # RGBA
-                img[:, :, 3] = np.where(np.any(img.mask, axis=2), 0,
-                                        img[:, :, 3])
-                img = img.data
+            # RGBA
+            img[:, :, 3] = np.where(np.any(img.mask, axis=2), 0,
+                                    img[:, :, 3])
+            img = img.data
 
         # Convert warped image array back to an Image, undoing the
         # earlier flip.

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -122,7 +122,8 @@ def _warped_located_image(image, source_projection, source_extent,
     else:
         # Convert Image to numpy array (flipping so that origin
         # is 'lower').
-        img, extent = warp_array(np.asanyarray(image)[::-1],
+        # convert to RGBA to keep the color palette
+        img, extent = warp_array(np.asanyarray(image.convert('RGBA'))[::-1],
                                  source_proj=source_projection,
                                  source_extent=source_extent,
                                  target_proj=output_projection,

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -122,7 +122,8 @@ def _warped_located_image(image, source_projection, source_extent,
     else:
         # Convert Image to numpy array (flipping so that origin
         # is 'lower').
-        # convert to RGBA to keep the color palette
+        # convert to RGBA to keep the color palette in the regrid process
+        # if any
         img, extent = warp_array(np.asanyarray(image.convert('RGBA'))[::-1],
                                  source_proj=source_projection,
                                  source_extent=source_extent,
@@ -132,12 +133,11 @@ def _warped_located_image(image, source_projection, source_extent,
                                  target_extent=output_extent,
                                  mask_extrapolated=True)
 
-        # Convert arrays with masked RGB(A) values to non-masked RGBA
+        # Convert arrays with masked RGBA values to non-masked RGBA
         # arrays, setting the alpha channel to zero for masked values.
         # This avoids unsightly grey boundaries appearing when the
         # extent is limited (i.e. not global).
         if np.ma.is_masked(img):
-            # RGBA
             img[:, :, 3] = np.where(np.any(img.mask, axis=2), 0,
                                     img[:, :, 3])
             img = img.data
@@ -563,7 +563,6 @@ class WMTSRasterSource(RasterSource):
             Preferred maximum pixel width or height in Axes coordinates.
 
         """
-
         # Find which tile matrix has the appropriate resolution.
         tile_matrix_set = wmts.tilematrixsets[matrix_set_name]
         tile_matrices = tile_matrix_set.tilematrix.values()


### PR DESCRIPTION
Fix issue #1386 when the color palette of the wms file is lost during the regrid process.

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

When the image fetched from the wms server is not in the expected projection, it is regridded.
When the source image is not RGB or RGBA, it looses its color palette in the regrid process.
To fix this, I have converted the source image to RGBA before the regrid process.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
 I am not aware of any implication.
There would be some implication if in some place cartopy regrids non RGBA image and need those to stay non RGBA.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
In the following example, when it works, both images have a "blue/red" palette, otherwise the reprojected image, the Mercator one, is a viridis colored image.
As those are images live from a server, they change with time.
```
from owslib.wms import WebMapService
import matplotlib.pyplot as plt
import cartopy.crs as ccrs

URL = "http://thredds.met.no/thredds/wms/sea/arctic20km/1h/aggregate_be?\
service=WMS&version=1.3.0&request=GetCapabilities"
WMS = WebMapService(URL, timeout=80)
LAYER = 'temperature'
WMS_KWARGS = {'transparent': False,
              'styles': ['boxfill/redblue']}
PROJECTIONS = [ccrs.Mercator(),
               ccrs.PlateCarree()]

for projection in PROJECTIONS:
    subplot_kw = dict(projection=projection)
    fig, ax = plt.subplots(subplot_kw=subplot_kw)
    ax.add_wms(WMS, LAYER, WMS_KWARGS)
    plt.title(projection.proj4_params['proj'])
```
![MercatorBlueRed](https://user-images.githubusercontent.com/54799451/70459234-08112c00-1ab4-11ea-93aa-d9c1265c6cf5.png)
