### PR TITLE
Add lcc

### DIFF
--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -39,6 +39,7 @@ the package wouldn't be as rich or diverse as it is today:
  * Robert Redl
  * Greg Lucas
  * Sadie Bartholomew
+ * Jonathan Eliashiv
 
 Thank you!
 

--- a/docs/source/crs/projections.rst
+++ b/docs/source/crs/projections.rst
@@ -96,6 +96,20 @@ LambertConformal
     ax.coastlines(resolution='110m')
     ax.gridlines()
 
+LambertConformalConic
+---------------------
+
+.. autoclass:: cartopy.crs.LambertConformalConic
+
+.. plot::
+
+    import matplotlib.pyplot as plt
+    import cartopy.crs as ccrs
+
+    plt.figure(figsize=(4, 3))
+    ax = plt.axes(projection.ccrs.LambertConformalConic())
+    ax.coastlines()
+    ax.gridlines()
 
 LambertCylindrical
 ------------------

--- a/docs/source/crs/projections.rst
+++ b/docs/source/crs/projections.rst
@@ -107,7 +107,7 @@ LambertConformalConic
     import cartopy.crs as ccrs
 
     plt.figure(figsize=(4, 3))
-    ax = plt.axes(projection.ccrs.LambertConformalConic())
+    ax = plt.axes(projection=ccrs.LambertConformalConic())
     ax.coastlines()
     ax.gridlines()
 

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -798,6 +798,84 @@ class PlateCarree(_CylindricalProjection):
 
         return return_value
 
+class LambertConformalConic(Projection):
+    """
+    A Lambert Conformal Conic Projection.
+
+    """
+    def __init__(self, central_longitude=-97.5, central_latitude=38.5,
+                 false_easting=0.0, false_northing=0.0,
+                 standard_parallels=(38.5, 38.5),
+                 x_limits=(-2.7e6, 2.7e6),
+                 y_limits=(-1.59e6, 1.59e6),
+                 globe=Globe(ellipse='intl')
+                 ):
+        """
+        Parameters
+        ----------
+        central_longitude: optional
+            The true longitude of the central meridian in degrees.
+            Defaults to -97.5.
+        central_latitude: optional
+            The true latitude of the planar origin in degrees.
+            Defaults to 38.5.
+        false_easting: optional
+            X offset from the planar origin metres. Defaults to 0.
+        false_northing: optional
+            Y offset from the planar origin in metres. Defaults to 0.
+        standard_parallels: optional
+            Standard parallel latitude(s). Defaults to (38.5, 38.5).
+        x_limits: optional
+            Standard x limits from the planar origin in metres.
+            Defaults to (-2.7e6, 2.7e6).
+        y_limits: optional
+            Standard y limits from the planar origin in metres.
+            Defaults to (-1.59e6, 1.59e6)
+        globe: optional
+            An instance of :class:`cartopy.crs.Globe`. If omitted, a default
+            globe with 'intl' ellipse is created.
+
+        """
+        n_parallels = len(standard_parallels)
+
+        if not 1 <= n_parallels <= 2:
+            raise ValueError('1 or 2 standard parallels must be specified. '
+                             'Got {} ({})'.format(n_parallels,
+                                                  standard_parallels))
+        proj4_params = [('proj', 'lcc'), ('lon_0', central_longitude),
+                        ('lat_0', central_latitude),
+                        ('x_0', false_easting), ('y_0', false_northing),
+                        ('units', 'm')]
+
+        proj4_params.append(('lat_1', standard_parallels[0]))
+        if n_parallels == 2:
+            proj4_params.append(('lat_2', standard_parallels[1]))
+
+        self._x_limits = x_limits
+        self._y_limits = y_limits
+        super(LambertConformalConic, self).__init__(proj4_params, globe=globe)
+
+    
+    @property
+    def threshold(self):
+        return 3e3
+    
+    @property
+    def boundary(self):
+        x0, x1 = self.x_limits
+        y0, y1 = self.y_limits
+        return sgeom.LineString([(x0, y0), (x0,y1),
+                                 (x1, y1), (x1, y0),
+                                 (x0, y0)])
+
+    @property
+    def x_limits(self):
+        return self._x_limits
+    
+    @property
+    def y_limits(self):
+        return self._y_limits
+
 
 class TransverseMercator(Projection):
     """

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -804,7 +804,8 @@ class LambertConformalConic(Projection):
     A Lambert Conformal Conic Projection.
 
     """
-    def __init__(self, central_longitude=-97.5, central_latitude=38.5,
+    def __init__(self,
+                 central_longitude=-97.5, central_latitude=38.5,
                  false_easting=0.0, false_northing=0.0,
                  standard_parallels=None,
                  x_limits=(-2.7e6, 2.7e6),

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -805,7 +805,7 @@ class LambertConformalConic(Projection):
     """
     def __init__(self, central_longitude=-97.5, central_latitude=38.5,
                  false_easting=0.0, false_northing=0.0,
-                 standard_parallels=(38.5, 38.5),
+                 standard_parallels=None,
                  x_limits=(-2.7e6, 2.7e6),
                  y_limits=(-1.59e6, 1.59e6),
                  globe=Globe(ellipse='intl')
@@ -824,7 +824,7 @@ class LambertConformalConic(Projection):
         false_northing: optional
             Y offset from the planar origin in metres. Defaults to 0.
         standard_parallels: optional
-            Standard parallel latitude(s). Defaults to (38.5, 38.5).
+            Standard parallel latitude(s). Defaults to None.
         x_limits: optional
             Standard x limits from the planar origin in metres.
             Defaults to (-2.7e6, 2.7e6).
@@ -836,8 +836,10 @@ class LambertConformalConic(Projection):
             globe with 'intl' ellipse is created.
 
         """
-        n_parallels = len(standard_parallels)
+        if standard_parallels is None:
+            standard_parallels = (central_latitude, central_latitude)
 
+        n_parallels = len(standard_parallels)
         if not 1 <= n_parallels <= 2:
             raise ValueError('1 or 2 standard parallels must be specified. '
                              'Got {} ({})'.format(n_parallels,

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -866,8 +866,8 @@ class LambertConformalConic(Projection):
     def boundary(self):
         x0, x1 = self.x_limits
         y0, y1 = self.y_limits
-        return sgeom.LineString([(x0, y0), (x0,y1), 
-                                 (x1, y1), (x1, y0), 
+        return sgeom.LineString([(x0, y0), (x0, y1),
+                                 (x1, y1), (x1, y0),
                                  (x0, y0)])
 
     @property

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -798,6 +798,7 @@ class PlateCarree(_CylindricalProjection):
 
         return return_value
 
+
 class LambertConformalConic(Projection):
     """
     A Lambert Conformal Conic Projection.
@@ -857,23 +858,22 @@ class LambertConformalConic(Projection):
         self._y_limits = y_limits
         super(LambertConformalConic, self).__init__(proj4_params, globe=globe)
 
-    
     @property
     def threshold(self):
         return 3e3
-    
+
     @property
     def boundary(self):
         x0, x1 = self.x_limits
         y0, y1 = self.y_limits
-        return sgeom.LineString([(x0, y0), (x0,y1),
-                                 (x1, y1), (x1, y0),
+        return sgeom.LineString([(x0, y0), (x0,y1), 
+                                 (x1, y1), (x1, y0), 
                                  (x0, y0)])
 
     @property
     def x_limits(self):
         return self._x_limits
-    
+
     @property
     def y_limits(self):
         return self._y_limits

--- a/lib/cartopy/tests/crs/test_lambert_conformal_conic.py
+++ b/lib/cartopy/tests/crs/test_lambert_conformal_conic.py
@@ -1,4 +1,4 @@
-# from __future__ import (absolute_import, division, print_function)
+from __future__ import (absolute_import, division, print_function)
 
 from numpy.testing import assert_array_almost_equal
 import pytest
@@ -15,19 +15,23 @@ def test_defaults():
 
 
 def test_specific_region():
-    aus = ccrs.LambertConformalConic(central_longitude=134.489, central_latitude=-23.993,
-                 x_limits=(-2.25e6, 2.25e6), y_limits=(-1.9e6, 1.9e6))
-    aus2 = ccrs.LambertConformalConic(central_longitude=134.489, central_latitude=-23.993,
-                 x_limits=(-2.25e6, 2.25e6), y_limits=(-1.9e6, 1.9e6))
+    aus_kwargs = dict(
+        central_longitude=134.489,
+        central_latitude=-23.993,
+        x_limits=(-2.25e6, 2.25e6), y_limits=(-1.9e6, 1.9e6)
+    )
+    aus = ccrs.LambertConformalConic(**aus_kwargs)
+    aus2 = ccrs.LambertConformalConic(**aus_kwargs)
     default = ccrs.LambertConformalConic()
-    other_args = {'ellps=intl', 'lon_0=134.489', 'lat_0=-23.993', 'lat_1=-23.993',
-                  'lat_2=-23.993' 'units=m', 'x_0=0.0', 'y_0=0.0'}
+    other_args = {'ellps=intl', 'lon_0=134.489', 'lat_0=-23.993',
+                  'lat_1=-23.993', 'lat_2=-23.993' 'units=m',
+                  'x_0=0.0', 'y_0=0.0'}
     check_proj_params('lcc', aus, other_args)
     assert aus == aus2
     assert aus != default
     assert hash(aus) != hash(default)
     assert hash(aus) == hash(aus2)
-    assert_array_almost_equal(aus.x_limits, (-2250000.0000001, 2249999.9999997))
+    assert_array_almost_equal(aus.x_limits, (-2250000.0000001, 2249999.999999))
 
 
 def test_too_many_standard_parallels():

--- a/lib/cartopy/tests/crs/test_lambert_conformal_conic.py
+++ b/lib/cartopy/tests/crs/test_lambert_conformal_conic.py
@@ -24,8 +24,8 @@ def test_specific_region():
     aus2 = ccrs.LambertConformalConic(**aus_kwargs)
     default = ccrs.LambertConformalConic()
     other_args = {'ellps=intl', 'lon_0=134.489', 'lat_0=-23.993',
-                  'lat_1=-23.993', 'lat_2=-23.993' 'units=m',
-                  'x_0=0.0', 'y_0=0.0'}
+                  'lat_1=-23.993', 'lat_2=-23.993' 'units=m', 'x_0=0.0', 'y_0=0.0'
+                  }
     check_proj_params('lcc', aus, other_args)
     assert aus == aus2
     assert aus != default

--- a/lib/cartopy/tests/crs/test_lambert_conformal_conic.py
+++ b/lib/cartopy/tests/crs/test_lambert_conformal_conic.py
@@ -1,0 +1,35 @@
+# from __future__ import (absolute_import, division, print_function)
+
+from numpy.testing import assert_array_almost_equal
+import pytest
+
+import cartopy.crs as ccrs
+from .helpers import check_proj_params
+
+
+def test_defaults():
+    conus = ccrs.LambertConformalConic()
+    other_args = {'ellps=intl', 'lon_0=-97.5', 'lat_0=38.5',
+                  'lat_1=38.5', 'lat_2=38.5', 'x_0=0.0', 'y_0=0.0', 'units=m'}
+    check_proj_params('lcc', conus, other_args)
+
+
+def test_specific_region():
+    aus = ccrs.LambertConformalConic(central_longitude=134.489, central_latitude=-23.993,
+                 x_limits=(-2.25e6, 2.25e6), y_limits=(-1.9e6, 1.9e6))
+    aus2 = ccrs.LambertConformalConic(central_longitude=134.489, central_latitude=-23.993,
+                 x_limits=(-2.25e6, 2.25e6), y_limits=(-1.9e6, 1.9e6))
+    default = ccrs.LambertConformalConic()
+    other_args = {'ellps=intl', 'lon_0=134.489', 'lat_0=-23.993', 'lat_1=-23.993',
+                  'lat_2=-23.993' 'units=m', 'x_0=0.0', 'y_0=0.0'}
+    check_proj_params('lcc', aus, other_args)
+    assert aus == aus2
+    assert aus != default
+    assert hash(aus) != hash(default)
+    assert hash(aus) == hash(aus2)
+    assert_array_almost_equal(aus.x_limits, (-2250000.0000001, 2249999.9999997))
+
+
+def test_too_many_standard_parallels():
+    with pytest.raises(ValueError, match='1 or 2 standard parallels'):
+        ccrs.LambertConformalConic(standard_parallels=(23.5, 37, 42.5))

--- a/lib/cartopy/tests/crs/test_lambert_conformal_conic.py
+++ b/lib/cartopy/tests/crs/test_lambert_conformal_conic.py
@@ -24,8 +24,8 @@ def test_specific_region():
     aus2 = ccrs.LambertConformalConic(**aus_kwargs)
     default = ccrs.LambertConformalConic()
     other_args = {'ellps=intl', 'lon_0=134.489', 'lat_0=-23.993',
-                  'lat_1=-23.993', 'lat_2=-23.993' 'units=m', 'x_0=0.0', 'y_0=0.0'
-                  }
+                  'lat_1=-23.993', 'lat_2=-23.993', 'units=m',
+                  'x_0=0.0', 'y_0=0.0'}
     check_proj_params('lcc', aus, other_args)
     assert aus == aus2
     assert aus != default


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
This PR allows users to create Lambert Conformal Conic projections. The available default closely resembles the "conus" region used in NCAR's HRRR model.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
This will add an available projection to the projection list that allows for Lambert Conformal Conic often used in WRF grids.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
Example usage:
```
import matplotlib.pyplot as plt
import cartopy.crs as ccrs

plt.figure(figsize=(4, 3))
ax = plt.axes(projection=ccrs.LambertConformalConic())
ax.coastlines()
ax.gridlines()
```

Another example:
```
import matplotlib.pyplot as plt
import cartopy.crs as ccrs
import cartopy.feature as cfeat

plt.figure(figsize=(4, 3))
Australia = LambertConformalConic(central_longitude=134.489, central_latitude=-23.993,
                 x_limits=(-2.25e6, 2.25e6),
                 y_limits=(-1.9e6, 1.9e6)
                 )
ax = plt.axes(projection=Australia)
ax.add_feature(cfeat.LAND)
ax.add_feature(cfeat.OCEAN)
ax.add_feature(cfeat.COASTLINE)
ax.gridlines()
```