### PR TITLE
Improve conversion of Paths to shapely Points

### DIFF
--- a/lib/cartopy/mpl/patch.py
+++ b/lib/cartopy/mpl/patch.py
@@ -170,8 +170,11 @@ def path_to_geos(path, force_ccw=False):
         if path_codes[-1] == Path.CLOSEPOLY:
             path_verts[-1, :] = path_verts[0, :]
 
-        verts_same_as_first = np.all(path_verts[0, :] == path_verts[1:, :],
-                                     axis=1)
+        verts_same_as_first = np.isclose(path_verts[0, :], path_verts[1:, :],
+                                         rtol=1e-10, atol=1e-13)
+        verts_same_as_first = np.logical_and.reduce(verts_same_as_first,
+                                                    axis=1)
+
         if all(verts_same_as_first):
             geom = sgeom.Point(path_verts[0, :])
         elif path_verts.shape[0] > 4 and path_codes[-1] == Path.CLOSEPOLY:

--- a/lib/cartopy/mpl/patch.py
+++ b/lib/cartopy/mpl/patch.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -166,6 +166,9 @@ def path_to_geos(path, force_ccw=False):
     for path_verts, path_codes in zip(verts_split, codes_split):
         if len(path_verts) == 0:
             continue
+
+        if path_codes[-1] == Path.CLOSEPOLY:
+            path_verts[-1, :] = path_verts[0, :]
 
         verts_same_as_first = np.all(path_verts[0, :] == path_verts[1:, :],
                                      axis=1)

--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2019, Met Office
+# (C) British Crown Copyright 2014 - 2020, Met Office
 #
 # This file is part of cartopy.
 #

--- a/lib/cartopy/tests/mpl/test_patch.py
+++ b/lib/cartopy/tests/mpl/test_patch.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015 - 2018, Met Office
+# (C) British Crown Copyright 2015 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -26,14 +26,15 @@ import cartopy.mpl.patch as cpatch
 
 
 class Test_path_to_geos(object):
-    def test_empty_polyon(self):
+    def test_empty_polygon(self):
         p = Path([[0, 0], [0, 0], [0, 0], [0, 0],
-                  [1, 2], [1, 2], [1, 2], [1, 2]],
-                 codes=[1, 2, 2, 79,
-                        1, 2, 2, 79])
+                  [1, 2], [1, 2], [1, 2], [1, 2],
+                  # The vertex for CLOSEPOLY should be ignored.
+                  [2, 3], [2, 3], [2, 3], [42, 42]],
+                 codes=[1, 2, 2, 79] * 3)
         geoms = cpatch.path_to_geos(p)
-        assert [type(geom) for geom in geoms] == [sgeom.Point, sgeom.Point]
-        assert len(geoms) == 2
+        assert [type(geom) for geom in geoms] == [sgeom.Point] * 3
+        assert len(geoms) == 3
 
     @pytest.mark.skipif(matplotlib.__version__ < '2.2.0',
                         reason='Paths may not be closed with old Matplotlib.')

--- a/lib/cartopy/tests/mpl/test_patch.py
+++ b/lib/cartopy/tests/mpl/test_patch.py
@@ -27,14 +27,20 @@ import cartopy.mpl.patch as cpatch
 
 class Test_path_to_geos(object):
     def test_empty_polygon(self):
-        p = Path([[0, 0], [0, 0], [0, 0], [0, 0],
-                  [1, 2], [1, 2], [1, 2], [1, 2],
-                  # The vertex for CLOSEPOLY should be ignored.
-                  [2, 3], [2, 3], [2, 3], [42, 42]],
-                 codes=[1, 2, 2, 79] * 3)
+        p = Path(
+            [
+                [0, 0], [0, 0], [0, 0], [0, 0],
+                [1, 2], [1, 2], [1, 2], [1, 2],
+                # The vertex for CLOSEPOLY should be ignored.
+                [2, 3], [2, 3], [2, 3], [42, 42],
+                # Very close points should be treated the same.
+                [193.75, -14.166664123535156], [193.75, -14.166664123535158],
+                [193.75, -14.166664123535156], [193.75, -14.166664123535156],
+            ],
+            codes=[1, 2, 2, 79] * 4)
         geoms = cpatch.path_to_geos(p)
-        assert [type(geom) for geom in geoms] == [sgeom.Point] * 3
-        assert len(geoms) == 3
+        assert [type(geom) for geom in geoms] == [sgeom.Point] * 4
+        assert len(geoms) == 4
 
     @pytest.mark.skipif(matplotlib.__version__ < '2.2.0',
                         reason='Paths may not be closed with old Matplotlib.')


### PR DESCRIPTION
## Rationale

There are a few cases that are incorrectly converted. See tests for information, but mainly it fixes handling of `CLOSEPOLY` and really close coordinates.

## Implications

A few more paths are now treated as `Point`s. They also will no longer cause splits of external/internal geometries and might improve those geometries (though it doesn't appear to have changed any tests.)