### PR TITLE
Mark additional tests as requiring network.

### DIFF
--- a/lib/cartopy/tests/mpl/test_crs.py
+++ b/lib/cartopy/tests/mpl/test_crs.py
@@ -47,6 +47,7 @@ def test_mercator_squashed():
     ax.gridlines()
 
 
+@pytest.mark.natural_earth
 @cleanup
 def test_repr_html():
     pc = ccrs.PlateCarree()


### PR DESCRIPTION
The Debian package build for 0.18.0b1 failed due to test failures.

`test_repr_html` failed because it the is no network in the package build environment.