### PR TITLE
Make using tox a bit easier

### DIFF
--- a/lib/cartopy/tests/conftest.py
+++ b/lib/cartopy/tests/conftest.py
@@ -1,0 +1,27 @@
+# (C) British Crown Copyright 2020, Met Office
+#
+# This file is part of cartopy.
+#
+# cartopy is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cartopy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+
+
+def pytest_configure(config):
+    # Register additional markers.
+    config.addinivalue_line('markers',
+                            'natural_earth: mark tests that use Natural Earth '
+                            'data, and the network, if not cached.')
+    config.addinivalue_line('markers',
+                            'network: mark tests that use the network.')

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,12 +11,6 @@ exclude = \
     versioneer.py
 
 
-[tool:pytest]
-markers =
-    natural_earth: mark tests that use Natural Earth data, and the network, if not cached.
-    network: mark tests that use the network.
-doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE
-
 [versioneer]
 # See the docstring in versioneer.py for instructions. Note that you must
 # re-run 'versioneer.py setup' after changing this section, and commit the

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -41,8 +41,9 @@ Distribution definition for Cartopy.
 # source installation or not (sdist).
 HERE = os.path.dirname(__file__)
 IS_SDIST = os.path.exists(os.path.join(HERE, 'PKG-INFO'))
+FORCE_CYTHON = os.environ.get('FORCE_CYTHON', False)
 
-if not IS_SDIST:
+if not IS_SDIST or FORCE_CYTHON:
     import Cython
     if Cython.__version__ < '0.28':
         raise ImportError(
@@ -415,7 +416,7 @@ def decythonize(extensions, **_ignore):
 
 cmdclass = versioneer.get_cmdclass()
 
-if IS_SDIST:
+if IS_SDIST and not FORCE_CYTHON:
     extensions = decythonize(extensions)
 else:
     cmdclass.update({'build_ext': cy_build_ext})


### PR DESCRIPTION
## Rationale

There are two things here, that help with using tox:
* When running with tox, every install to the environment uses a single sdist. This sdist will not contain the Cython-processed files (unless you built them in your source tree previously), plus we want to rebuild them anyway using the Cython in the environment.
* For installed copies when not running pytest in the source directory, then pytest cannot find the `setup.cfg`, thus doesn't know about the markers, and complains about them.

## Implications

* Add a build envvar to force using Cython.
  This option, when added to tox configuration, allows the sdist to be installed, even without pre-created Cython sources.
* Add a conftest to setup pytest markers.