### PR TITLE
Changing autoscale to work with collections during draw.

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -413,7 +413,7 @@ class GeoAxes(matplotlib.axes.Axes):
         # If data has been added (i.e. autoscale hasn't been turned off)
         # then we should autoscale the view.
 
-        if self.get_autoscale_on() and self.ignore_existing_data_limits:
+        if self.get_autoscale_on():
             self.autoscale_view()
 
         if self.background_patch.reclip:

--- a/lib/cartopy/tests/mpl/test_set_extent.py
+++ b/lib/cartopy/tests/mpl/test_set_extent.py
@@ -19,6 +19,8 @@ from __future__ import (absolute_import, division, print_function)
 
 from matplotlib.testing.decorators import cleanup
 import matplotlib.pyplot as plt
+import matplotlib.collections as mplcollections
+from matplotlib.patches import Circle
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
@@ -179,4 +181,21 @@ def test_view_lim_default_global(tmpdir):
     expected = np.array([[-180, -90], [180, 90]])
     assert_array_almost_equal(ax.viewLim.frozen().get_points(),
                               expected)
+    plt.close()
+
+
+def test_view_lim_autoscale_collections(tmpdir):
+    ax = plt.axes(projection=ccrs.Orthographic(central_longitude=-100))
+
+    patches = []
+    patches.append(Circle((-90, -45), radius=30))
+    patches.append(Circle((-90, 45), radius=30))
+    collection = mplcollections.PatchCollection(patches,
+                                                transform=ccrs.PlateCarree())
+    ax.add_collection(collection)
+    expected = np.array([[-1898550.764068, -6378073.21863],
+                         [3503186.63727968, 6378073.21863]])
+    plt.savefig(str(tmpdir.join('view_lim_autoscale_collection.png')))
+    assert_array_almost_equal(ax.viewLim.frozen().get_points(),
+                              expected, decimal=1)
     plt.close()


### PR DESCRIPTION
I have added a quick test case to show that adding collections doesn't properly update the extents, and with this fix the test should pass. The example was taken from https://github.com/SciTools/cartopy/issues/1345#issuecomment-513864270

Note that it doesn't fix the issue with `.tri*()` functions in that issue. I think those will need to be wrapped in Cartopy-specific functions to get back proper data extents returned still.

## Rationale

Update the plot extents when a collection is added to the axes.

## Implications

Adding a collection currently modifies `self.ignore_existing_data_limits`, removing the ability to update the limits of the plot. This removes that check in the draw command. I'm not sure why it was there in the first place, so there could be a potential reason not to do this.


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
