### PR TITLE
Add Python 3.8 to list of supported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -468,6 +468,7 @@ setup(
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
             'Topic :: Scientific/Engineering',
             'Topic :: Scientific/Engineering :: GIS',
             'Topic :: Scientific/Engineering :: Visualization',


### PR DESCRIPTION
I have at least one user report that pip on 3.8 doesn't want to install cartopy because it doesn't think it works on 3.8. 