### PR TITLE
Fix Travis build for Python 2 latest.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,14 @@ install:
   # Customise the testing environment
   # ---------------------------------
   - PACKAGES="$PACKAGES pillow pytest pytest-xdist filelock pep8 pyshp shapely six requests pyepsg owslib"
-  - if [[ "$NAME" == "Latest everything"* ]]; then
+  - |
+    if [[ "$NAME" == "Latest everything"* ]]; then
         PACKAGES="$PACKAGES pytest-cov coveralls";
         export CYTHON_COVERAGE=1;
+        if [[ "$PYTHON_VERSION" == 2* ]]; then
+            # Latest available pytest-forked requires a newer pytest than available.
+            PACKAGES="$PACKAGES pytest-forked<1.1.0"
+        fi
     fi
   - conda create -n $ENV_NAME python=$PYTHON_VERSION $PACKAGES
   - source activate $ENV_NAME


### PR DESCRIPTION
## Rationale

The latest `pytest-forked` uses `get_latest_marker`, which is only in a new version of `pytest`, that appears unavailable for Conda (or maybe Python 2).

## Implications

Pin `pytest-forked` to an older version so that Travis works again.