### PR TITLE
Add stacklevel and category to warnings.

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1172,7 +1172,9 @@ class LambertConformal(Projection):
         elif secant_latitudes is not None:
             warnings.warn('secant_latitudes has been deprecated in v0.12. '
                           'The standard_parallels keyword can be used as a '
-                          'direct replacement.')
+                          'direct replacement.',
+                          DeprecationWarning,
+                          stacklevel=2)
             standard_parallels = secant_latitudes
         elif standard_parallels is None:
             # The default. Put this as a keyword arg default once
@@ -1436,12 +1438,14 @@ class Stereographic(Projection):
                         'The Stereographic projection in Proj older than '
                         '5.0.0 incorrectly transforms points when '
                         'central_latitude=0. Use this projection with '
-                        'caution.')
+                        'caution.',
+                        stacklevel=2)
             else:
                 warnings.warn(
                     'Cannot determine Proj version. The Stereographic '
                     'projection may be unreliable and should be used with '
-                    'caution.')
+                    'caution.',
+                    stacklevel=2)
 
         proj4_params = [('proj', 'stere'), ('lat_0', central_latitude),
                         ('lon_0', central_longitude),
@@ -1451,7 +1455,8 @@ class Stereographic(Projection):
             if central_latitude not in (-90., 90.):
                 warnings.warn('"true_scale_latitude" parameter is only used '
                               'for polar stereographic projections. Consider '
-                              'the use of "scale_factor" instead.')
+                              'the use of "scale_factor" instead.',
+                              stacklevel=2)
             proj4_params.append(('lat_ts', true_scale_latitude))
 
         if scale_factor is not None:
@@ -1529,11 +1534,13 @@ class Orthographic(Projection):
                 warnings.warn(
                     'The Orthographic projection in the v5.0.x series of Proj '
                     'incorrectly transforms points. Use this projection with '
-                    'caution.')
+                    'caution.',
+                    stacklevel=2)
         else:
             warnings.warn(
                 'Cannot determine Proj version. The Orthographic projection '
-                'may be unreliable and should be used with caution.')
+                'may be unreliable and should be used with caution.',
+                stacklevel=2)
 
         proj4_params = [('proj', 'ortho'), ('lon_0', central_longitude),
                         ('lat_0', central_latitude)]
@@ -1865,11 +1872,13 @@ class Robinson(_WarpedRectangularProjection):
                 warnings.warn('The Robinson projection in the v4.8.x series '
                               'of Proj contains a discontinuity at '
                               '40 deg latitude. Use this projection with '
-                              'caution.')
+                              'caution.',
+                              stacklevel=2)
         else:
             warnings.warn('Cannot determine Proj version. The Robinson '
                           'projection may be unreliable and should be used '
-                          'with caution.')
+                          'with caution.',
+                          stacklevel=2)
 
         proj4_params = [('proj', 'robin'), ('lon_0', central_longitude)]
         super(Robinson, self).__init__(proj4_params, central_longitude,
@@ -2291,11 +2300,13 @@ class AzimuthalEquidistant(Projection):
                 warnings.warn('The Azimuthal Equidistant projection in Proj '
                               'older than 4.9.2 incorrectly transforms points '
                               'farther than 90 deg from the origin. Use this '
-                              'projection with caution.')
+                              'projection with caution.',
+                              stacklevel=2)
         else:
             warnings.warn('Cannot determine Proj version. The Azimuthal '
                           'Equidistant projection may be unreliable and '
-                          'should be used with caution.')
+                          'should be used with caution.',
+                          stacklevel=2)
 
         proj4_params = [('proj', 'aeqd'), ('lon_0', central_longitude),
                         ('lat_0', central_latitude),

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -348,7 +348,9 @@ class StamenTerrain(Stamen):
     def __init__(self):
         warnings.warn(
             "The StamenTerrain class was deprecated in v0.17. "
-            "Please use Stamen('terrain-background') instead.")
+            "Please use Stamen('terrain-background') instead.",
+            DeprecationWarning,
+            stacklevel=2)
 
         # NOTE: This subclass of Stamen exists for legacy reasons.
         # No further Stamen subclasses will be accepted as

--- a/lib/cartopy/io/srtm.py
+++ b/lib/cartopy/io/srtm.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2018, Met Office
+# (C) British Crown Copyright 2011 - 2019, Met Office
 #
 # This file is part of cartopy.
 #
@@ -242,7 +242,9 @@ def srtm(lon, lat):
     Elevation is in meters.
     """
     warnings.warn("This method has been deprecated. "
-                  "See the \"What's new\" section for v0.12.")
+                  "See the \"What's new\" section for v0.12.",
+                  DeprecationWarning,
+                  stacklevel=2)
     return SRTM3Source().single_tile(lon, lat)
 
 
@@ -294,7 +296,9 @@ def fill_gaps(elevation, max_distance=10):
 
     """
     warnings.warn("The fill_gaps function has been deprecated. "
-                  "See the \"What's new\" section for v0.14.")
+                  "See the \"What's new\" section for v0.14.",
+                  DeprecationWarning,
+                  stacklevel=2)
     # Lazily import osgeo - it is only an optional dependency for cartopy.
     from osgeo import gdal
     from osgeo import gdal_array
@@ -314,7 +318,9 @@ def fill_gaps(elevation, max_distance=10):
 
 def srtm_composite(lon_min, lat_min, nx, ny):
     warnings.warn("This method has been deprecated. "
-                  "See the \"What's new\" section for v0.12.")
+                  "See the \"What's new\" section for v0.12.",
+                  DeprecationWarning,
+                  stacklevel=2)
     return SRTM3Source().combined(lon_min, lat_min, nx, ny)
 
 
@@ -382,7 +388,9 @@ def SRTM3_retrieve(lon, lat):
 
     """
     warnings.warn("This method has been deprecated. "
-                  "See the \"What's new\" section for v0.12.")
+                  "See the \"What's new\" section for v0.12.",
+                  DeprecationWarning,
+                  stacklevel=2)
     return SRTM3Source().srtm_fname(lon, lat)
 
 

--- a/lib/cartopy/mpl/clip_path.py
+++ b/lib/cartopy/mpl/clip_path.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2018, Met Office
+# (C) British Crown Copyright 2013 - 2019, Met Office
 #
 # This file is part of cartopy.
 #
@@ -62,7 +62,9 @@ def clip_path(subject, clip_bbox):
     warnings.warn("This method has been deprecated. "
                   "You can replace ``clip_path(subject, clip_bbox)`` by "
                   "``subject.clip_to_bbox(clip_bbox)``. "
-                  "See the \"What's new\" section for v0.17.")
+                  "See the \"What's new\" section for v0.17.",
+                  DeprecationWarning,
+                  stacklevel=2)
     return subject.clip_to_bbox(clip_bbox)
 
 

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -332,7 +332,9 @@ class GeoAxes(matplotlib.axes.Axes):
         """
         warnings.warn("The outline_patch property is deprecated. Use "
                       "GeoAxes.spines['geo'] or the default Axes properties "
-                      "instead.")
+                      "instead.",
+                      DeprecationWarning,
+                      stacklevel=2)
         return self.spines['geo']
 
     def add_image(self, factory, *args, **kwargs):
@@ -612,7 +614,9 @@ class GeoAxes(matplotlib.axes.Axes):
 
         """
         warnings.warn('This method has been deprecated.'
-                      ' Please use `add_feature` instead.')
+                      ' Please use `add_feature` instead.',
+                      DeprecationWarning,
+                      stacklevel=2)
         kwargs.setdefault('edgecolor', 'face')
         kwargs.setdefault('facecolor', cartopy.feature.COLORS['land'])
         feature = cartopy.feature.NaturalEarthFeature(category, name,
@@ -1584,7 +1588,6 @@ class GeoAxes(matplotlib.axes.Axes):
         See PATCH comments below.
 
         """
-        import warnings
         import matplotlib.colors as mcolors
         import matplotlib.collections as mcoll
 
@@ -1697,7 +1700,8 @@ class GeoAxes(matplotlib.axes.Axes):
                     if collection.get_cmap()._rgba_bad[3] != 0.0:
                         warnings.warn("The colormap's 'bad' has been set, but "
                                       "in order to wrap pcolormesh across the "
-                                      "map it must be fully transparent.")
+                                      "map it must be fully transparent.",
+                                      stacklevel=3)
 
                     # at this point C has a shape of (Ny-1, Nx-1), to_mask has
                     # a shape of (Ny, Nx-1) and pts has a shape of (Ny*Nx, 2)


### PR DESCRIPTION
## Rationale

Warnings are confusing if they originate in Cartopy code, when they are user issues.

## Implications

For top-level functions and class init, bump stack level to 2; for internal methods, bump to 3. This should make warnings originate from the caller (i.e., user code) instead.