### PR TITLE
Limit +to_meter workaround to Proj < 6.3.0.

### DIFF
--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -121,7 +121,7 @@ def _safe_pj_transform_pre_611(CRS src_crs not None, CRS tgt_crs not None,
                             &x[0], &y[0], NULL)
 
 
-if (6, 1, 1) <= PROJ4_VERSION:
+if (6, 1, 1) <= PROJ4_VERSION < (6, 3, 0):
     _safe_pj_transform = _safe_pj_transform_611
 else:
     _safe_pj_transform = _safe_pj_transform_pre_611

--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -612,7 +612,7 @@ def project_linear(geometry not None, CRS src_crs not None,
     else:
         interpolator = CartesianInterpolator()
     interpolator.init(src_crs.proj4, (<CRS>dest_projection).proj4)
-    if (6, 1, 1) <= PROJ4_VERSION:
+    if (6, 1, 1) <= PROJ4_VERSION < (6, 3, 0):
         # Workaround bug in Proj 6.1.1+ with +to_meter on +proj=ob_tran.
         # See https://github.com/OSGeo/proj#1782.
         lonlat = ('latlon', 'latlong', 'lonlat', 'longlat')


### PR DESCRIPTION
## Rationale

It has been fixed upstream in https://github.com/OSGeo/PROJ/pull/1783 and will be in Proj 6.3.0.

## Implications

No double-correction for `+to_meter`.