### PR TITLE
Increase tolerance of test_pcolormesh_mercator_wrap.

### DIFF
--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -446,7 +446,7 @@ def test_pcolormesh_goode_wrap():
 
 
 @pytest.mark.natural_earth
-@ImageTesting(['pcolormesh_mercator_wrap'])
+@ImageTesting(['pcolormesh_mercator_wrap'], tolerance=0.93)
 def test_pcolormesh_mercator_wrap():
     x = np.linspace(0, 360, 73)
     y = np.linspace(-87.5, 87.5, 36)


### PR DESCRIPTION
This is the only test that is affected by matplotlib/matplotlib#15970. The new image is correct, but the difference is small enough to just change the tolerance.