### PR TITLE
Ensure raster sources work with tight layout

### DIFF
--- a/lib/cartopy/mpl/slippy_image_artist.py
+++ b/lib/cartopy/mpl/slippy_image_artist.py
@@ -54,6 +54,9 @@ class SlippyImageArtist(AxesImage):
         self.user_is_interacting = False
         self.stale = True
 
+    def get_window_extent(self, renderer=None):
+        return self.axes.get_window_extent(renderer=renderer)
+
     @matplotlib.artist.allow_rasterization
     def draw(self, renderer, *args, **kwargs):
         if not self.get_visible():

--- a/lib/cartopy/mpl/slippy_image_artist.py
+++ b/lib/cartopy/mpl/slippy_image_artist.py
@@ -39,6 +39,9 @@ class SlippyImageArtist(AxesImage):
     """
     def __init__(self, ax, raster_source, **kwargs):
         self.raster_source = raster_source
+        if matplotlib.__version__ >= '3':
+            # This artist fills the Axes, so should not influence layout.
+            kwargs.setdefault('in_layout', False)
         super(SlippyImageArtist, self).__init__(ax, **kwargs)
         self.cache = []
 

--- a/lib/cartopy/tests/mpl/test_web_services.py
+++ b/lib/cartopy/tests/mpl/test_web_services.py
@@ -18,6 +18,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 import matplotlib.pyplot as plt
+from matplotlib.testing.decorators import cleanup
 import pytest
 
 from cartopy.tests.mpl import MPL_VERSION, ImageTesting
@@ -34,6 +35,17 @@ def test_wmts():
     url = 'https://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi'
     # Use a layer which doesn't change over time.
     ax.add_wmts(url, 'MODIS_Water_Mask')
+
+
+@pytest.mark.network
+@pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
+@cleanup
+def test_wms_tight_layout():
+    ax = plt.axes(projection=ccrs.PlateCarree())
+    url = 'http://vmap0.tiles.osgeo.org/wms/vmap0'
+    layer = 'basic'
+    ax.add_wms(url, layer)
+    ax.figure.tight_layout()
 
 
 @pytest.mark.network


### PR DESCRIPTION
## Rationale

The simplest way is to tell Matplotlib that it isn't part of the layout, because it always matches the `Axes` extent, but that property only exists in 3. So instead (or also), return a valid window extent that mirrors the `Axes`.

## Implications

Fixes #1451.