### PR TITLE
Adding a bounds check to imshow fast path.

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -1245,8 +1245,8 @@ class GeoAxes(matplotlib.axes.Axes):
                           y0 - eps <= extent[2] <= y1 + eps and
                           y0 - eps <= extent[3] <= y1 + eps))
 
-        if ((transform is None) or (transform == self.transData) or
-                (same_projection and inside_bounds)):
+        if (transform is None or transform == self.transData or
+                same_projection and inside_bounds):
             result = matplotlib.axes.Axes.imshow(self, img, *args, **kwargs)
         else:
             extent = kwargs.pop('extent', None)

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -149,6 +149,16 @@ def test_imshow_projected():
     ax.set_extent(img_extent, crs=source_proj)
     ax.coastlines(resolution='50m')
     ax.imshow(img, extent=img_extent, origin='upper', transform=source_proj)
+
+
+def test_imshow_wrapping():
+    ax = plt.axes(projection=ccrs.PlateCarree(central_longitude=0.0))
+    # Set the extent outside of the current projection domain to ensure
+    # it is wrapped back to the (-180, 180) extent of the projection
+    ax.imshow(np.random.random((10, 10)), transform=ccrs.PlateCarree(),
+              extent=(0, 360, -90, 90))
+
+    assert ax.get_xlim() == (-180, 180)
 
 
 @pytest.mark.xfail((5, 0, 0) <= ccrs.PROJ4_VERSION < (5, 1, 0),


### PR DESCRIPTION

## Rationale

The current imshow call does not wrap the image if the image extents are beyond the valid projection. This adds an additional bounds check to make sure that the fast path is only called when fully within the projection domain.

Fixes #1439 

## Implications

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
