### PR TITLE
Default lonlat formatter

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1290,8 +1290,9 @@ class GeoAxes(matplotlib.axes.Axes):
 
     def gridlines(self, crs=None, draw_labels=False,
                   xlocs=None, ylocs=None, dms=False,
-                  x_inline=None, y_inline=None,
-                  auto_inline=True, **kwargs):
+                  x_inline=None, y_inline=None, auto_inline=True,
+                  xformatter=None, yformatter=None,
+                  **kwargs):
         """
         Automatically add gridlines to the axes, in the given coordinate
         system, at draw time.
@@ -1328,6 +1329,18 @@ class GeoAxes(matplotlib.axes.Axes):
             Toggle whether the y labels drawn should be inline.
         auto_inline: optional
             Set x_inline and y_inline automatically based on projection
+        xformatter: optional
+            A :class:`matplotlib.ticker.Formatter` instance to format labels
+            for x-coordinate gridlines. It defaults to None, which implies the
+            use of a :class:`cartopy.mpl.ticker.LongitudeFormatter` initiated
+            with the ``dms`` argument, if the crs is of
+            :class:`~cartopy.crs.PlateCarree` type.
+        yformatter: optional
+            A :class:`matplotlib.ticker.Formatter` instance to format labels
+            for y-coordinate gridlines. It defaults to None, which implies the
+            use of a :class:`cartopy.mpl.ticker.LatitudeFormatter` initiated
+            with the ``dms`` argument, if the crs is of
+            :class:`~cartopy.crs.PlateCarree` type.
 
         Keyword Parameters
         ------------------
@@ -1355,7 +1368,8 @@ class GeoAxes(matplotlib.axes.Axes):
         gl = Gridliner(
             self, crs=crs, draw_labels=draw_labels, xlocator=xlocs,
             ylocator=ylocs, collection_kwargs=kwargs, dms=dms,
-            x_inline=x_inline, y_inline=y_inline, auto_inline=auto_inline)
+            x_inline=x_inline, y_inline=y_inline, auto_inline=auto_inline,
+            xformatter=xformatter, yformatter=yformatter)
         self._gridliners.append(gl)
         return gl
 

--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -36,6 +36,7 @@ from cartopy.mpl.ticker import (
 
 degree_locator = mticker.MaxNLocator(nbins=9, steps=[1, 1.5, 1.8, 2, 3, 6, 10])
 classic_locator = mticker.MaxNLocator(nbins=9)
+classic_formatter = mticker.ScalarFormatter
 
 _DEGREE_SYMBOL = u'\u00B0'
 _X_INLINE_PROJS = (
@@ -146,12 +147,14 @@ class Gridliner(object):
             A :class:`matplotlib.ticker.Formatter` instance to format labels
             for x-coordinate gridlines. It defaults to None, which implies the
             use of a :class:`cartopy.mpl.ticker.LongitudeFormatter` initiated
-            with the ``dms`` argument.
+            with the ``dms`` argument, if the crs is of
+            :class:`~cartopy.crs.PlateCarree` type.
         yformatter: optional
             A :class:`matplotlib.ticker.Formatter` instance to format labels
             for y-coordinate gridlines. It defaults to None, which implies the
             use of a :class:`cartopy.mpl.ticker.LatitudeFormatter` initiated
-            with the ``dms`` argument.
+            with the ``dms`` argument, if the crs is of
+            :class:`~cartopy.crs.PlateCarree` type.
         collection_kwargs: optional
             Dictionary controlling line properties, passed to
             :class:`matplotlib.collections.Collection`. Defaults to None.
@@ -200,10 +203,20 @@ class Gridliner(object):
             self.ylocator = classic_locator
 
         #: The :class:`~matplotlib.ticker.Formatter` to use for the lon labels.
-        self.xformatter = xformatter or LongitudeFormatter(dms=dms)
+        if xformatter is None:
+            if isinstance(crs, cartopy.crs.PlateCarree):
+                xformatter = LongitudeFormatter(dms=dms)
+            else:
+                xformatter = classic_formatter()
+        self.xformatter = xformatter
 
         #: The :class:`~matplotlib.ticker.Formatter` to use for the lat labels.
-        self.yformatter = yformatter or LatitudeFormatter(dms=dms)
+        if yformatter is None:
+            if isinstance(crs, cartopy.crs.PlateCarree):
+                yformatter = LatitudeFormatter(dms=dms)
+            else:
+                yformatter = classic_formatter()
+        self.yformatter = yformatter
 
         #: Whether to draw labels on the top of the map.
         self.top_labels = draw_labels

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -23,7 +23,11 @@ import pytest
 
 import cartopy.crs as ccrs
 from cartopy.mpl.geoaxes import GeoAxes
-from cartopy.mpl.gridliner import LATITUDE_FORMATTER, LONGITUDE_FORMATTER
+from cartopy.mpl.ticker import LongitudeLocator, LongitudeFormatter
+from cartopy.mpl.gridliner import (
+    LATITUDE_FORMATTER, LONGITUDE_FORMATTER,
+    classic_locator, classic_formatter)
+
 
 from cartopy.tests.mpl import MPL_VERSION, ImageTesting
 
@@ -299,3 +303,33 @@ def test_grid_labels_inline_usa():
             ax.gridlines(draw_labels=True, auto_inline=True, clip_on=True)
         ax.coastlines()
     plt.subplots_adjust(wspace=0.35, hspace=0.35)
+
+
+@pytest.mark.parametrize(
+    "proj,gcrs,xloc,xfmt,xloc_expected,xfmt_expected",
+    [
+       (ccrs.PlateCarree(), ccrs.PlateCarree(),
+        [10, 20], None, mticker.FixedLocator, LongitudeFormatter),
+       (ccrs.PlateCarree(), ccrs.Mercator(),
+        [10, 20], None, mticker.FixedLocator, classic_formatter),
+       (ccrs.PlateCarree(), ccrs.PlateCarree(),
+        mticker.MaxNLocator(nbins=9), None,
+        mticker.MaxNLocator, LongitudeFormatter),
+       (ccrs.PlateCarree(), ccrs.Mercator(),
+        mticker.MaxNLocator(nbins=9), None,
+        mticker.MaxNLocator, classic_formatter),
+       (ccrs.PlateCarree(), ccrs.PlateCarree(),
+        None, None, LongitudeLocator, LongitudeFormatter),
+       (ccrs.PlateCarree(), ccrs.Mercator(),
+        None, None, classic_locator.__class__, classic_formatter),
+       (ccrs.PlateCarree(), ccrs.PlateCarree(),
+        None, mticker.StrMethodFormatter('{x}'),
+        LongitudeLocator, mticker.StrMethodFormatter),
+     ])
+def test_gridliner_default_fmtloc(
+        proj, gcrs, xloc, xfmt, xloc_expected, xfmt_expected):
+    ax = plt.subplot(111, projection=proj)
+    gl = ax.gridlines(crs=gcrs, draw_labels=False, xlocs=xloc, xformatter=xfmt)
+    plt.close()
+    assert isinstance(gl.xlocator, xloc_expected)
+    assert isinstance(gl.xformatter, xfmt_expected)


### PR DESCRIPTION

## Rationale

Longitude and latitude labels have no meaning for projections other than `PlateCarree`.
However, the default label formatter is always of longitude and latitude degrees type, whetever the gridliner crs is.
A test is now added and the default formatter is of `ScalarFormatter` type as in MPL, except when the crs is `PlateCaree()`.

## Implications

This prevents displaying labels in degrees for projected gridlines.


