### PR TITLE
Update geoaxes.py pcolormesh overlapping cells plot issue #1416

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1720,36 +1720,47 @@ class GeoAxes(matplotlib.axes.Axes):
 
                     collection.set_array(pcolormesh_data.ravel())
 
-                    # now that the pcolormesh has masked the bad values,
-                    # create a pcolor with just those values that were masked
-                    if C_mask is not None:
-                        # remember to re-apply the original data mask
-                        pcolor_data = np.ma.array(C, mask=~mask | C_mask)
-                    else:
-                        pcolor_data = np.ma.array(C, mask=~mask)
-
-                    pts = coords.reshape((Ny, Nx, 2))
-                    if np.any(~pcolor_data.mask):
-                        # plot with slightly lower zorder to avoid odd issue
-                        # where the main plot is obscured
-                        zorder = collection.zorder - .1
-                        kwargs.pop('zorder', None)
-                        kwargs.setdefault('snap', False)
-                        pcolor_col = self.pcolor(pts[..., 0], pts[..., 1],
-                                                 pcolor_data, zorder=zorder,
-                                                 **kwargs)
-
-                        pcolor_col.set_cmap(cmap)
-                        pcolor_col.set_norm(norm)
-                        pcolor_col.set_clim(vmin, vmax)
-                        # scale the data according to the *original* data
-                        pcolor_col.norm.autoscale_None(C)
-
-                        # put the pcolor_col on the pcolormesh collection so
-                        # that if really necessary, users can do things post
-                        # this method
-                        collection._wrapped_collection_fix = pcolor_col
-
+                    # the part below in comment retrieves the masked 
+                    # overlapping cells and plot them with pcolor and a 
+                    # smaller zorder to hide them
+                    # but there are not always hidden 
+                    # if one wants to retrieve those cells, split them at the 
+                    # boundary and plot them, the code below could be 
+                    # useful.
+                    
+#                    #############
+#
+#                    # now that the pcolormesh has masked the bad values,
+#                    # create a pcolor with just those values that were masked
+#                    if C_mask is not None:
+#                        # remember to re-apply the original data mask
+#                        pcolor_data = np.ma.array(C, mask=~mask | C_mask)
+#                    else:
+#                        pcolor_data = np.ma.array(C, mask=~mask)
+#
+#                    pts = coords.reshape((Ny, Nx, 2))
+#                    
+#                    if np.any(~pcolor_data.mask):
+#                        # plot with slightly lower zorder to avoid odd issue
+#                        # where the main plot is obscured
+#                        zorder = collection.zorder - .1
+#                        kwargs.pop('zorder', None)
+#                        kwargs.setdefault('snap', False)
+#                        pcolor_col = self.pcolor(pts[..., 0], pts[..., 1],
+#                                                 pcolor_data, zorder=zorder,
+#                                                 **kwargs)
+#
+#                        pcolor_col.set_cmap(cmap)
+#                        pcolor_col.set_norm(norm)
+#                        pcolor_col.set_clim(vmin, vmax)
+#                        # scale the data according to the *original* data
+#                        pcolor_col.norm.autoscale_None(C)
+#
+#                        # put the pcolor_col on the pcolormesh collection so
+#                        # that if really necessary, users can do things post
+#                        # this method
+#                        collection._wrapped_collection_fix = pcolor_col
+#                    #############
             # Clip the QuadMesh to the projection boundary, which is required
             # to keep the shading inside the projection bounds.
             collection.set_clip_path(self.background_patch)

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1720,14 +1720,14 @@ class GeoAxes(matplotlib.axes.Axes):
 
                     collection.set_array(pcolormesh_data.ravel())
 
-                    # the part below in comment retrieves the masked 
-                    # overlapping cells and plot them with pcolor and a 
+                    # the part below in comment retrieves the masked
+                    # overlapping cells and plot them with pcolor and a
                     # smaller zorder to hide them
-                    # but there are not always hidden 
-                    # if one wants to retrieve those cells, split them at the 
-                    # boundary and plot them, the code below could be 
+                    # but there are not always hidden
+                    # if one wants to retrieve those cells, split them at the
+                    # boundary and plot them, the code below could be
                     # useful.
-                    
+
 #                    #############
 #
 #                    # now that the pcolormesh has masked the bad values,
@@ -1739,7 +1739,7 @@ class GeoAxes(matplotlib.axes.Axes):
 #                        pcolor_data = np.ma.array(C, mask=~mask)
 #
 #                    pts = coords.reshape((Ny, Nx, 2))
-#                    
+#
 #                    if np.any(~pcolor_data.mask):
 #                        # plot with slightly lower zorder to avoid odd issue
 #                        # where the main plot is obscured


### PR DESCRIPTION
Commented out the part plotting the overlapping cells (despite a smaller zorder).
Now the overlapping cells larger than half the projection span stay masked.

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
There is already a patch in pcolormesh that masks overlapping cells which are the cells crossing the longitude boundary and therefore overlapping the plot. 
In that patch, the overlapping cells, those who size is more than half the projection span in x, are masked and plot then again with a zorder supposedly small enough so that they don't appear.
Unfortunately they still appeared on the plot.
The idea in plotting the bad cells is that someone may want to use them, by splitting them at the boundary and plot the split part. But they shouldn't be plotted as there are.

So the fix is to comment out the part plotting the bad cells.

This patch works only for pcolormesh, there should be one of the same kind to mask the data generating overlapping cells or contours in  contourf, pcolor and contour.

This patch removes the cell greater than half the projection span in x, which works well for Plate Carree but not for the narrow part of a projection like Mollweide. This part is not fixed.

The image below displays ice concentration provided in a polar stereographic grid.
It had been plotted after the proposed fix.
The left plots are pcolormesh which includes the patch for overlapping cells, the right plots are contourf and displays many overlapping cells.
The pcolormesh plot in Mollweide projection still displays some small overlapping cells (less than half the projection span) on the narrow part of the plot.

There are no overlapping cells in the stereographic projection.
![pcolormesh_contourf](https://user-images.githubusercontent.com/54799451/70789684-c7efc900-1d93-11ea-9700-f95884aecc8d.png)

The data can be found [here](https://github.com/htonchia/cartopy-plotting-examples/blob/master/ice_conc_nh_polstere-100_multi_201912091200.nc).

```
import matplotlib.pyplot as plt
from netCDF4 import Dataset
import cartopy.crs as ccrs

# file available here:
# https://github.com/htonchia/cartopy-plotting-examples/blob/master\
#/ice_conc_nh_polstere-100_multi_201912091200.nc

FILE = "ice_conc_nh_polstere-100_multi_201912091200.nc"
VARNAME = 'ice_conc'
STEP = 1  

def projection4test():
    """
    define the list of projection for the tests
    """
#    proj_data = ccrs.Stereographic(
#        central_longitude=-45, central_latitude=90,
#        true_scale_latitude=70)

    proj2s = {}
    proj2s['PlateCarre_90'] = ccrs.PlateCarree(central_longitude=90)
    proj2s['Robinson_0'] = ccrs.Robinson(central_longitude=0)
    proj2s['Mollweide_90'] = ccrs.Mollweide(central_longitude=90)
    proj2s['polar 45'] = ccrs.Stereographic(
        central_longitude=45, central_latitude=90,
        true_scale_latitude=70)
    
    return proj2s

def main(data, varname, step=1):
    """
    Run plotting tests on different set of projections
    """

    lats = data.variables['lat'][::step, ::step]
    lons = data.variables['lon'][::step, ::step]

    projs = projection4test()

    dplotkwargs = {}
    dplotkwargs['pcolor'] = {'cmap' : 'bwr'}
    dplotkwargs['pcolormesh'] = {'cmap' : 'bwr'}
    dplotkwargs['contourf'] = {'cmap' : 'bwr'}
    dplotkwargs['contour'] = {'colors' : 'black', 'linewidths' : 1}

    opes = ['pcolormesh', 'contourf']

    plt.figure(figsize=(12, 6.4), dpi=100)
    plt.subplots_adjust(wspace=0.01, left=0.01, right=0.99, top=0.95,
                        hspace=0.01, bottom=0.01)

    iii = 0
    
    plt.suptitle("{} {}".format(*opes))
    for proj in projs:
        for ope in opes:
            iii += 1
            mdata = data.variables[varname][0, ::step, ::step]
            axe = plt.subplot(4, 2, iii,
                              projection=projs[proj])
            axe.set_title("{} {}".format(proj, ope))
            if (hasattr(projs[proj], 'proj4_params') and
                    projs[proj].proj4_params['proj'] in
                    ['geos', 'nsper', 'gnom']
                    and ope == 'pcolormesh'):
                # will crash if we try to plot
                axe.coastlines()
                continue
            xy2 = axe.projection.transform_points(
                    ccrs.Geodetic(),
                    lons, lats)
            cx2, cy2 = xy2[..., 0], xy2[..., 1]
            getattr(axe,ope)(cx2, cy2, mdata, **dplotkwargs[ope])
            axe.coastlines()

    plt.savefig("img/{}_{}.png".format(*opes),
                    dpi=200, pad_inches=0)


if __name__ == '__main__':
    main(Dataset(FILE), varname=VARNAME, step=STEP)


```
## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

I don't see any implication.
<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
