### PR TITLE
Fix file paths for coverage on coveralls.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,6 +12,11 @@ omit =
     *.pxd
 plugins = Cython.Coverage
 
+[paths]
+source =
+    lib/cartopy
+    /home/travis/miniconda/envs/test-environment/lib/python?.?/site-packages/cartopy
+
 [report]
 exclude_lines =
     pragma: no cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,9 @@ script:
 
 after_success:
   - if [[ "$NAME" == "Latest everything"* ]]; then
+      if [[ "$PYTHON_VERSION" == 2* ]]; then
+          coverage combine;
+      fi;
       coveralls;
     fi
 


### PR DESCRIPTION
## Rationale

Currently, coverage is recorded for the file path as installed in the conda environment on Travis. This causes coveralls to be unable to map coverage to files in the repo, though it still produces final statistics.

## Implications

We need to flatten those paths back to the source directory, so that coverage works properly.