### PR TITLE
Validating Natural Earth scales

### DIFF
--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -260,10 +260,19 @@ class NaturalEarthFeature(Feature):
             scale = Scaler(scale)
 
         self.scaler = scale
+        # Make sure this is a valid resolution
+        self._validate_scale()
 
     @property
     def scale(self):
         return self.scaler.scale
+
+    def _validate_scale(self):
+        if self.scale not in ('110m', '50m', '10m'):
+            raise ValueError(
+                '{} is not a valid Natural Earth scale. '.format(self.scale) +
+                'Valid scales are "110m", "50m", and "10m".'
+            )
 
     def geometries(self):
         """

--- a/lib/cartopy/tests/test_features.py
+++ b/lib/cartopy/tests/test_features.py
@@ -1,23 +1,13 @@
-# (C) British Crown Copyright 2017 - 2018, Met Office
+# Copyright Cartopy Contributors
 #
-# This file is part of cartopy.
-#
-# cartopy is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# cartopy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with cartopy.  If not, see <https://www.gnu.org/licenses/>.
+# This file is part of Cartopy and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
 
 from __future__ import (absolute_import, division, print_function)
 
 import cartopy.feature as cfeature
+import pytest
 
 small_extent = (-6, -8, 56, 59)
 medium_extent = (-20, 20, 20, 60)
@@ -71,3 +61,8 @@ class TestFeatures(object):
         # '110m' when the extent is large and autoscale is True.
         auto_land.intersecting_geometries(large_extent)
         assert auto_land.scale == '110m'
+
+
+def test_bad_ne_scale():
+    with pytest.raises(ValueError, match='not a valid Natural Earth scale'):
+        cfeature.NaturalEarthFeature('physical', 'land', '30m')


### PR DESCRIPTION


## Rationale

Fixes #1294 

Raises if scale is not in (10m, 50m, 110m).

There could be more validation done to make sure the scale is valid with the selection still, but that could also get out of sync easily with Natural Earth. This is at least a first step towards raising better errors if someone doesn't pass in a valid scale.


## Implications

ValueError is now raised if the scale isn't valid.