### PR TITLE
Fix contourf crash with empty collection.

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1494,10 +1494,12 @@ class GeoAxes(matplotlib.axes.Axes):
         result = matplotlib.axes.Axes.contourf(self, *args, **kwargs)
 
         # We need to compute the dataLim correctly for contours.
-        extent = mtransforms.Bbox.union([col.get_datalim(self.transData)
-                                         for col in result.collections
-                                         if col.get_paths()])
-        self.dataLim.update_from_data_xy(extent.get_points())
+        bboxes = [col.get_datalim(self.transData)
+                  for col in result.collections
+                  if col.get_paths()]
+        if bboxes:
+            extent = mtransforms.Bbox.union(bboxes)
+            self.dataLim.update_from_data_xy(extent.get_points())
 
         self.autoscale_view()
 

--- a/lib/cartopy/tests/mpl/test_contour.py
+++ b/lib/cartopy/tests/mpl/test_contour.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016 - 2018, Met Office
+# (C) British Crown Copyright 2016 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -40,6 +40,11 @@ def test_contour_plot_bounds():
     ax.contourf(x, y, data, levels=np.arange(0, 40, 1))
     assert_array_almost_equal(ax.get_extent(),
                               np.array([x[0], x[-1], y[0], y[-1]]))
+
+    # Levels that don't include data should not fail.
+    plt.figure()
+    ax = plt.axes(projection=proj_lcc)
+    ax.contourf(x, y, data, levels=np.max(data) + np.arange(1, 3))
 
 
 @cleanup


### PR DESCRIPTION
## Rationale

If there are no contours to plot, the data limits do not need to be updated, so don't do that or it'll error out.

## Implications

Fixes #1290.