### PR TITLE
Remove geoaxes restriction for lon/lat formatters

### DIFF
--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -57,11 +57,7 @@ class _PlateCarreeFormatter(Formatter):
         self._precision = 5  # locator precision
 
     def __call__(self, value, pos=None):
-        if self.axis is not None:
-
-            if not isinstance(self.axis.axes, GeoAxes):
-                raise TypeError("This formatter can only be "
-                                "used with cartopy GeoAxes.")
+        if self.axis is not None and isinstance(self.axis.axes, GeoAxes):
 
             # We want to produce labels for values in the familiar Plate Carree
             # projection, so convert the tick values from their own projection

--- a/lib/cartopy/tests/mpl/test_ticker.py
+++ b/lib/cartopy/tests/mpl/test_ticker.py
@@ -273,4 +273,3 @@ def test_LongitudeLocator(cls, vmin, vmax, expected):
     locator = cls(dms=True)
     result = locator.tick_values(vmin, vmax)
     np.testing.assert_allclose(result, expected)
-


### PR DESCRIPTION

## Rationale

These formaters are usesul in the context of non geoaxes.
In this context, coordinates are assumed to be in degrees.


## Implications

It is now possible to use LongitudeFormatter and LatitudeFormatter in 1D plots, or howmoller diagrams as explained in issue #1478.

This solves #1478.

## Checklist

* Tests have been adapted.

<!--

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
