### PR TITLE
Updating test that failed network requirement

### DIFF
--- a/lib/cartopy/tests/mpl/test_crs.py
+++ b/lib/cartopy/tests/mpl/test_crs.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2019, Met Office
+# (C) British Crown Copyright 2013 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -47,6 +47,7 @@ def test_mercator_squashed():
     ax.gridlines()
 
 
+@pytest.mark.natural_earth
 @cleanup
 def test_repr_html():
     pc = ccrs.PlateCarree()


### PR DESCRIPTION
Fixes #1462

This is taking over the fix from #1461, which the user didn't want to sign the CLA for.

I was a bit confused about why this was dependent on the network at all. But, I think it boils down to the _repr_html_() adding coastlines to the axis:
https://github.com/SciTools/cartopy/blob/1e58c360bb5579c96cc08b87a7c743c915ff450b/lib/cartopy/crs.py#L174

If there are no coastline features already stored locally, then it likely goes out and tries to get those? Marking _repr_html as dependent on Natural Earth in tests will fix that.