### PR TITLE
Geoaxes v2 fix issues #1419 #1447 #1416

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1760,7 +1760,7 @@ class GeoAxes(matplotlib.axes.Axes):
                         # so we need to hide them
                         if t is self.projection:
                             collection._wrapped_collection_fix.\
-                            set_visible(False)
+                                set_visible(False)
 
             # Clip the QuadMesh to the projection boundary, which is required
             # to keep the shading inside the projection bounds.

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1708,7 +1708,7 @@ class GeoAxes(matplotlib.axes.Axes):
                                       stacklevel=3)
 
                     # at this point C has a shape of (Ny-1, Nx-1), to_mask has
-                    # a shape of (Ny, Nx-1) and pts has a shape of (Ny*Nx, 2)
+                    # a shape of (Ny-1, Nx-1) and pts has a shape of (Ny*Nx, 2)
 
                     mask = np.zeros(C.shape, dtype=np.bool)
 

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1754,6 +1754,14 @@ class GeoAxes(matplotlib.axes.Axes):
                         # this method
                         collection._wrapped_collection_fix = pcolor_col
 
+                        # if t is self.projection and
+                        # there are overlapping cells
+                        # then pcolor won't work for those cells
+                        # so we need to hide them
+                        if t is self.projection:
+                            collection._wrapped_collection_fix.\
+                            set_visible(False)
+
             # Clip the QuadMesh to the projection boundary, which is required
             # to keep the shading inside the projection bounds.
             collection.set_clip_path(self.background_patch)

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1671,15 +1671,15 @@ class GeoAxes(matplotlib.axes.Axes):
                 C = C.reshape((Ny - 1, Nx - 1))
                 transformed_pts = transformed_pts.reshape((Ny, Nx, 2))
 
-                 # Compute the length of diagonals in transformed coordinates
-                 # If either diagonal (Pt0 - Pt2) or (Pt1 - Pt3) is over half
-                 # the length of the projection limits it will be masked.
-                 # This accounts for long edges,both points of an edge are
-                 # on the same side of the boundary and transposed coordinates.
-                 #
-                 #    Pt0----Pt1  |
-                 #                |  Pt4-----Pt3
-                 #
+                # Compute the length of diagonals in transformed coordinates
+                # If either diagonal (Pt0 - Pt2) or (Pt1 - Pt3) is over half
+                # the length of the projection limits it will be masked.
+                # This accounts for long edges,both points of an edge are
+                # on the same side of the boundary and transposed coordinates.
+                #
+                #    Pt0----Pt1  |
+                #                |  Pt4-----Pt3
+                #
                 with np.errstate(invalid='ignore'):
                     ptx, pty = transformed_pts[..., 0], transformed_pts[..., 1]
                     diagonal0_lengths = np.hypot(

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -24,10 +24,17 @@ plot results from source coordinates to the GeoAxes' target projection.
 
 from __future__ import (absolute_import, division, print_function)
 
+import six
+
 import collections
 import contextlib
+import functools
 import warnings
 import weakref
+if not six.PY2:
+    import collections.abc as collections_abc
+else:
+    import collections as collections_abc
 
 import matplotlib as mpl
 import matplotlib.artist
@@ -274,6 +281,24 @@ class GeoSpine(mspines.Spine):
             'GeoSpine does not support changing its position.')
 
 
+def _add_transform(func):
+    """A decorator that adds and validates the transform keyword argument."""
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        transform = kwargs.get('transform', None)
+        if transform is None:
+            transform = self.projection
+        if (isinstance(transform, ccrs.CRS) and
+                not isinstance(transform, ccrs.Projection)):
+            raise ValueError('Invalid transform: Spherical {} '
+                             'is not supported - consider using '
+                             'PlateCarree/RotatedPole.'.format(func.__name__))
+
+        kwargs['transform'] = transform
+        return func(self, *args, **kwargs)
+    return wrapper
+
+
 class GeoAxes(matplotlib.axes.Axes):
     """
     A subclass of :class:`matplotlib.axes.Axes` which represents a
@@ -332,7 +357,9 @@ class GeoAxes(matplotlib.axes.Axes):
         """
         warnings.warn("The outline_patch property is deprecated. Use "
                       "GeoAxes.spines['geo'] or the default Axes properties "
-                      "instead.")
+                      "instead.",
+                      DeprecationWarning,
+                      stacklevel=2)
         return self.spines['geo']
 
     def add_image(self, factory, *args, **kwargs):
@@ -429,16 +456,10 @@ class GeoAxes(matplotlib.axes.Axes):
                 self.imshow(img, extent=extent, origin=origin,
                             transform=factory.crs, *args[1:], **kwargs)
         self._done_img_factory = True
-        self._cachedRenderer = renderer
         return matplotlib.axes.Axes.draw(self, renderer=renderer,
                                          inframe=inframe)
 
     def _update_title_position(self, renderer):
-        """
-        Update the title position based on the bounding box enclosing
-        all the ticklabels and x-axis spine and xlabel...
-
-        """
         matplotlib.axes.Axes._update_title_position(self, renderer)
         if not self._gridliners:
             return
@@ -578,10 +599,9 @@ class GeoAxes(matplotlib.axes.Axes):
         if lons.shape != lats.shape:
             raise ValueError('lons and lats must have the same shape.')
 
-        for i in range(len(lons)):
-                circle = geod.circle(lons[i], lats[i], rad_km*1e3,
-                                     n_samples=n_samples)
-                geoms.append(sgeom.Polygon(circle))
+        for lon, lat in zip(lons, lats):
+            circle = geod.circle(lon, lat, rad_km*1e3, n_samples=n_samples)
+            geoms.append(sgeom.Polygon(circle))
 
         feature = cartopy.feature.ShapelyFeature(geoms, ccrs.Geodetic(),
                                                  **kwargs)
@@ -612,7 +632,9 @@ class GeoAxes(matplotlib.axes.Axes):
 
         """
         warnings.warn('This method has been deprecated.'
-                      ' Please use `add_feature` instead.')
+                      ' Please use `add_feature` instead.',
+                      DeprecationWarning,
+                      stacklevel=2)
         kwargs.setdefault('edgecolor', 'face')
         kwargs.setdefault('facecolor', cartopy.feature.COLORS['land'])
         feature = cartopy.feature.NaturalEarthFeature(category, name,
@@ -735,7 +757,7 @@ class GeoAxes(matplotlib.axes.Axes):
 
         return geom_in_crs
 
-    def set_extent(self, extents, crs=None, clip=False):
+    def set_extent(self, extents, crs=None):
         """
         Set the extent (x0, x1, y0, y1) of the map in the given
         coordinate system.
@@ -747,9 +769,6 @@ class GeoAxes(matplotlib.axes.Axes):
         ----------
         extents
             Tuple of floats representing the required extent (x0, x1, y0, y1).
-
-        clip: bool
-            Clip map boundary to match exactly this extent.
         """
         # TODO: Implement the same semantics as plt.xlim and
         # plt.ylim - allowing users to set None for a minimum and/or
@@ -774,25 +793,6 @@ class GeoAxes(matplotlib.axes.Axes):
             boundary = self.projection.boundary
             if boundary.equals(domain_in_crs):
                 projected = boundary
-
-        if clip:
-
-            # compute coordinates of the clipping polygon as two 1D arrays
-            n = 100
-            x = np.linspace(x1, x2, n)
-            y = np.linspace(y1, y2, n)
-            xx = np.concatenate((x, [x[-1]]*n, x[::-1], [x[0]]*n))
-            yy = np.concatenate(([y[0]]*n, y, [y[-1]]*n, y[::-1]))
-
-            # project the coordinates and create the path object
-            if crs is not None and crs != self.projection:
-                xy = self.projection.transform_points(crs, xx, yy)[:, :2]
-            else:
-                xy = np.array([xx, yy]).T
-            path = mpath.Path(xy)
-
-            # set it as a boundary
-            self.set_boundary(path)
 
         if projected is None:
             projected = self.projection.project_geometry(domain_in_crs, crs)
@@ -887,7 +887,7 @@ class GeoAxes(matplotlib.axes.Axes):
         # Switch on drawing of x axis
         self.xaxis.set_visible(True)
 
-        return super(GeoAxes, self).set_xticks(xticks, minor)
+        return super(GeoAxes, self).set_xticks(xticks, minor=minor)
 
     def set_yticks(self, ticks, minor=False, crs=None):
         """
@@ -934,7 +934,7 @@ class GeoAxes(matplotlib.axes.Axes):
         # Switch on drawing of y axis
         self.yaxis.set_visible(True)
 
-        return super(GeoAxes, self).set_yticks(yticks, minor)
+        return super(GeoAxes, self).set_yticks(yticks, minor=minor)
 
     def stock_img(self, name='ne_shaded'):
         """
@@ -1168,7 +1168,7 @@ class GeoAxes(matplotlib.axes.Axes):
         plotting methods.
 
         """
-        if not isinstance(regrid_shape, collections.Sequence):
+        if not isinstance(regrid_shape, collections_abc.Sequence):
             target_size = int(regrid_shape)
             x_range, y_range = np.diff(target_extent)[::2]
             desired_aspect = x_range / y_range
@@ -1178,6 +1178,7 @@ class GeoAxes(matplotlib.axes.Axes):
                 regrid_shape = (target_size, int(target_size / desired_aspect))
         return regrid_shape
 
+    @_add_transform
     def imshow(self, img, *args, **kwargs):
         """
         Add the "transform" keyword to :func:`~matplotlib.pyplot.imshow'.
@@ -1214,20 +1215,31 @@ class GeoAxes(matplotlib.axes.Axes):
             Default is ``'lower'``.
 
         """
-        transform = kwargs.pop('transform', None)
         if 'update_datalim' in kwargs:
             raise ValueError('The update_datalim keyword has been removed in '
                              'imshow. To hold the data and view limits see '
                              'GeoAxes.hold_limits.')
 
+        transform = kwargs.pop('transform')
+        extent = kwargs.get('extent', None)
         kwargs.setdefault('origin', 'lower')
 
         same_projection = (isinstance(transform, ccrs.Projection) and
                            self.projection == transform)
 
-        if transform is None or transform == self.transData or same_projection:
-            if isinstance(transform, ccrs.Projection):
-                transform = transform._as_mpl_transform(self)
+        # Only take the shortcut path if the image is within the current
+        # bounds (+/- threshold) of the projection
+        x0, x1 = self.projection.x_limits
+        y0, y1 = self.projection.y_limits
+        eps = self.projection.threshold
+        inside_bounds = (extent is None or
+                         (x0 - eps <= extent[0] <= x1 + eps and
+                          x0 - eps <= extent[1] <= x1 + eps and
+                          y0 - eps <= extent[2] <= y1 + eps and
+                          y0 - eps <= extent[3] <= y1 + eps))
+
+        if (transform is None or transform == self.transData or
+                same_projection and inside_bounds):
             result = matplotlib.axes.Axes.imshow(self, img, *args, **kwargs)
         else:
             extent = kwargs.pop('extent', None)
@@ -1295,21 +1307,20 @@ class GeoAxes(matplotlib.axes.Axes):
         xlocs: optional
             An iterable of gridline locations or a
             :class:`matplotlib.ticker.Locator` instance which will be
-            used to determine the locations of the meridian gridlines in the
-            coordinate of the given CRS. Defaults to None, which
+            used to determine the locations of the gridlines in the
+            x-coordinate of the given CRS. Defaults to None, which
             implies automatic locating of the gridlines.
         ylocs: optional
             An iterable of gridline locations or a
             :class:`matplotlib.ticker.Locator` instance which will be
-            used to determine the locations of the parallel gridlines in the
-            coordinate of the given CRS. Defaults to None, which
+            used to determine the locations of the gridlines in the
+            y-coordinate of the given CRS. Defaults to None, which
             implies automatic locating of the gridlines.
         dms: bool
             When default longitude and latitude locators and formatters are
-            used, ticks are able to stop on minutes and seconds if minutes
-            is set to True, and not fraction of degrees.
-            This keyword is passed to
-            :class:`~cartopy.mpl.gridliner.Gridliner` and has no effect
+            used, ticks are able to stop on minutes and seconds if minutes is
+            set to True, and not fraction of degrees. This keyword is passed
+            to :class:`~cartopy.mpl.gridliner.Gridliner` and has no effect
             if xlocs and ylocs are explicitly set.
         x_inline: optional
             Toggle whether the x labels drawn should be inline.
@@ -1318,25 +1329,32 @@ class GeoAxes(matplotlib.axes.Axes):
         auto_inline: optional
             Set x_inline and y_inline automatically based on projection
 
+        Keyword Parameters
+        ------------------
+        **kwargs
+            All other keywords control line properties.  These are passed
+            through to :class:`matplotlib.collections.Collection`.
+
         Returns
         -------
         gridliner
             A :class:`cartopy.mpl.gridliner.Gridliner` instance.
 
-        Note
-        ----
-            All other keywords control line properties.  These are passed
-            through to :class:`matplotlib.collections.Collection`.
-
+        Notes
+        -----
+        The "x" and "y" for locations and inline settings do not necessarily
+        correspond to X and Y, but to the first and second coordinates of the
+        specified CRS. For the common case of PlateCarree gridlines, these
+        correspond to longitudes and latitudes. Depending on the projection
+        used for the map, meridians and parallels can cross both the X axis and
+        the Y axis.
         """
         if crs is None:
             crs = ccrs.PlateCarree()
         from cartopy.mpl.gridliner import Gridliner
-        mlocs = kwargs.pop('mlocs', xlocs)
-        plocs = kwargs.pop('plocs', ylocs)
         gl = Gridliner(
-            self, crs=crs, draw_labels=draw_labels, xlocator=mlocs,
-            ylocator=plocs, collection_kwargs=kwargs, dms=dms,
+            self, crs=crs, draw_labels=draw_labels, xlocator=xlocs,
+            ylocator=ylocs, collection_kwargs=kwargs, dms=dms,
             x_inline=x_inline, y_inline=y_inline, auto_inline=auto_inline)
         self._gridliners.append(gl)
         return gl
@@ -1448,6 +1466,7 @@ class GeoAxes(matplotlib.axes.Axes):
         with self.hold_limits():
             self.add_patch(background)
 
+    @_add_transform
     def contour(self, *args, **kwargs):
         """
         Add the "transform" keyword to :func:`~matplotlib.pyplot.contour'.
@@ -1458,17 +1477,6 @@ class GeoAxes(matplotlib.axes.Axes):
             A :class:`~cartopy.crs.Projection`.
 
         """
-        t = kwargs.get('transform', None)
-        if t is None:
-            t = self.projection
-        if isinstance(t, ccrs.CRS) and not isinstance(t, ccrs.Projection):
-            raise ValueError('invalid transform:'
-                             ' Spherical contouring is not supported - '
-                             ' consider using PlateCarree/RotatedPole.')
-        if isinstance(t, ccrs.Projection):
-            kwargs['transform'] = t._as_mpl_transform(self)
-        else:
-            kwargs['transform'] = t
         result = matplotlib.axes.Axes.contour(self, *args, **kwargs)
 
         self.autoscale_view()
@@ -1478,6 +1486,7 @@ class GeoAxes(matplotlib.axes.Axes):
             result.__class__ = cartopy.mpl.contour.GeoContourSet
         return result
 
+    @_add_transform
     def contourf(self, *args, **kwargs):
         """
         Add the "transform" keyword to :func:`~matplotlib.pyplot.contourf'.
@@ -1488,18 +1497,9 @@ class GeoAxes(matplotlib.axes.Axes):
             A :class:`~cartopy.crs.Projection`.
 
         """
-        t = kwargs.get('transform', None)
-        if t is None:
-            t = self.projection
-        if isinstance(t, ccrs.CRS) and not isinstance(t, ccrs.Projection):
-            raise ValueError('invalid transform:'
-                             ' Spherical contouring is not supported - '
-                             ' consider using PlateCarree/RotatedPole.')
+        t = kwargs['transform']
         if isinstance(t, ccrs.Projection):
             kwargs['transform'] = t = t._as_mpl_transform(self)
-        else:
-            kwargs['transform'] = t
-
         # Set flag to indicate correcting orientation of paths if not ccw
         if isinstance(t, mtransforms.Transform):
             for sub_trans, _ in t._iter_break_from_left_to_right():
@@ -1523,6 +1523,7 @@ class GeoAxes(matplotlib.axes.Axes):
 
         return result
 
+    @_add_transform
     def scatter(self, *args, **kwargs):
         """
         Add the "transform" keyword to :func:`~matplotlib.pyplot.scatter'.
@@ -1533,19 +1534,12 @@ class GeoAxes(matplotlib.axes.Axes):
             A :class:`~cartopy.crs.Projection`.
 
         """
-        t = kwargs.get('transform', None)
-        # Keep this bit - even at mpl v1.2
-        if t is None:
-            t = self.projection
-        if hasattr(t, '_as_mpl_transform'):
-            kwargs['transform'] = t._as_mpl_transform(self)
-
         # exclude Geodetic as a valid source CS
-        if (isinstance(kwargs.get('transform', None),
+        if (isinstance(kwargs['transform'],
                        InterProjectionTransform) and
                 kwargs['transform'].source_projection.is_geodetic()):
             raise ValueError('Cartopy cannot currently do spherical '
-                             'contouring. The source CRS cannot be a '
+                             'scatter. The source CRS cannot be a '
                              'geodetic, consider using the cyllindrical form '
                              '(PlateCarree or RotatedPole).')
 
@@ -1553,6 +1547,7 @@ class GeoAxes(matplotlib.axes.Axes):
         self.autoscale_view()
         return result
 
+    @_add_transform
     def pcolormesh(self, *args, **kwargs):
         """
         Add the "transform" keyword to :func:`~matplotlib.pyplot.pcolormesh'.
@@ -1563,14 +1558,6 @@ class GeoAxes(matplotlib.axes.Axes):
             A :class:`~cartopy.crs.Projection`.
 
         """
-        t = kwargs.get('transform', None)
-        if t is None:
-            t = self.projection
-        if isinstance(t, ccrs.CRS) and not isinstance(t, ccrs.Projection):
-            raise ValueError('invalid transform:'
-                             ' Spherical pcolormesh is not supported - '
-                             ' consider using PlateCarree/RotatedPole.')
-        kwargs.setdefault('transform', t)
         result = self._pcolormesh_patched(*args, **kwargs)
         self.autoscale_view()
         return result
@@ -1584,7 +1571,6 @@ class GeoAxes(matplotlib.axes.Axes):
         See PATCH comments below.
 
         """
-        import warnings
         import matplotlib.colors as mcolors
         import matplotlib.collections as mcoll
 
@@ -1718,7 +1704,8 @@ class GeoAxes(matplotlib.axes.Axes):
                     if collection.get_cmap()._rgba_bad[3] != 0.0:
                         warnings.warn("The colormap's 'bad' has been set, but "
                                       "in order to wrap pcolormesh across the "
-                                      "map it must be fully transparent.")
+                                      "map it must be fully transparent.",
+                                      stacklevel=3)
 
                     # at this point C has a shape of (Ny-1, Nx-1), to_mask has
                     # a shape of (Ny, Nx-1) and pts has a shape of (Ny*Nx, 2)
@@ -1776,6 +1763,7 @@ class GeoAxes(matplotlib.axes.Axes):
 
         return collection
 
+    @_add_transform
     def pcolor(self, *args, **kwargs):
         """
         Add the "transform" keyword to :func:`~matplotlib.pyplot.pcolor'.
@@ -1786,14 +1774,6 @@ class GeoAxes(matplotlib.axes.Axes):
             A :class:`~cartopy.crs.Projection`.
 
         """
-        t = kwargs.get('transform', None)
-        if t is None:
-            t = self.projection
-        if isinstance(t, ccrs.CRS) and not isinstance(t, ccrs.Projection):
-            raise ValueError('invalid transform:'
-                             ' Spherical pcolor is not supported - '
-                             ' consider using PlateCarree/RotatedPole.')
-        kwargs.setdefault('transform', t)
         result = matplotlib.axes.Axes.pcolor(self, *args, **kwargs)
 
         # Update the datalim for this pcolor.
@@ -1803,6 +1783,7 @@ class GeoAxes(matplotlib.axes.Axes):
         self.autoscale_view()
         return result
 
+    @_add_transform
     def quiver(self, x, y, u, v, *args, **kwargs):
         """
         Plot a field of arrows.
@@ -1846,17 +1827,7 @@ class GeoAxes(matplotlib.axes.Axes):
             grid northward.
 
         """
-        t = kwargs.get('transform', None)
-        if t is None:
-            t = self.projection
-        if isinstance(t, ccrs.CRS) and not isinstance(t, ccrs.Projection):
-            raise ValueError('invalid transform:'
-                             ' Spherical quiver is not supported - '
-                             ' consider using PlateCarree/RotatedPole.')
-        if isinstance(t, ccrs.Projection):
-            kwargs['transform'] = t._as_mpl_transform(self)
-        else:
-            kwargs['transform'] = t
+        t = kwargs['transform']
         regrid_shape = kwargs.pop('regrid_shape', None)
         target_extent = kwargs.pop('target_extent',
                                    self.get_extent(self.projection))
@@ -1884,6 +1855,7 @@ class GeoAxes(matplotlib.axes.Axes):
             u, v = self.projection.transform_vectors(t, x, y, u, v)
         return matplotlib.axes.Axes.quiver(self, x, y, u, v, *args, **kwargs)
 
+    @_add_transform
     def barbs(self, x, y, u, v, *args, **kwargs):
         """
         Plot a field of barbs.
@@ -1927,17 +1899,7 @@ class GeoAxes(matplotlib.axes.Axes):
             grid northward.
 
         """
-        t = kwargs.get('transform', None)
-        if t is None:
-            t = self.projection
-        if isinstance(t, ccrs.CRS) and not isinstance(t, ccrs.Projection):
-            raise ValueError('invalid transform:'
-                             ' Spherical barbs are not supported - '
-                             ' consider using PlateCarree/RotatedPole.')
-        if isinstance(t, ccrs.Projection):
-            kwargs['transform'] = t._as_mpl_transform(self)
-        else:
-            kwargs['transform'] = t
+        t = kwargs['transform']
         regrid_shape = kwargs.pop('regrid_shape', None)
         target_extent = kwargs.pop('target_extent',
                                    self.get_extent(self.projection))
@@ -1965,6 +1927,7 @@ class GeoAxes(matplotlib.axes.Axes):
             u, v = self.projection.transform_vectors(t, x, y, u, v)
         return matplotlib.axes.Axes.barbs(self, x, y, u, v, *args, **kwargs)
 
+    @_add_transform
     def streamplot(self, x, y, u, v, **kwargs):
         """
         Plot streamlines of a vector flow.
@@ -1995,13 +1958,7 @@ class GeoAxes(matplotlib.axes.Axes):
             grid northward.
 
         """
-        t = kwargs.pop('transform', None)
-        if t is None:
-            t = self.projection
-        if isinstance(t, ccrs.CRS) and not isinstance(t, ccrs.Projection):
-            raise ValueError('invalid transform:'
-                             ' Spherical streamplot is not supported - '
-                             ' consider using PlateCarree/RotatedPole.')
+        t = kwargs.pop('transform')
         # Regridding is required for streamplot, it must have an evenly spaced
         # grid to work correctly. Choose our destination grid based on the
         # density keyword. The grid need not be bigger than the grid used by

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2020, Met Office
+# (C) British Crown Copyright 2011 - 2019, Met Office
 #
 # This file is part of cartopy.
 #
@@ -24,17 +24,10 @@ plot results from source coordinates to the GeoAxes' target projection.
 
 from __future__ import (absolute_import, division, print_function)
 
-import six
-
 import collections
 import contextlib
-import functools
 import warnings
 import weakref
-if not six.PY2:
-    import collections.abc as collections_abc
-else:
-    import collections as collections_abc
 
 import matplotlib as mpl
 import matplotlib.artist
@@ -281,24 +274,6 @@ class GeoSpine(mspines.Spine):
             'GeoSpine does not support changing its position.')
 
 
-def _add_transform(func):
-    """A decorator that adds and validates the transform keyword argument."""
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        transform = kwargs.get('transform', None)
-        if transform is None:
-            transform = self.projection
-        if (isinstance(transform, ccrs.CRS) and
-                not isinstance(transform, ccrs.Projection)):
-            raise ValueError('Invalid transform: Spherical {} '
-                             'is not supported - consider using '
-                             'PlateCarree/RotatedPole.'.format(func.__name__))
-
-        kwargs['transform'] = transform
-        return func(self, *args, **kwargs)
-    return wrapper
-
-
 class GeoAxes(matplotlib.axes.Axes):
     """
     A subclass of :class:`matplotlib.axes.Axes` which represents a
@@ -357,9 +332,7 @@ class GeoAxes(matplotlib.axes.Axes):
         """
         warnings.warn("The outline_patch property is deprecated. Use "
                       "GeoAxes.spines['geo'] or the default Axes properties "
-                      "instead.",
-                      DeprecationWarning,
-                      stacklevel=2)
+                      "instead.")
         return self.spines['geo']
 
     def add_image(self, factory, *args, **kwargs):
@@ -456,10 +429,16 @@ class GeoAxes(matplotlib.axes.Axes):
                 self.imshow(img, extent=extent, origin=origin,
                             transform=factory.crs, *args[1:], **kwargs)
         self._done_img_factory = True
+        self._cachedRenderer = renderer
         return matplotlib.axes.Axes.draw(self, renderer=renderer,
                                          inframe=inframe)
 
     def _update_title_position(self, renderer):
+        """
+        Update the title position based on the bounding box enclosing
+        all the ticklabels and x-axis spine and xlabel...
+
+        """
         matplotlib.axes.Axes._update_title_position(self, renderer)
         if not self._gridliners:
             return
@@ -599,9 +578,10 @@ class GeoAxes(matplotlib.axes.Axes):
         if lons.shape != lats.shape:
             raise ValueError('lons and lats must have the same shape.')
 
-        for lon, lat in zip(lons, lats):
-            circle = geod.circle(lon, lat, rad_km*1e3, n_samples=n_samples)
-            geoms.append(sgeom.Polygon(circle))
+        for i in range(len(lons)):
+                circle = geod.circle(lons[i], lats[i], rad_km*1e3,
+                                     n_samples=n_samples)
+                geoms.append(sgeom.Polygon(circle))
 
         feature = cartopy.feature.ShapelyFeature(geoms, ccrs.Geodetic(),
                                                  **kwargs)
@@ -632,9 +612,7 @@ class GeoAxes(matplotlib.axes.Axes):
 
         """
         warnings.warn('This method has been deprecated.'
-                      ' Please use `add_feature` instead.',
-                      DeprecationWarning,
-                      stacklevel=2)
+                      ' Please use `add_feature` instead.')
         kwargs.setdefault('edgecolor', 'face')
         kwargs.setdefault('facecolor', cartopy.feature.COLORS['land'])
         feature = cartopy.feature.NaturalEarthFeature(category, name,
@@ -757,7 +735,7 @@ class GeoAxes(matplotlib.axes.Axes):
 
         return geom_in_crs
 
-    def set_extent(self, extents, crs=None):
+    def set_extent(self, extents, crs=None, clip=False):
         """
         Set the extent (x0, x1, y0, y1) of the map in the given
         coordinate system.
@@ -769,6 +747,9 @@ class GeoAxes(matplotlib.axes.Axes):
         ----------
         extents
             Tuple of floats representing the required extent (x0, x1, y0, y1).
+
+        clip: bool
+            Clip map boundary to match exactly this extent.
         """
         # TODO: Implement the same semantics as plt.xlim and
         # plt.ylim - allowing users to set None for a minimum and/or
@@ -793,6 +774,25 @@ class GeoAxes(matplotlib.axes.Axes):
             boundary = self.projection.boundary
             if boundary.equals(domain_in_crs):
                 projected = boundary
+
+        if clip:
+
+            # compute coordinates of the clipping polygon as two 1D arrays
+            n = 100
+            x = np.linspace(x1, x2, n)
+            y = np.linspace(y1, y2, n)
+            xx = np.concatenate((x, [x[-1]]*n, x[::-1], [x[0]]*n))
+            yy = np.concatenate(([y[0]]*n, y, [y[-1]]*n, y[::-1]))
+
+            # project the coordinates and create the path object
+            if crs is not None and crs != self.projection:
+                xy = self.projection.transform_points(crs, xx, yy)[:, :2]
+            else:
+                xy = np.array([xx, yy]).T
+            path = mpath.Path(xy)
+
+            # set it as a boundary
+            self.set_boundary(path)
 
         if projected is None:
             projected = self.projection.project_geometry(domain_in_crs, crs)
@@ -887,7 +887,7 @@ class GeoAxes(matplotlib.axes.Axes):
         # Switch on drawing of x axis
         self.xaxis.set_visible(True)
 
-        return super(GeoAxes, self).set_xticks(xticks, minor=minor)
+        return super(GeoAxes, self).set_xticks(xticks, minor)
 
     def set_yticks(self, ticks, minor=False, crs=None):
         """
@@ -934,7 +934,7 @@ class GeoAxes(matplotlib.axes.Axes):
         # Switch on drawing of y axis
         self.yaxis.set_visible(True)
 
-        return super(GeoAxes, self).set_yticks(yticks, minor=minor)
+        return super(GeoAxes, self).set_yticks(yticks, minor)
 
     def stock_img(self, name='ne_shaded'):
         """
@@ -1168,7 +1168,7 @@ class GeoAxes(matplotlib.axes.Axes):
         plotting methods.
 
         """
-        if not isinstance(regrid_shape, collections_abc.Sequence):
+        if not isinstance(regrid_shape, collections.Sequence):
             target_size = int(regrid_shape)
             x_range, y_range = np.diff(target_extent)[::2]
             desired_aspect = x_range / y_range
@@ -1178,7 +1178,6 @@ class GeoAxes(matplotlib.axes.Axes):
                 regrid_shape = (target_size, int(target_size / desired_aspect))
         return regrid_shape
 
-    @_add_transform
     def imshow(self, img, *args, **kwargs):
         """
         Add the "transform" keyword to :func:`~matplotlib.pyplot.imshow'.
@@ -1215,31 +1214,20 @@ class GeoAxes(matplotlib.axes.Axes):
             Default is ``'lower'``.
 
         """
+        transform = kwargs.pop('transform', None)
         if 'update_datalim' in kwargs:
             raise ValueError('The update_datalim keyword has been removed in '
                              'imshow. To hold the data and view limits see '
                              'GeoAxes.hold_limits.')
 
-        transform = kwargs.pop('transform')
-        extent = kwargs.get('extent', None)
         kwargs.setdefault('origin', 'lower')
 
         same_projection = (isinstance(transform, ccrs.Projection) and
                            self.projection == transform)
 
-        # Only take the shortcut path if the image is within the current
-        # bounds (+/- threshold) of the projection
-        x0, x1 = self.projection.x_limits
-        y0, y1 = self.projection.y_limits
-        eps = self.projection.threshold
-        inside_bounds = (extent is None or
-                         (x0 - eps <= extent[0] <= x1 + eps and
-                          x0 - eps <= extent[1] <= x1 + eps and
-                          y0 - eps <= extent[2] <= y1 + eps and
-                          y0 - eps <= extent[3] <= y1 + eps))
-
-        if (transform is None or transform == self.transData or
-                same_projection and inside_bounds):
+        if transform is None or transform == self.transData or same_projection:
+            if isinstance(transform, ccrs.Projection):
+                transform = transform._as_mpl_transform(self)
             result = matplotlib.axes.Axes.imshow(self, img, *args, **kwargs)
         else:
             extent = kwargs.pop('extent', None)
@@ -1307,20 +1295,21 @@ class GeoAxes(matplotlib.axes.Axes):
         xlocs: optional
             An iterable of gridline locations or a
             :class:`matplotlib.ticker.Locator` instance which will be
-            used to determine the locations of the gridlines in the
-            x-coordinate of the given CRS. Defaults to None, which
+            used to determine the locations of the meridian gridlines in the
+            coordinate of the given CRS. Defaults to None, which
             implies automatic locating of the gridlines.
         ylocs: optional
             An iterable of gridline locations or a
             :class:`matplotlib.ticker.Locator` instance which will be
-            used to determine the locations of the gridlines in the
-            y-coordinate of the given CRS. Defaults to None, which
+            used to determine the locations of the parallel gridlines in the
+            coordinate of the given CRS. Defaults to None, which
             implies automatic locating of the gridlines.
         dms: bool
             When default longitude and latitude locators and formatters are
-            used, ticks are able to stop on minutes and seconds if minutes is
-            set to True, and not fraction of degrees. This keyword is passed
-            to :class:`~cartopy.mpl.gridliner.Gridliner` and has no effect
+            used, ticks are able to stop on minutes and seconds if minutes
+            is set to True, and not fraction of degrees.
+            This keyword is passed to
+            :class:`~cartopy.mpl.gridliner.Gridliner` and has no effect
             if xlocs and ylocs are explicitly set.
         x_inline: optional
             Toggle whether the x labels drawn should be inline.
@@ -1329,32 +1318,25 @@ class GeoAxes(matplotlib.axes.Axes):
         auto_inline: optional
             Set x_inline and y_inline automatically based on projection
 
-        Keyword Parameters
-        ------------------
-        **kwargs
-            All other keywords control line properties.  These are passed
-            through to :class:`matplotlib.collections.Collection`.
-
         Returns
         -------
         gridliner
             A :class:`cartopy.mpl.gridliner.Gridliner` instance.
 
-        Notes
-        -----
-        The "x" and "y" for locations and inline settings do not necessarily
-        correspond to X and Y, but to the first and second coordinates of the
-        specified CRS. For the common case of PlateCarree gridlines, these
-        correspond to longitudes and latitudes. Depending on the projection
-        used for the map, meridians and parallels can cross both the X axis and
-        the Y axis.
+        Note
+        ----
+            All other keywords control line properties.  These are passed
+            through to :class:`matplotlib.collections.Collection`.
+
         """
         if crs is None:
             crs = ccrs.PlateCarree()
         from cartopy.mpl.gridliner import Gridliner
+        mlocs = kwargs.pop('mlocs', xlocs)
+        plocs = kwargs.pop('plocs', ylocs)
         gl = Gridliner(
-            self, crs=crs, draw_labels=draw_labels, xlocator=xlocs,
-            ylocator=ylocs, collection_kwargs=kwargs, dms=dms,
+            self, crs=crs, draw_labels=draw_labels, xlocator=mlocs,
+            ylocator=plocs, collection_kwargs=kwargs, dms=dms,
             x_inline=x_inline, y_inline=y_inline, auto_inline=auto_inline)
         self._gridliners.append(gl)
         return gl
@@ -1466,7 +1448,6 @@ class GeoAxes(matplotlib.axes.Axes):
         with self.hold_limits():
             self.add_patch(background)
 
-    @_add_transform
     def contour(self, *args, **kwargs):
         """
         Add the "transform" keyword to :func:`~matplotlib.pyplot.contour'.
@@ -1477,6 +1458,17 @@ class GeoAxes(matplotlib.axes.Axes):
             A :class:`~cartopy.crs.Projection`.
 
         """
+        t = kwargs.get('transform', None)
+        if t is None:
+            t = self.projection
+        if isinstance(t, ccrs.CRS) and not isinstance(t, ccrs.Projection):
+            raise ValueError('invalid transform:'
+                             ' Spherical contouring is not supported - '
+                             ' consider using PlateCarree/RotatedPole.')
+        if isinstance(t, ccrs.Projection):
+            kwargs['transform'] = t._as_mpl_transform(self)
+        else:
+            kwargs['transform'] = t
         result = matplotlib.axes.Axes.contour(self, *args, **kwargs)
 
         self.autoscale_view()
@@ -1486,7 +1478,6 @@ class GeoAxes(matplotlib.axes.Axes):
             result.__class__ = cartopy.mpl.contour.GeoContourSet
         return result
 
-    @_add_transform
     def contourf(self, *args, **kwargs):
         """
         Add the "transform" keyword to :func:`~matplotlib.pyplot.contourf'.
@@ -1497,9 +1488,18 @@ class GeoAxes(matplotlib.axes.Axes):
             A :class:`~cartopy.crs.Projection`.
 
         """
-        t = kwargs['transform']
+        t = kwargs.get('transform', None)
+        if t is None:
+            t = self.projection
+        if isinstance(t, ccrs.CRS) and not isinstance(t, ccrs.Projection):
+            raise ValueError('invalid transform:'
+                             ' Spherical contouring is not supported - '
+                             ' consider using PlateCarree/RotatedPole.')
         if isinstance(t, ccrs.Projection):
             kwargs['transform'] = t = t._as_mpl_transform(self)
+        else:
+            kwargs['transform'] = t
+
         # Set flag to indicate correcting orientation of paths if not ccw
         if isinstance(t, mtransforms.Transform):
             for sub_trans, _ in t._iter_break_from_left_to_right():
@@ -1523,7 +1523,6 @@ class GeoAxes(matplotlib.axes.Axes):
 
         return result
 
-    @_add_transform
     def scatter(self, *args, **kwargs):
         """
         Add the "transform" keyword to :func:`~matplotlib.pyplot.scatter'.
@@ -1534,12 +1533,19 @@ class GeoAxes(matplotlib.axes.Axes):
             A :class:`~cartopy.crs.Projection`.
 
         """
+        t = kwargs.get('transform', None)
+        # Keep this bit - even at mpl v1.2
+        if t is None:
+            t = self.projection
+        if hasattr(t, '_as_mpl_transform'):
+            kwargs['transform'] = t._as_mpl_transform(self)
+
         # exclude Geodetic as a valid source CS
-        if (isinstance(kwargs['transform'],
+        if (isinstance(kwargs.get('transform', None),
                        InterProjectionTransform) and
                 kwargs['transform'].source_projection.is_geodetic()):
             raise ValueError('Cartopy cannot currently do spherical '
-                             'scatter. The source CRS cannot be a '
+                             'contouring. The source CRS cannot be a '
                              'geodetic, consider using the cyllindrical form '
                              '(PlateCarree or RotatedPole).')
 
@@ -1547,7 +1553,6 @@ class GeoAxes(matplotlib.axes.Axes):
         self.autoscale_view()
         return result
 
-    @_add_transform
     def pcolormesh(self, *args, **kwargs):
         """
         Add the "transform" keyword to :func:`~matplotlib.pyplot.pcolormesh'.
@@ -1558,6 +1563,14 @@ class GeoAxes(matplotlib.axes.Axes):
             A :class:`~cartopy.crs.Projection`.
 
         """
+        t = kwargs.get('transform', None)
+        if t is None:
+            t = self.projection
+        if isinstance(t, ccrs.CRS) and not isinstance(t, ccrs.Projection):
+            raise ValueError('invalid transform:'
+                             ' Spherical pcolormesh is not supported - '
+                             ' consider using PlateCarree/RotatedPole.')
+        kwargs.setdefault('transform', t)
         result = self._pcolormesh_patched(*args, **kwargs)
         self.autoscale_view()
         return result
@@ -1571,6 +1584,7 @@ class GeoAxes(matplotlib.axes.Axes):
         See PATCH comments below.
 
         """
+        import warnings
         import matplotlib.colors as mcolors
         import matplotlib.collections as mcoll
 
@@ -1660,42 +1674,58 @@ class GeoAxes(matplotlib.axes.Axes):
             wrap_proj_types = (ccrs._RectangularProjection,
                                ccrs._WarpedRectangularProjection,
                                ccrs.InterruptedGoodeHomolosine,
-                               ccrs.Mercator)
+                               ccrs.Mercator,
+                               ccrs.LambertAzimuthalEqualArea,
+                               ccrs.AzimuthalEquidistant,
+                               ccrs.TransverseMercator,
+                               ccrs.Stereographic)
             if isinstance(t, wrap_proj_types) and \
                     isinstance(self.projection, wrap_proj_types):
 
                 C = C.reshape((Ny - 1, Nx - 1))
                 transformed_pts = transformed_pts.reshape((Ny, Nx, 2))
 
-                # Compute the length of edges in transformed coordinates
+                # Compute the length of diagonals in transformed coordinates
+                # This takes into account the case where the top of the cell
+                # is on one side of the boundary while the other is on the
+                # other side, case overlooked with the edges only.
+                #
+                #    Top----Top  |
+                #                |  Bottom-----Bottom
+                #
                 with np.errstate(invalid='ignore'):
-                    edge_lengths = np.hypot(
-                        np.diff(transformed_pts[..., 0], axis=1),
-                        np.diff(transformed_pts[..., 1], axis=1)
+                    ptx, pty = transformed_pts[..., 0], transformed_pts[..., 1]
+                    diagonal0_lengths = np.hypot(
+                        ptx[1:, 1:] - ptx[:-1, :-1],
+                        pty[1:, 1:] - pty[:-1, :-1]
+                    )
+                    diagonal1_lengths = np.hypot(
+                        ptx[1:, :-1] - ptx[:-1, 1:],
+                        pty[1:, :-1] - pty[:-1, 1:]
                     )
                     to_mask = (
-                        (edge_lengths > abs(self.projection.x_limits[1] -
-                                            self.projection.x_limits[0]) / 2) |
-                        np.isnan(edge_lengths)
+                        (diagonal0_lengths > (
+                            abs(self.projection.x_limits[1]
+                                - self.projection.x_limits[0])) / 2) |
+                        np.isnan(diagonal0_lengths) |
+                        (diagonal1_lengths > (
+                            abs(self.projection.x_limits[1]
+                                - self.projection.x_limits[0])) / 2) |
+                        np.isnan(diagonal1_lengths)
                     )
 
                 if np.any(to_mask):
                     if collection.get_cmap()._rgba_bad[3] != 0.0:
                         warnings.warn("The colormap's 'bad' has been set, but "
                                       "in order to wrap pcolormesh across the "
-                                      "map it must be fully transparent.",
-                                      stacklevel=3)
+                                      "map it must be fully transparent.")
 
                     # at this point C has a shape of (Ny-1, Nx-1), to_mask has
                     # a shape of (Ny, Nx-1) and pts has a shape of (Ny*Nx, 2)
 
                     mask = np.zeros(C.shape, dtype=np.bool)
 
-                    # Mask out the neighbouring cells if there was an edge
-                    # found with a large length. NB. Masking too much only has
-                    # a detrimental impact on performance.
-                    mask[to_mask[:-1, :]] = True  # Edges above a cell.
-                    mask[to_mask[1:, :]] = True  # Edges below a cell.
+                    mask[to_mask] = True
 
                     C_mask = getattr(C, 'mask', None)
 
@@ -1746,7 +1776,6 @@ class GeoAxes(matplotlib.axes.Axes):
 
         return collection
 
-    @_add_transform
     def pcolor(self, *args, **kwargs):
         """
         Add the "transform" keyword to :func:`~matplotlib.pyplot.pcolor'.
@@ -1757,6 +1786,14 @@ class GeoAxes(matplotlib.axes.Axes):
             A :class:`~cartopy.crs.Projection`.
 
         """
+        t = kwargs.get('transform', None)
+        if t is None:
+            t = self.projection
+        if isinstance(t, ccrs.CRS) and not isinstance(t, ccrs.Projection):
+            raise ValueError('invalid transform:'
+                             ' Spherical pcolor is not supported - '
+                             ' consider using PlateCarree/RotatedPole.')
+        kwargs.setdefault('transform', t)
         result = matplotlib.axes.Axes.pcolor(self, *args, **kwargs)
 
         # Update the datalim for this pcolor.
@@ -1766,7 +1803,6 @@ class GeoAxes(matplotlib.axes.Axes):
         self.autoscale_view()
         return result
 
-    @_add_transform
     def quiver(self, x, y, u, v, *args, **kwargs):
         """
         Plot a field of arrows.
@@ -1810,7 +1846,17 @@ class GeoAxes(matplotlib.axes.Axes):
             grid northward.
 
         """
-        t = kwargs['transform']
+        t = kwargs.get('transform', None)
+        if t is None:
+            t = self.projection
+        if isinstance(t, ccrs.CRS) and not isinstance(t, ccrs.Projection):
+            raise ValueError('invalid transform:'
+                             ' Spherical quiver is not supported - '
+                             ' consider using PlateCarree/RotatedPole.')
+        if isinstance(t, ccrs.Projection):
+            kwargs['transform'] = t._as_mpl_transform(self)
+        else:
+            kwargs['transform'] = t
         regrid_shape = kwargs.pop('regrid_shape', None)
         target_extent = kwargs.pop('target_extent',
                                    self.get_extent(self.projection))
@@ -1838,7 +1884,6 @@ class GeoAxes(matplotlib.axes.Axes):
             u, v = self.projection.transform_vectors(t, x, y, u, v)
         return matplotlib.axes.Axes.quiver(self, x, y, u, v, *args, **kwargs)
 
-    @_add_transform
     def barbs(self, x, y, u, v, *args, **kwargs):
         """
         Plot a field of barbs.
@@ -1882,7 +1927,17 @@ class GeoAxes(matplotlib.axes.Axes):
             grid northward.
 
         """
-        t = kwargs['transform']
+        t = kwargs.get('transform', None)
+        if t is None:
+            t = self.projection
+        if isinstance(t, ccrs.CRS) and not isinstance(t, ccrs.Projection):
+            raise ValueError('invalid transform:'
+                             ' Spherical barbs are not supported - '
+                             ' consider using PlateCarree/RotatedPole.')
+        if isinstance(t, ccrs.Projection):
+            kwargs['transform'] = t._as_mpl_transform(self)
+        else:
+            kwargs['transform'] = t
         regrid_shape = kwargs.pop('regrid_shape', None)
         target_extent = kwargs.pop('target_extent',
                                    self.get_extent(self.projection))
@@ -1910,7 +1965,6 @@ class GeoAxes(matplotlib.axes.Axes):
             u, v = self.projection.transform_vectors(t, x, y, u, v)
         return matplotlib.axes.Axes.barbs(self, x, y, u, v, *args, **kwargs)
 
-    @_add_transform
     def streamplot(self, x, y, u, v, **kwargs):
         """
         Plot streamlines of a vector flow.
@@ -1941,7 +1995,13 @@ class GeoAxes(matplotlib.axes.Axes):
             grid northward.
 
         """
-        t = kwargs.pop('transform')
+        t = kwargs.pop('transform', None)
+        if t is None:
+            t = self.projection
+        if isinstance(t, ccrs.CRS) and not isinstance(t, ccrs.Projection):
+            raise ValueError('invalid transform:'
+                             ' Spherical streamplot is not supported - '
+                             ' consider using PlateCarree/RotatedPole.')
         # Regridding is required for streamplot, it must have an evenly spaced
         # grid to work correctly. Choose our destination grid based on the
         # density keyword. The grid need not be bigger than the grid used by


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

Fix issues #1419, #1447 and #1328 for pcolormesh plots of data in stereographic grid in other projections, including the management of overlapping of diagonals cells.
Fix issue #1416 in the case where the data coordinates are given in the axis projection and the data still comprise overlapping cells as the mesh is not in the axis projection.

- add the stereographic projections and some more to the pcolormesh patch
- replace the top and bottom edges of cells by the diagonals for the detection of overlapping cells
- if projection is self.projection, hide the overlapping cells plotted with pcolor.
- it probably fixes #323 but one would need the data to confirm it.

The purpose is to plot data on a stereographic grid with pcolormesh without overlapping cells crossing the plot.
An overlapping cell is a cell for which one or two corners are beyond the projection boundary and are wrapped on the other side of the plot, thus creating a cell that crosses the plot.
Pcolormesh has a patch to manage those cells but it was excluding data in stereographic projection.

Up to now, by excluding stereographic data form the patch managing the overlapping cells, pcolormesh managed only overlapping cells for which either the top or bottom edges were very wide. With stereographic plot, there is a new type of overlapping cells, with the bottom edge on one side and the top edge on the other side of the projection boundary. Those cells were not masked by the current patch in pcolormesh. To detect those cells, the detection method based on the size of the top and bottom edges has to be replaced by a method based on the diagonals.

This is an example of overlapping cells not managed because they have small top and bottom edges and big diagonals.

![](https://user-images.githubusercontent.com/54799451/70859687-c5b67780-1f17-11ea-8c57-81fbdf2ecff2.png)

A 'diagonal' overlapping cell:

                # 
                #    Top----Top  |
                #                |  Bottom-----Bottom
                #

### issue #1416 
In the current version of pcolormesh, the overlapping cells are plotted with pcolor.
For some cases as in #1416, this fix didn't work, but it worked in an example provided in #1418 
After further analysis, it seems that the current fix using pcolor works only if the data coordinates are given in the mesh projection and provided to pcolormesh.
It doesn't work if the data coordinates provided to pcolormesh are already in the axis projection.
So I have added a test to manage that case.

### test of diagonals cells
The following code creates a sample data set with diagonals cells (it is based on a stereographic grid) and plots it.

```
import numpy as np
import matplotlib.pyplot as plt
import cartopy.crs as ccrs


PROJ_DATA = ccrs.Stereographic(
        central_longitude=-45, central_latitude=90,
        true_scale_latitude=70)

def sample_data(proj=PROJ_DATA):
    """
    simulated data in a mesh in projection proj
    with coordinates in latitudes and longitudes
    return (lons, lats) in  projection proj, simulated data, proj
    """
    xcc = np.linspace(-3845, 3745, 760) * 1000
    ycc = np.linspace(5845, -5345, 1120) * 1000
    xcm, ycm = np.meshgrid(xcc, ycc)
    lls = ccrs.Geodetic().transform_points(proj, xcm, ycm)
    lats = np.deg2rad(lls[..., 1])
    lons = np.deg2rad(lls[..., 0])
    lats = lats - np.min(lats)
    wave = 0.75 * (np.sin(2 * lats) ** 8) * np.cos(4 * lons)
    mean = 0.5 * np.cos(2 * lats) * ((np.sin(2 * lats)) ** 2 + 2)
    data = wave + mean
    circle = (xcm+2000000)**2 + (ycm-200000)**2
    data = np.ma.masked_where(circle < 1500000**2, data)
    return (lls[..., 0], lls[..., 1]), data, proj

def main():
    """
    Test geoaxe pcolormesh with cells not removed by
    cell border length but by the diagonals length
    """
    coords, data2plot, _ = sample_data(proj=PROJ_DATA)
    proj = ccrs.PlateCarree(central_longitude=182)
    plt.figure(figsize=(12, 6.4), dpi=100)

    ### here we consider that we don't know the data projection
    ### and we have the coordinates in lat lon
    xy2 = proj.transform_points(
        ccrs.Geodetic(),
        coords[0], coords[1])
    cx2, cy2 = xy2[..., 0], xy2[..., 1]

    axe0 = plt.subplot(1, 1, 1, projection=proj)
    axe0.pcolormesh(cx2, cy2, data2plot)
    axe0.set_title('pcolormesh, coords in ax projection, with diag cells')
    plt.show()
    plt.savefig("img/PR1419_test_wrapped_diag_new.png",
                dpi=100, pad_inches=0)


if __name__ == '__main__':
    main()
```

The result before the fix:
![PR1419_test_wrapped_diag_showing](https://user-images.githubusercontent.com/54799451/74760761-314ff480-527b-11ea-9342-c4cca7e4ff8a.png)

and after:
![PR1419_test_wrapped_diag](https://user-images.githubusercontent.com/54799451/74760783-39a82f80-527b-11ea-823a-1d371daa3766.png)

### Notes
This PR replaces #1420 which has a CLA issue and #1418 
I will close both.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
I cannot find any implication in adding the stereographic projection from the pcolormesh patch.

Changing the overlapping cells detection by using the diagonals instead of the edges, double the detection calculation time. I cannot see any other implication as this patch is used only in very specific cases.

For the #1416, it hides the cells plotted with pcolor only when the data coordinates are given in the axis projection. To my knowledge, that when pcolor fails to manage the overlapping cells.
I don't know of a case where it would work.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
