### PR TITLE
Fix pickle/deepcopy for non-default argument CRSs

### DIFF
--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# Copyright Cartopy Contributors
 #
-# This file is part of cartopy.
-#
-# cartopy is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cartopy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+# This file is part of Cartopy and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 #
 # cython: embedsignature=True
 

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -17,6 +17,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+import copy
 from io import BytesIO
 import pickle
 
@@ -236,13 +237,32 @@ class TestCRS(object):
                              decimal=1)
 
 
-def test_pickle():
+@pytest.fixture(params=[
+    [ccrs.PlateCarree, {}],
+    [ccrs.PlateCarree, dict(
+        central_longitude=1.23)],
+    [ccrs.NorthPolarStereo, dict(
+        central_longitude=42.5,
+        globe=ccrs.Globe(ellipse="helmert"))],
+])
+def proj_to_copy(request):
+    cls, kwargs = request.param
+    return cls(**kwargs)
+
+
+def test_pickle(proj_to_copy):
     # check that we can pickle a simple CRS
     fh = BytesIO()
-    pickle.dump(ccrs.PlateCarree(), fh)
+    pickle.dump(proj_to_copy, fh)
     fh.seek(0)
-    pc = pickle.load(fh)
-    assert pc == ccrs.PlateCarree()
+    pickled_prj = pickle.load(fh)
+    assert proj_to_copy == pickled_prj
+
+
+def test_deepcopy(proj_to_copy):
+    prj_cp = copy.deepcopy(proj_to_copy)
+    assert proj_to_copy.proj4_params == prj_cp.proj4_params
+    assert proj_to_copy == prj_cp
 
 
 def test_PlateCarree_shortcut():

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -1,19 +1,8 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# Copyright Cartopy Contributors
 #
-# This file is part of cartopy.
-#
-# cartopy is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cartopy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+# This file is part of Cartopy and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 from __future__ import (absolute_import, division, print_function)
 

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,9 @@
-# (C) British Crown Copyright 2011 - 2020, Met Office
+# Copyright Cartopy Contributors
 #
-# This file is part of cartopy.
-#
-# cartopy is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cartopy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+# This file is part of Cartopy and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+
 from __future__ import print_function
 
 import fnmatch
@@ -33,9 +23,6 @@ import versioneer
 Distribution definition for Cartopy.
 
 """
-
-
-
 
 # The existence of a PKG-INFO directory is enough to tell us whether this is a
 # source installation or not (sdist).

--- a/setup.py
+++ b/setup.py
@@ -328,7 +328,7 @@ for name in os.listdir(os.path.join(HERE, 'requirements')):
             else:
                 extras_require[section].append(line.strip())
 install_requires = extras_require.pop('default')
-tests_require = extras_require.pop('tests', [])
+tests_require = extras_require.get('tests', [])
 
 # General extension paths
 if sys.platform.startswith('win'):


### PR DESCRIPTION

## Rationale

Currently the CRS ``__reduce__`` implementation ignores the state entirely (i.e. ``__getstate__`` is never called), and you end up with ``deepcopy`` / pickle returned instances which have default values, not the values that the original instance had.

## Implications

* Fixes the incorrect copy/pickling behaviour
* Preserves arbitrary state created by subclass constructors (e.g. threshold, x_limits)
* Continues to allow subclasses to override if they have special behaviour
* Increases pickle coverage, and adds deepcopy coverage 
* Closes #1336

