### PR TITLE
Update geoaxes.py

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1691,7 +1691,7 @@ class GeoAxes(matplotlib.axes.Axes):
                 #                |  Bottom-----Bottom
                 #
                 with np.errstate(invalid='ignore'):
-                    ptx, pty = transformed_pts[..., 0], transformed_pts[..., 0]
+                    ptx, pty = transformed_pts[..., 0], transformed_pts[..., 1]
                     diagonal0_lengths = np.hypot(
                         ptx[1:, 1:] - ptx[:-1, :-1],
                         pty[1:, 1:] - pty[:-1, :-1]

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1697,7 +1697,7 @@ class GeoAxes(matplotlib.axes.Axes):
                         pty[1:, 1:] - pty[:-1, :-1]
                     )
                     diagonal1_lengths = np.hypot(
-                        ptx[1:, 1:] - ptx[:-1, :-1],
+                        ptx[1:, :-1] - ptx[:-1, 1:],
                         pty[1:, :-1] - pty[:-1, 1:]
                     )
                     to_mask = (

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1674,10 +1674,9 @@ class GeoAxes(matplotlib.axes.Axes):
             wrap_proj_types = (ccrs._RectangularProjection,
                                ccrs._WarpedRectangularProjection,
                                ccrs.InterruptedGoodeHomolosine,
-                               ccrs.Mercator)
-            if isinstance(t, (*wrap_proj_types,
-                              ccrs.Stereographic,
-                              )) and \
+                               ccrs.Mercator,
+                               ccrs.Stereographic)
+            if isinstance(t, wrap_proj_types) and \
                     isinstance(self.projection, wrap_proj_types):
 
                 C = C.reshape((Ny - 1, Nx - 1))


### PR DESCRIPTION
Fix issue #1419 for pcolormesh plots of data in stereographic grid in other projections, including the management of overlapping of diagonals cells.
- add the stereographic projections to the pcolormesh patch
- replace the top and bottom edges of cells by the diagonals for the detection of overlapping cells

it probably fixes #323  but one would need the data to confirm it.

It just occurs to me that with an other tiny modification it can also fix issue #1328 with a small change in the fix. Will update the PR accordingly so that we can also plot in stereographic projection and still benefit from the pcolormesh patch.
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

The purpose is to plot data on a stereographic grid with pcolormesh without overlapping cells crossing the plot.
An overlapping cell is a cell for which one or two corners are beyond the projection boundary and are wrapped on the other side of the plot, thus creating a cell that crosses the plot.
Pcolormesh has a patch to manage those cells but it was excluding data in stereographic projection.

Up to now, by excluding stereographic data form the patch managing the overlapping cells, pcolormesh managed only overlapping cells for which either the top or bottom edges were very wide. With stereographic plot, there is a new type of overlapping cells, with the bottom edge on one side and the top edge on the other side of the projection boundary. Those cells were not masked by the current patch in pcolormesh. To detect those cells, the detection method based on the size of the top and bottom edges has to be replaced by a method based on the diagonals.

This is an example of overlapping cells not managed because they have small top and bottom edges and big diagonals.
![Capture d’écran 2019-12-15 à 08 48 45](https://user-images.githubusercontent.com/54799451/70859687-c5b67780-1f17-11ea-8c57-81fbdf2ecff2.png)

It fixes the issue #1419 which can be used as an example.

Please note that issue #1416 needs to be fixed (PR #1418) for the overlapping cells not to show up in the plots. 

A 'diagonal' overlapping cell:
```
                # 
                #    Top----Top  |
                #                |  Bottom-----Bottom
                #

```
## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
I cannot find any implication in adding the stereographic projection from the pcolormesh patch.

Changing the overlapping cells detection by using the diagonals instead of the edges, double the detection calculation time. I cannot see any other implication as this patch is used only in very specific cases.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
