### PR TITLE
Adding deprecations for old gridliner labels

### DIFF
--- a/docs/source/matplotlib/gridliner.rst
+++ b/docs/source/matplotlib/gridliner.rst
@@ -1,8 +1,8 @@
-Cartopy map gridlines and tick labels 
+Cartopy map gridlines and tick labels
 =====================================
 
-The :class:`~cartopy.mpl.gridliner.Gridliner` instance, often created by calling the 
-:meth:`cartopy.mpl.geoaxes.GeoAxes.gridlines` method on a 
+The :class:`~cartopy.mpl.gridliner.Gridliner` instance, often created by calling the
+:meth:`cartopy.mpl.geoaxes.GeoAxes.gridlines` method on a
 :class:`cartopy.mpl.geoaxes.GeoAxes` instance, has a variety of attributes which can be
 used to determine draw time behaviour of the gridlines and labels.
 
@@ -11,14 +11,14 @@ used to determine draw time behaviour of the gridlines and labels.
     The current :class:`~cartopy.mpl.gridliner.Gridliner` interface is likely to undergo
     a significant change in the versions following v0.6 in order to fix some of the underying
     limitations of the current implementation.
-    
+
 
 .. autoclass:: cartopy.mpl.gridliner.Gridliner
     :members:
     :undoc-members:
 
-    
-    
+
+
 The following contrived example makes use of many of the features of the Gridliner
 class to produce customized gridlines and tick labels:
 
@@ -28,22 +28,22 @@ class to produce customized gridlines and tick labels:
     import matplotlib.pyplot as plt
     import matplotlib.ticker as mticker
     import cartopy.crs as ccrs
-    
+
     from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
-    
-    
+
+
     ax = plt.axes(projection=ccrs.Mercator())
     ax.coastlines()
-    
-    gl = ax.gridlines(crs=ccrs.PlateCarree(), draw_labels=True, 
+
+    gl = ax.gridlines(crs=ccrs.PlateCarree(), draw_labels=True,
                       linewidth=2, color='gray', alpha=0.5, linestyle='--')
-    gl.xlabels_top = False
-    gl.ylabels_left = False
+    gl.top_labels = False
+    gl.left_labels = False
     gl.xlines = False
     gl.xlocator = mticker.FixedLocator([-180, -45, 0, 45, 180])
     gl.xformatter = LONGITUDE_FORMATTER
     gl.yformatter = LATITUDE_FORMATTER
     gl.xlabel_style = {'size': 15, 'color': 'gray'}
     gl.xlabel_style = {'color': 'red', 'weight': 'bold'}
-    
+
     plt.show()

--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -294,6 +294,46 @@ class Gridliner(object):
         # (or once drawn, only at resize event ?)
         self.axes.figure.canvas.mpl_connect('draw_event', self._draw_event)
 
+    @property
+    def xlabels_top(self):
+        return self.top_labels
+
+    @xlabels_top.setter
+    def xlabels_top(self, value):
+        warnings.warn('The .xlabels_top attribute is deprecated. Please '
+                      'use .top_labels to toggle visibility instead.')
+        self.top_labels = value
+
+    @property
+    def xlabels_bottom(self):
+        return self.bottom_labels
+
+    @xlabels_bottom.setter
+    def xlabels_bottom(self, value):
+        warnings.warn('The .xlabels_bottom attribute is deprecated. Please '
+                      'use .bottom_labels to toggle visibility instead.')
+        self.bottom_labels = value
+
+    @property
+    def ylabels_left(self):
+        return self.left_labels
+
+    @ylabels_left.setter
+    def ylabels_left(self, value):
+        warnings.warn('The .ylabels_left attribute is deprecated. Please '
+                      'use .left_labels to toggle visibility instead.')
+        self.left_labels = value
+
+    @property
+    def ylabels_right(self):
+        return self.right_labels
+
+    @ylabels_right.setter
+    def ylabels_right(self, value):
+        warnings.warn('The .ylabels_right attribute is deprecated. Please '
+                      'use .right_labels to toggle visibility instead.')
+        self.right_labels = value
+
     def _draw_event(self, event):
         if self.has_labels():
             self._update_labels_visibility(event.renderer)

--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #

--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -296,6 +296,8 @@ class Gridliner(object):
 
     @property
     def xlabels_top(self):
+        warnings.warn('The .xlabels_top attribute is deprecated. Please '
+                      'use .top_labels to toggle visibility instead.')
         return self.top_labels
 
     @xlabels_top.setter
@@ -306,6 +308,8 @@ class Gridliner(object):
 
     @property
     def xlabels_bottom(self):
+        warnings.warn('The .xlabels_bottom attribute is deprecated. Please '
+                      'use .bottom_labels to toggle visibility instead.')
         return self.bottom_labels
 
     @xlabels_bottom.setter
@@ -316,6 +320,8 @@ class Gridliner(object):
 
     @property
     def ylabels_left(self):
+        warnings.warn('The .ylabels_left attribute is deprecated. Please '
+                      'use .left_labels to toggle visibility instead.')
         return self.left_labels
 
     @ylabels_left.setter
@@ -326,6 +332,8 @@ class Gridliner(object):
 
     @property
     def ylabels_right(self):
+        warnings.warn('The .ylabels_right attribute is deprecated. Please '
+                      'use .right_labels to toggle visibility instead.')
         return self.right_labels
 
     @ylabels_right.setter


### PR DESCRIPTION
Fixes #1383
## Rationale

The previous gridliners were called `xbottom_labels` and have been renamed `bottom_labels`, this is adding in a deprecation to allow the old versions to still be used, but warning on it.

Also updated the gridliner example to use the new attributes.


## Implications


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
