### PR TITLE
Better label rotation

### DIFF
--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -639,8 +639,23 @@ class Gridliner(object):
                         else matplotlib.rc_params['xtick.major.pad'])
             ypadding = (self.ypadding if self.ypadding is not None
                         else matplotlib.rc_params['ytick.major.pad'])
-            dx = ypadding * np.cos(angle * np.pi / 180)
-            dy = xpadding * np.sin(angle * np.pi / 180)
+
+            angle = ((angle+180) % 360 - 180) * np.pi / 180
+            tangle = np.tan(angle)
+            cangle = np.arctan2(xpadding, ypadding)
+            if abs(angle) < cangle:  # right
+                dx = ypadding
+                dy = dx * tangle
+            elif abs(angle) > (np.pi - cangle):  # left
+                dx = -ypadding
+                dy = dx * tangle
+            elif angle >= cangle:  # top
+                dy = xpadding
+                dx = dy / tangle
+            else:  # bottom
+                dy = -xpadding
+                dx = dy / tangle
+
             transform = mtrans.offset_copy(
                 self.axes.transData, self.axes.figure,
                 x=dx, y=dy, units='dots')

--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

Labels are rectangles with text and their rotation make them
to overlap the map boundary, which force the current algorithm
to try another rotation angle, and eventually leads to suprising
rotations. This occurs because the labels are also moved along
an ellipse that is defined xpadding and ypadding.

This patch make the labels to move along the rectangle defined by xpadding
and yappding, the one that encloses the ellipse. This
sligthly increases the padding which may be sufficient to prevent
labels to overlap boundaries in most situations.

## Implications

Labels should undergo less exagerated rotation in some circumstances.


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
