### PR TITLE
Remove support for Python 2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,9 +3,6 @@ environment:
         - PYTHON_VERSION: "3.6"
           CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
           PACKAGES: "cython numpy matplotlib-base proj pykdtree scipy"
-        - PYTHON_VERSION: "2.7"
-          CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
-          PACKAGES: "cython=0.28 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 mock msinttypes futures"
 
 install:
   # Install miniconda
@@ -17,7 +14,6 @@ install:
   - conda config --set always_yes yes --set changeps1 no --set show_channel_urls yes
   - conda config --add channels conda-forge
   - conda config --add channels conda-forge/label/testing
-  - if %PYTHON_VERSION%==2.7 conda config --set restore_free_channel true
   - if %PYTHON_VERSION%==3.6 conda update conda --yes
   - set ENV_NAME=test-environment
   - set PACKAGES=%PACKAGES% pillow pytest filelock pep8 pyshp shapely six requests pyepsg owslib

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,2 +1,3 @@
 linters:
     flake8:
+        python: 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,12 @@ env:
     matrix:
         # These ancient versions are linked to an old libgfortran, but that version
         # isn't pinned in the package metadata
-        - PYTHON_VERSION=2.7
-          PACKAGES="cython=0.28 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 libgfortran=1 mock futures"
         - PYTHON_VERSION=3.5
           PACKAGES="cython=0.28 numpy=1.10.0 matplotlib=1.5.1 nose proj4=4.9.1 scipy=0.16.0 libgfortran=1 owslib=0.19.1"
           PYTHONHASHSEED=0  # So pytest-xdist works.
         - NAME="Latest everything."
           PYTHON_VERSION=3.6
           PACKAGES="cython numpy matplotlib-base proj4 pykdtree scipy fiona"
-        - NAME="Latest everything (py2)."
-          PYTHON_VERSION=2
-          PACKAGES="cython=0.29 numpy matplotlib-base proj4 scipy mock futures"
 
 
 sudo: false
@@ -27,11 +22,7 @@ git:
 install:
   # Install miniconda
   # -----------------
-  - if [[ "$PYTHON_VERSION" == 2* ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
 
@@ -52,18 +43,9 @@ install:
     if [[ "$NAME" == "Latest everything"* ]]; then
         PACKAGES="$PACKAGES pytest-cov coveralls";
         export CYTHON_COVERAGE=1;
-        if [[ "$PYTHON_VERSION" == 2* ]]; then
-            # Latest available pytest-forked requires a newer pytest than available.
-            PACKAGES="$PACKAGES pytest-forked<1.1.0"
-        fi
     fi
   - conda create -n $ENV_NAME python=$PYTHON_VERSION $PACKAGES
   - source activate $ENV_NAME
-  # Re-install so it's using FreeType 2.6; conda-forge/label/testing does not
-  # include the latest Python 2-compatible Matplotlib.
-  - if [[ "$NAME" == "Latest everything (py2)." ]]; then
-        pip install --force matplotlib;
-    fi
 
   # Conda debug
   # -----------
@@ -93,15 +75,12 @@ script:
 
 after_success:
   - if [[ "$NAME" == "Latest everything"* ]]; then
-      if [[ "$PYTHON_VERSION" == 2* ]]; then
-          coverage combine;
-      fi;
       coveralls;
     fi
 
 after_failure:
   - source activate $ENV_NAME
-  - python -c "from __future__ import print_function; import cartopy.tests.mpl; print(cartopy.tests.mpl.failed_images_html())"
+  - python -c "import cartopy.tests.mpl; print(cartopy.tests.mpl.failed_images_html())"
 
 deploy:
   - provider: pypi

--- a/INSTALL
+++ b/INSTALL
@@ -67,7 +67,7 @@ to the core packages.
 
 Further information about the required dependencies can be found here:
 
-**Python** 2.7 or later (https://www.python.org/)
+**Python** 3.5 or later (https://www.python.org/)
 
 **Cython** 0.28 or later (https://pypi.python.org/pypi/Cython/)
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,7 +22,7 @@ assumptions of spherical data traditionally break down. If you've ever experienc
 at the pole or a cut-off at the dateline, it is likely you will appreciate cartopy's unique features!
 
 .. warning::
-  The 0.18 release is the final release that will support Python 2.7.
+  The 0.19 release, and later, no longer support Python 2.7.
 
 .. _getting-started-with-cartopy:
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -3,4 +3,3 @@ shapely>=1.5.6
 pyshp>=1.1.4
 six>=1.3.0
 setuptools>=0.7.2
-futures; python_version == "2.7"

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,29 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import print_function
+# NOTE: This file must remain Python 2 compatible for the foreseeable future,
+# to ensure that we error out properly for people with outdated setuptools
+# and/or pip.
+import sys
+
+PYTHON_MIN_VERSION = (3, 5)
+
+if sys.version_info < PYTHON_MIN_VERSION:
+    error = """
+Beginning with Cartopy 0.19, Python {0} or above is required.
+You are using Python {1}.
+
+This may be due to an out of date pip.
+
+Make sure you have pip >= 9.0.1.
+""".format('.'.join(str(n) for n in PYTHON_MIN_VERSION),
+           '.'.join(str(n) for n in sys.version_info[:3]))
+    sys.exit(error)
+
 
 import fnmatch
 import os
 import subprocess
-import sys
 import warnings
 from collections import defaultdict
 from distutils.spawn import find_executable
@@ -44,8 +61,6 @@ try:
 except ImportError:
     raise ImportError('NumPy 1.10+ is required to install cartopy.')
 
-
-PY3 = (sys.version_info[0] == 3)
 
 # Please keep in sync with INSTALL file.
 GEOS_MIN_VERSION = (3, 3, 3)
@@ -117,14 +132,10 @@ else:
               file=sys.stderr)
         exit(1)
 
-    if PY3:
-        geos_includes = geos_includes.decode()
-        geos_clibs = geos_clibs.decode()
-
-    geos_includes = geos_includes.split()
+    geos_includes = geos_includes.decode().split()
     geos_libraries = []
     geos_library_dirs = []
-    for entry in geos_clibs.split():
+    for entry in geos_clibs.decode().split():
         if entry.startswith('-L'):
             geos_library_dirs.append(entry[2:])
         elif entry.startswith('-l'):
@@ -224,17 +235,13 @@ else:
                 file=sys.stderr)
             exit(1)
 
-        if PY3:
-            proj_includes = proj_includes.decode()
-            proj_clibs = proj_clibs.decode()
-
         proj_includes = [
             proj_include[2:] if proj_include.startswith('-I') else
-            proj_include for proj_include in proj_includes.split()]
+            proj_include for proj_include in proj_includes.decode().split()]
 
         proj_libraries = []
         proj_library_dirs = []
-        for entry in proj_clibs.split():
+        for entry in proj_clibs.decode().split():
             if entry.startswith('-L'):
                 proj_library_dirs.append(entry[2:])
             elif entry.startswith('-l'):
@@ -388,7 +395,7 @@ setup(
     # requires proj headers
     ext_modules=extensions,
     cmdclass=cmdclass,
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=' + '.'.join(str(n) for n in PYTHON_MIN_VERSION),
     classifiers=[
             'Development Status :: 4 - Beta',
             'Framework :: Matplotlib',
@@ -401,8 +408,6 @@ setup(
             'Operating System :: POSIX :: Linux',
             'Programming Language :: C++',
             'Programming Language :: Python',
-            'Programming Language :: Python :: 2',
-            'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
## Rationale

Python 2 is quite a burden, so we'll be dropping it after the next release. Do not merge until it's out.

## Implications

No more Python 2.