### PR TITLE
Update CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,7 @@ env-run:  &env-setup
 deps-run: &deps-install
   name: Install Python dependencies
   command: |
-    source activate test-environment
-    conda install --quiet \
+    conda install -n test-environment --quiet \
         numpy \
         matplotlib \
         scipy \
@@ -49,7 +48,7 @@ deps-run: &deps-install
         pykdtree \
         $EXTRA_PACKAGES \
         --file docs/doc-requirements.txt
-    conda list
+    conda list -n test-environment
 
 cp-run: &cp-install
   name: Install Cartopy
@@ -61,8 +60,7 @@ doc-run: &doc-build
   name: Build documentation
   command: |
     source activate test-environment
-    make html
-  working_directory: docs
+    make -C docs html
 
 
 ##########################################

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,6 @@ jobs:
       - store_artifacts:
           path: docs/build/html
 
-      - run:
-          name: "Built documentation is available at:"
-          command: echo "${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/docs/build/html/index.html"
-
   docs-python2:
     docker:
       - image: continuumio/miniconda:latest
@@ -108,10 +104,6 @@ jobs:
 
       - store_artifacts:
           path: docs/build/html
-
-      - run:
-          name: "Built documentation is available at:"
-          command: echo "${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/docs/build/html/index.html"
 
 
 #########################################

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # Circle CI configuration file
 # https://circleci.com/docs/
 
-version: 2
+version: 2.1
 
 
 ###########################################

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,6 @@ env-run:  &env-setup
   # a separate environment.
   name: Setup conda environment
   command: |
-    # Update conda to fix https://github.com/conda/conda/issues/6811
-    conda install -n base conda
     conda config --set always_yes yes --set changeps1 no --set show_channel_urls yes
     conda create -n test-environment python=$PYTHON_VERSION
     conda config --add channels conda-forge

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,0 +1,12 @@
+on: [status]
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/docs/build/html/index.html
+          circleci-jobs: docs-python2,docs-python3


### PR DESCRIPTION
## Rationale

CircleCI is turning on Pipelines next week. I just flipped the switch early to confirm that everything is working.

Additionally, I dropped the printing of the link to the documentation in the build, because it stopped working. When you're already on the build page, it's easier to go through the artifacts tab at the top. For a quick link directly from the PR, I've added a GitHub Action that posts a status with the correct link (the Action knows the right way to get the link.) Note, it does note post here yet because the Action is not in this repo, but you can see it if you look at the commit in my repo:
![image](https://user-images.githubusercontent.com/302469/75959198-b8ac8300-5e8b-11ea-8de1-fe9777895212.png)

## Implications

No surprises next week. A direct link to the built documentation in the commit/PR status.