### PR TITLE
Legends for feature artists

### DIFF
--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -249,7 +249,7 @@ class HandlerFeature(matplotlib.legend_handler.HandlerPathCollection):
         style = dict(list(stylised_paths.keys())[0])
 
         facecolor = style.get('facecolor', 'none')
-        if facecolor != 'none':
+        if facecolor not in ('none', 'never'):
             p = matplotlib.patches.Rectangle(
                 xy=(-xdescent, -ydescent),
                 width=width, height=height,

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -229,15 +229,16 @@ class FeatureArtist(matplotlib.artist.Artist):
             try:
                 extent = ax.get_extent(feature_crs)
             except ValueError:
-                warnings.warn('Unable to determine extent. Defaulting to global.')
+                warnings.warn('''Unable to determine extent.
+                              Defaulting to global.''')
         else:
             transform = None
             feature_crs = ccrs.PlateCarree()
 
         geoms = self._feature.intersecting_geometries(extent)
 
-
         return geoms, feature_crs, transform
+
 
 class HandlerFeature(matplotlib.legend_handler.HandlerPathCollection):
     def create_artists(self, legend, orig_handle,
@@ -267,12 +268,14 @@ class HandlerFeature(matplotlib.legend_handler.HandlerPathCollection):
                 style['color'] = val
 
             xdata, _ = self.get_xdata(legend, xdescent, ydescent,
-                                             width, height, fontsize)
+                                      width, height, fontsize)
             ydata = np.full_like(xdata, (height - ydescent) / 2)
             p = matplotlib.lines.Line2D(xdata, ydata, **style)
 
         p.set_transform(trans)
         return [p]
+
+
 
 matplotlib.legend.Legend.update_default_handler_map({
     FeatureArtist: HandlerFeature()})

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -20,8 +20,6 @@ import numpy as np
 import matplotlib.artist
 import matplotlib.collections
 
-from shapely.geometry import Polygon, LineString, LinearRing
-
 import cartopy.mpl.patch as cpatch
 import cartopy.crs as ccrs
 from .style import merge as style_merge, finalize as style_finalize
@@ -253,23 +251,11 @@ class HandlerFeature(matplotlib.legend_handler.HandlerPathCollection):
                                                         projection)
         style = dict(list(stylised_paths.keys())[0])
 
-        if type(geom) is Polygon:
-            p = matplotlib.patches.Rectangle(
-                xy=(-xdescent, -ydescent),
-                width=width, height=height,
-                **style
-            )
-        elif type(geom) in (LineString, LinearRing):
-            # color handling
-            style.pop('facecolor')
-            val = style.pop('edgecolor', None)
-            if val != 'none' and style.get('color', 'none') == 'none':
-                style['color'] = val
-
-            xdata, _ = self.get_xdata(legend, xdescent, ydescent,
-                                      width, height, fontsize)
-            ydata = np.full_like(xdata, (height - ydescent) / 2)
-            p = matplotlib.lines.Line2D(xdata, ydata, **style)
+        p = matplotlib.patches.Rectangle(
+            xy=(-xdescent, -ydescent),
+            width=width, height=height,
+            **style
+        )
 
         p.set_transform(trans)
         return [p]

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -276,6 +276,5 @@ class HandlerFeature(matplotlib.legend_handler.HandlerPathCollection):
         return [p]
 
 
-
 matplotlib.legend.Legend.update_default_handler_map({
     FeatureArtist: HandlerFeature()})

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -253,7 +253,6 @@ class HandlerFeature(matplotlib.legend_handler.HandlerPathCollection):
                                                         projection)
         style = dict(list(stylised_paths.keys())[0])
 
-        # style = deepcopy(style)
         if type(geom) is Polygon:
             p = matplotlib.patches.Rectangle(
                 xy=(-xdescent, -ydescent),

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -20,6 +20,8 @@ import numpy as np
 import matplotlib.artist
 import matplotlib.collections
 
+from shapely.geometry import Polygon, LineString, LinearRing
+
 import cartopy.mpl.patch as cpatch
 import cartopy.crs as ccrs
 from .style import merge as style_merge, finalize as style_finalize
@@ -241,6 +243,9 @@ class FeatureArtist(matplotlib.artist.Artist):
 class HandlerFeature(matplotlib.legend_handler.HandlerPathCollection):
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize, trans):
+        # Use first geometry object to determine type
+        geom = next(orig_handle._feature.geometries())
+
         # Take the first path to generate legend artist
         geoms, feature_crs, _ = orig_handle.get_geometry()
         projection = ccrs.PlateCarree()
@@ -249,13 +254,13 @@ class HandlerFeature(matplotlib.legend_handler.HandlerPathCollection):
         style = dict(list(stylised_paths.keys())[0])
 
         facecolor = style.get('facecolor', 'none')
-        if facecolor not in ('none', 'never'):
+        if facecolor not in ('none', 'never') or type(geom) is Polygon:
             p = matplotlib.patches.Rectangle(
                 xy=(-xdescent, -ydescent),
                 width=width, height=height,
                 **style
             )
-        else:
+        elif type(geom) in (LineString, LinearRing):
             # color handling
             style.pop('facecolor')
             val = style.pop('edgecolor', 'none')

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -143,20 +143,8 @@ class FeatureArtist(matplotlib.artist.Artist):
         if not self.get_visible():
             return
 
-        ax = self.axes
-        feature_crs = self._feature.crs
-
-        # Get geometries that we need to draw.
-        extent = None
-        try:
-            extent = ax.get_extent(feature_crs)
-        except ValueError:
-            warnings.warn('Unable to determine extent. Defaulting to global.')
-        geoms = self._feature.intersecting_geometries(extent)
-
-        stylised_paths = self._get_stylised_paths(geoms, ax, feature_crs, **kwargs)
-
-        transform = ax.projection._as_mpl_transform(ax)
+        geoms, ax, feature_crs, transform = self.get_geometry()
+        stylised_paths = self.get_stylised_paths(geoms, ax, feature_crs, **kwargs)
 
         # Draw one PathCollection per style. We could instead pass an array
         # of style items through to a single PathCollection, but that
@@ -174,7 +162,7 @@ class FeatureArtist(matplotlib.artist.Artist):
         # n.b. matplotlib.collection.Collection.draw returns None
         return None
 
-    def _get_stylised_paths(self, geoms, ax, feature_crs, **kwargs):
+    def get_stylised_paths(self, geoms, ax, feature_crs, **kwargs):
         # Combine all the keyword args in priority order.
         prepared_kwargs = style_merge(self._feature.kwargs,
                                       self._kwargs,
@@ -224,3 +212,19 @@ class FeatureArtist(matplotlib.artist.Artist):
             stylised_paths.setdefault(style, []).extend(geom_paths)
 
         return stylised_paths
+
+    def get_geometry(self):
+        ax = self.axes
+        feature_crs = self._feature.crs
+
+        # Get geometries that we need to draw.
+        extent = None
+        try:
+            extent = ax.get_extent(feature_crs)
+        except ValueError:
+            warnings.warn('Unable to determine extent. Defaulting to global.')
+        geoms = self._feature.intersecting_geometries(extent)
+
+        transform = ax.projection._as_mpl_transform(ax)
+
+        return geoms, ax, feature_crs, transform


### PR DESCRIPTION
Fixes #334.

Enables legends for `FeatureArtists` by implementing a legend handler and registering it with matplotlib.

This necessitated factoring out some of the code in the `FeatureArtists`' `draw` method to make it accessible to the new `HandlerFeature` legend handler.

As for tests, I haven't looked into how to test legend handling in matplotlib. Can do that though if you think this PR is useful!

Example:
```
import matplotlib.pyplot as plt
import cartopy.crs as ccrs
import cartopy.feature as cfeature

ax = plt.axes(projection=ccrs.PlateCarree())
ax.set_extent([80, 170, -45, 30])

states_provinces = cfeature.NaturalEarthFeature(
    category='cultural',
    name='admin_1_states_provinces_lines',
    scale='50m',
    facecolor='none')

land = ax.add_feature(cfeature.LAND, facecolor='wheat', edgecolor='black')
prov = ax.add_feature(states_provinces, edgecolor='gray', ls=':')
plt.legend(handles=[land, prov], labels=['Land', 'Province borders'], loc='lower left')
```
PS:
`cb3de4f` draws all legend artists as Polygons, which looks as below, will also respect facecolor options and is much simpler even for `LineString`s but may look non-intuitive when `facecolor`=`none`.

![image](https://user-images.githubusercontent.com/38992106/77904713-029e4400-7253-11ea-8b97-e5e39eca06c9.png)

`cb3de4f` adds another if/else clause based on facecolor to decide between `Rectangle` and `Line2D` for the legend artist, which looks like

![image](https://user-images.githubusercontent.com/38992106/77905486-552c3000-7254-11ea-81b6-018cff5f80da.png)

PPS:
I have a vague feeling that the legend artists could have been based off of `HandlerPathCollection` since that is what the `FeatureArtist` is drawing but I could not find a way to make the right submethods available to the handler since the actual artist is not based off `PathCollection`.