### PR TITLE
Fix proj lib name

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@ environment:
     matrix:
         - PYTHON_VERSION: "3.6"
           CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
-          PACKAGES: "cython numpy matplotlib-base proj4 pykdtree scipy"
+          PACKAGES: "cython numpy matplotlib-base proj pykdtree scipy"
         - PYTHON_VERSION: "2.7"
           CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
           PACKAGES: "cython=0.28 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 mock msinttypes futures"

--- a/setup.py
+++ b/setup.py
@@ -242,7 +242,7 @@ def get_proj_libraries():
     This function gets the PROJ libraries to cythonize with
     """
     proj_libraries = ["proj"]
-    if os.name == "nt" and proj_version >= (6, 0, 0):
+    if os.name == "nt" and proj_version < (6, 0, 0):
         proj_libraries = [
             "proj_{}_{}".format(proj_version[0], proj_version[1])
         ]

--- a/setup.py
+++ b/setup.py
@@ -242,11 +242,7 @@ def get_proj_libraries():
     This function gets the PROJ libraries to cythonize with
     """
     proj_libraries = ["proj"]
-    if (
-        os.name == "nt"
-        and proj_version >= (6, 0, 0)
-        and proj_version < (6, 3, 0)
-    ):
+    if os.name == "nt" and (6, 0, 0) <= proj_version < (6, 3, 0):
         proj_libraries = [
             "proj_{}_{}".format(proj_version[0], proj_version[1])
         ]

--- a/setup.py
+++ b/setup.py
@@ -242,7 +242,7 @@ def get_proj_libraries():
     This function gets the PROJ libraries to cythonize with
     """
     proj_libraries = ["proj"]
-    if os.name == "nt" and proj_version < (6, 0, 0):
+    if os.name == "nt" and proj_version >= (6, 0, 0) and proj_version < (6, 3, 0):
         proj_libraries = [
             "proj_{}_{}".format(proj_version[0], proj_version[1])
         ]

--- a/setup.py
+++ b/setup.py
@@ -242,7 +242,11 @@ def get_proj_libraries():
     This function gets the PROJ libraries to cythonize with
     """
     proj_libraries = ["proj"]
-    if os.name == "nt" and proj_version >= (6, 0, 0) and proj_version < (6, 3, 0):
+    if (
+        os.name == "nt"
+        and proj_version >= (6, 0, 0)
+        and proj_version < (6, 3, 0)
+    ):
         proj_libraries = [
             "proj_{}_{}".format(proj_version[0], proj_version[1])
         ]


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

I believe the sue of `proj>=6` in the `setup.py` logic was mislead due to the use of the old `proj4` in `.appveyor.yml`. I updated the latter and fixed the former. Hopefully this is a simple change and things will pass.


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

This change will allow us to build `cartopy` on Windows with latest and old `proj` with either library names (`proj` and `proj4`).

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
