### PR TITLE
Remove six.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -47,8 +47,8 @@ using the `setup.py` file::
 Required dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 In order to install Cartopy, or to access its basic functionality, it will be
-necessary to first install **GEOS**, **NumPy**, **Cython**, **Shapely**,
-**pyshp** and **six**. Many of these packages can be installed using pip or
+necessary to first install **GEOS**, **NumPy**, **Cython**, **Shapely**, and
+**pyshp**. Many of these packages can be installed using pip or
 other package managers such as apt-get (Linux) and brew (macOS). Many of these
 dependencies are built as part of Cartopy's conda distribution, and the recipes
 for these packages can be found at https://github.com/conda-forge/feedstocks.
@@ -56,7 +56,7 @@ for these packages can be found at https://github.com/conda-forge/feedstocks.
 For macOS, the required dependencies can be installed in the following way::
 
     brew install proj geos
-    pip3 install --upgrade cython numpy pyshp six
+    pip3 install --upgrade cython numpy pyshp
     # shapely needs to be built from source to link to geos. If it is already
     # installed, uninstall it by: pip3 uninstall shapely
     pip3 install shapely --no-binary shapely
@@ -88,9 +88,6 @@ Further information about the required dependencies can be found here:
 
 **PROJ** 4.9.0 or later (https://proj4.org/)
     Cartographic Projections library.
-
-**six** 1.3.0 or later (https://pypi.python.org/pypi/six)
-    Python 2 and 3 compatibility.
 
 Optional Dependencies
 ~~~~~~~~~~~~~~~~~~~~~

--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -17,8 +17,6 @@ import re
 import warnings
 
 import numpy as np
-import six
-
 cimport numpy as np
 
 from cython.operator cimport dereference as deref
@@ -32,9 +30,7 @@ from ._proj4 cimport (pj_init_plus, pj_free, pj_transform, pj_is_latlong,
 cdef double NAN = float('nan')
 
 
-PROJ4_RELEASE = pj_get_release()
-if six.PY3:
-    PROJ4_RELEASE = PROJ4_RELEASE.decode()
+PROJ4_RELEASE = pj_get_release().decode('utf-8')
 _match = re.search(r"\d+\.\d+.\d+", PROJ4_RELEASE)
 if _match is not None:
     PROJ4_VERSION = tuple(int(v) for v in _match.group().split('.'))
@@ -228,7 +224,7 @@ cdef class CRS:
             else:
                 init_items.append('+{}'.format(k))
         self.proj4_init = ' '.join(init_items) + ' +no_defs'
-        proj4_init_bytes = six.b(self.proj4_init)
+        proj4_init_bytes = self.proj4_init.encode('utf-8')
         if self.proj4 != NULL:
             pj_free(self.proj4)
         self.proj4 = pj_init_plus(proj4_init_bytes)

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -25,13 +25,13 @@ between them.
 from __future__ import (absolute_import, division, print_function)
 
 from abc import ABCMeta, abstractproperty
+import io
 import math
 import warnings
 
 import numpy as np
 import shapely.geometry as sgeom
 from shapely.prepared import prep
-import six
 
 from cartopy._crs import (CRS, Geodetic, Globe, PROJ4_VERSION,
                           WGS84_SEMIMAJOR_AXIS, WGS84_SEMIMINOR_AXIS)
@@ -82,7 +82,7 @@ class RotatedGeodetic(CRS):
         super(RotatedGeodetic, self).__init__(proj4_params, globe=globe)
 
 
-class Projection(six.with_metaclass(ABCMeta, CRS)):
+class Projection(CRS, metaclass=ABCMeta):
     """
     Define a projected coordinate system with flat topology and Euclidean
     distance.
@@ -154,10 +154,7 @@ class Projection(six.with_metaclass(ABCMeta, CRS)):
         return minlon, maxlon
 
     def _repr_html_(self):
-        if not six.PY2:
-            from html import escape
-        else:
-            from cgi import escape
+        from html import escape
         try:
             # As matplotlib is not a core cartopy dependency, don't error
             # if it's not available.
@@ -173,7 +170,7 @@ class Projection(six.with_metaclass(ABCMeta, CRS)):
         ax.set_global()
         ax.coastlines('auto')
         ax.gridlines()
-        buf = six.StringIO()
+        buf = io.StringIO()
         fig.savefig(buf, format='svg', bbox_inches='tight')
         plt.close(fig)
         # "Rewind" the buffer to the start and return it as an svg string.
@@ -653,7 +650,7 @@ class Projection(six.with_metaclass(ABCMeta, CRS)):
         return return_value
 
 
-class _RectangularProjection(six.with_metaclass(ABCMeta, Projection)):
+class _RectangularProjection(Projection, metaclass=ABCMeta):
     """
     The abstract superclass of projections with a rectangular domain which
     is symmetric about the origin.
@@ -678,8 +675,7 @@ class _RectangularProjection(six.with_metaclass(ABCMeta, Projection)):
         return (-self._half_height, self._half_height)
 
 
-class _CylindricalProjection(six.with_metaclass(ABCMeta,
-                                                _RectangularProjection)):
+class _CylindricalProjection(_RectangularProjection, metaclass=ABCMeta):
     """
     The abstract class which denotes cylindrical projections where we
     want to allow x values to wrap around.
@@ -1579,7 +1575,7 @@ class Orthographic(Projection):
         return self._y_limits
 
 
-class _WarpedRectangularProjection(six.with_metaclass(ABCMeta, Projection)):
+class _WarpedRectangularProjection(Projection, metaclass=ABCMeta):
     def __init__(self, proj4_params, central_longitude,
                  false_easting=None, false_northing=None, globe=None):
         if false_easting is not None:
@@ -1622,7 +1618,7 @@ class _WarpedRectangularProjection(six.with_metaclass(ABCMeta, Projection)):
         return self._y_limits
 
 
-class _Eckert(six.with_metaclass(ABCMeta, _WarpedRectangularProjection)):
+class _Eckert(_WarpedRectangularProjection, metaclass=ABCMeta):
     """
     An Eckert projection.
 

--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -16,7 +16,6 @@ from abc import ABCMeta, abstractmethod
 
 import numpy as np
 import shapely.geometry as sgeom
-import six
 
 import cartopy.io.shapereader as shapereader
 import cartopy.crs
@@ -46,7 +45,7 @@ same projection.
 """
 
 
-class Feature(six.with_metaclass(ABCMeta)):
+class Feature(metaclass=ABCMeta):
     """
     Represents a collection of points, lines and polygons with convenience
     methods for common drawing and filtering operations.
@@ -256,7 +255,7 @@ class NaturalEarthFeature(Feature):
         self.name = name
 
         # Cast the given scale to a (constant) Scaler if a string is passed.
-        if isinstance(scale, six.string_types):
+        if isinstance(scale, str):
             scale = Scaler(scale)
 
         self.scaler = scale
@@ -450,9 +449,9 @@ class WFSFeature(Feature):
         try:
             from cartopy.io.ogc_clients import WFSGeometrySource
         except ImportError as e:
-            six.raise_from(ImportError(
+            raise ImportError(
                 'WFSFeature requires additional dependencies. If installed '
-                'via pip, try `pip install cartopy[ows]`.\n'), e)
+                'via pip, try `pip install cartopy[ows]`.\n') from e
 
         self.source = WFSGeometrySource(wfs, features)
         crs = self.source.default_projection()

--- a/lib/cartopy/io/__init__.py
+++ b/lib/cartopy/io/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2018, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -26,14 +26,8 @@ from __future__ import (absolute_import, division, print_function)
 import collections
 import os
 import string
+from urllib.request import urlopen
 import warnings
-
-import six
-
-if six.PY3:
-    from urllib.request import urlopen
-else:
-    from urllib2 import urlopen
 
 from cartopy import config
 
@@ -60,7 +54,7 @@ def fh_getter(fh, mode='r', needs_filename=False):
     if mode != 'r':
         raise ValueError('Only mode "r" currently supported.')
 
-    if isinstance(fh, six.string_types):
+    if isinstance(fh, str):
         filename = fh
         fh = open(fh, mode)
     elif isinstance(fh, tuple):

--- a/lib/cartopy/io/img_nest.py
+++ b/lib/cartopy/io/img_nest.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -24,7 +24,6 @@ import os.path
 import numpy as np
 from PIL import Image
 import shapely.geometry as sgeom
-from six.moves import zip
 
 
 _img_class_attrs = ['filename', 'extent', 'origin', 'pixel_size']

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -32,18 +32,18 @@ from __future__ import (absolute_import, division, print_function)
 
 from abc import ABCMeta, abstractmethod
 import concurrent.futures
+import io
 import warnings
 
 from PIL import Image
 import shapely.geometry as sgeom
 import numpy as np
-import six
 
 import cartopy
 import cartopy.crs as ccrs
 
 
-class GoogleWTS(six.with_metaclass(ABCMeta, object)):
+class GoogleWTS(metaclass=ABCMeta):
     """
     Implement web tile retrieval using the Google WTS coordinate system.
 
@@ -180,16 +180,13 @@ class GoogleWTS(six.with_metaclass(ABCMeta, object)):
         pass
 
     def get_image(self, tile):
-        if six.PY3:
-            from urllib.request import urlopen, Request, HTTPError, URLError
-        else:
-            from urllib2 import urlopen, Request, HTTPError, URLError
+        from urllib.request import urlopen, Request, HTTPError, URLError
 
         url = self._image_url(tile)
         try:
             request = Request(url, headers={"User-Agent": self.user_agent})
             fh = urlopen(request)
-            im_data = six.BytesIO(fh.read())
+            im_data = io.BytesIO(fh.read())
             fh.close()
             img = Image.open(im_data)
 
@@ -474,8 +471,7 @@ class QuadtreeTiles(GoogleWTS):
     def quadkey_to_tms(self, quadkey, google=False):
         # algorithm ported from
         # https://msdn.microsoft.com/en-us/library/bb259689.aspx
-        assert isinstance(quadkey, six.string_types), \
-            'quadkey must be a string'
+        assert isinstance(quadkey, str), 'quadkey must be a string'
 
         x = y = 0
         z = len(quadkey)

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -30,8 +30,6 @@ this way can be found at :ref:`sphx_glr_gallery_wmts.py`.
 
 from __future__ import (absolute_import, division, print_function)
 
-import six
-
 import collections
 import io
 import math
@@ -235,10 +233,10 @@ class WMSRasterSource(RasterSource):
         if WebMapService is None:
             raise ImportError(_OWSLIB_REQUIRED)
 
-        if isinstance(service, six.string_types):
+        if isinstance(service, str):
             service = WebMapService(service)
 
-        if isinstance(layers, six.string_types):
+        if isinstance(layers, str):
             layers = [layers]
 
         if getmap_extra_kwargs is None:
@@ -273,7 +271,7 @@ class WMSRasterSource(RasterSource):
 
         """
         contents = self.service.contents
-        for proj, srs in six.iteritems(_CRS_TO_OGC_SRS):
+        for proj, srs in _CRS_TO_OGC_SRS.items():
             missing = any(srs not in contents[layer].crsOptions for
                           layer in self.layers)
             if not missing:
@@ -658,10 +656,10 @@ class WFSGeometrySource(object):
         if WebFeatureService is None:
             raise ImportError(_OWSLIB_REQUIRED)
 
-        if isinstance(service, six.string_types):
+        if isinstance(service, str):
             service = WebFeatureService(service)
 
-        if isinstance(features, six.string_types):
+        if isinstance(features, str):
             features = [features]
 
         if getfeature_extra_kwargs is None:
@@ -696,13 +694,13 @@ class WFSGeometrySource(object):
             else:
                 default_urn = default_urn.pop()
 
-            if six.text_type(default_urn) not in _URN_TO_CRS:
+            if str(default_urn) not in _URN_TO_CRS:
                 raise ValueError('Unknown mapping from SRS/CRS_URN {!r} to '
                                  'cartopy projection.'.format(default_urn))
 
             self._default_urn = default_urn
 
-        return _URN_TO_CRS[six.text_type(self._default_urn)]
+        return _URN_TO_CRS[str(self._default_urn)]
 
     def fetch_geometries(self, projection, extent):
         """

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -42,12 +42,12 @@ geometry representation of shapely:
 from __future__ import (absolute_import, division, print_function)
 
 import glob
+import io
 import itertools
 import os
 
 import shapely.geometry as sgeom
 import shapefile
-import six
 
 from cartopy.io import Downloader
 from cartopy import config
@@ -349,7 +349,7 @@ class NEShpDownloader(Downloader):
 
         shapefile_online = self._urlopen(url)
 
-        zfh = ZipFile(six.BytesIO(shapefile_online.read()), 'r')
+        zfh = ZipFile(io.BytesIO(shapefile_online.read()), 'r')
 
         for member_path in self.zip_file_contents(format_dict):
             ext = os.path.splitext(member_path)[1]
@@ -450,7 +450,7 @@ class GSHHSShpDownloader(Downloader):
         # Download archive.
         url = self.url(format_dict)
         shapefile_online = self._urlopen(url)
-        zfh = ZipFile(six.BytesIO(shapefile_online.read()), 'r')
+        zfh = ZipFile(io.BytesIO(shapefile_online.read()), 'r')
         shapefile_online.close()
 
         # Iterate through all scales and levels and extract relevant files.

--- a/lib/cartopy/io/srtm.py
+++ b/lib/cartopy/io/srtm.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -27,11 +27,11 @@ database of Earth prior to the release of the ASTER GDEM in 2009.
 
 from __future__ import (absolute_import, division, print_function)
 
+import io
 import os
 import warnings
 
 import numpy as np
-import six
 
 from cartopy import config
 import cartopy.crs as ccrs
@@ -457,7 +457,7 @@ class SRTMDownloader(Downloader):
         url = self.url(format_dict)
 
         srtm_online = self._urlopen(url)
-        zfh = ZipFile(six.BytesIO(srtm_online.read()), 'r')
+        zfh = ZipFile(io.BytesIO(srtm_online.read()), 'r')
 
         zip_member_path = u'{y}{x}.hgt'.format(**format_dict)
         member = zfh.getinfo(zip_member_path)
@@ -490,7 +490,7 @@ class SRTMDownloader(Downloader):
         # dependencies of cartopy.
         from bs4 import BeautifulSoup
         if filename is None:
-            from six.moves.urllib.request import urlopen
+            from urllib.request import urlopen
             url = SRTMDownloader._SRTM_BASE_URL.format(resolution=resolution)
             with urlopen(url) as f:
                 html = f.read()

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -14,17 +14,11 @@ plot results from source coordinates to the GeoAxes' target projection.
 
 from __future__ import (absolute_import, division, print_function)
 
-import six
-
 import collections
 import contextlib
 import functools
 import warnings
 import weakref
-if not six.PY2:
-    import collections.abc as collections_abc
-else:
-    import collections as collections_abc
 
 import matplotlib as mpl
 import matplotlib.artist
@@ -1190,7 +1184,7 @@ class GeoAxes(matplotlib.axes.Axes):
         plotting methods.
 
         """
-        if not isinstance(regrid_shape, collections_abc.Sequence):
+        if not isinstance(regrid_shape, collections.abc.Sequence):
             target_size = int(regrid_shape)
             x_range, y_range = np.diff(target_extent)[::2]
             desired_aspect = x_range / y_range

--- a/lib/cartopy/mpl/style.py
+++ b/lib/cartopy/mpl/style.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2018 - 2019, Met Office
+# (C) British Crown Copyright 2018 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -22,8 +22,6 @@ Handles matplotlib styling in a single consistent place.
 
 """
 import warnings
-
-import six
 
 
 # Define the matplotlib style aliases that cartopy can expand.
@@ -80,10 +78,10 @@ def merge(*style_dicts):
             this_style['edgecolor'] = color
             this_style['facecolor'] = color
 
-        if isinstance(facecolor, six.string_types) and facecolor == 'never':
+        if isinstance(facecolor, str) and facecolor == 'never':
             requested_color = this_style.pop('facecolor', None)
             setting_color = not (
-                isinstance(requested_color, six.string_types) and
+                isinstance(requested_color, str) and
                 requested_color.lower() == 'none')
             if (('fc' in orig_style or 'facecolor' in orig_style) and
                     setting_color):

--- a/lib/cartopy/sphinxext/summarise_package.py
+++ b/lib/cartopy/sphinxext/summarise_package.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2018, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -23,7 +23,6 @@ import os
 import sys
 import sysconfig
 import warnings
-import six
 
 
 def walk_module(mod_name, exclude_folders=None):
@@ -170,7 +169,7 @@ def gen_summary_rst(app):
     exclude_dirs = app.config.summarise_package_exclude_directories
     fnames = app.config.summarise_package_fnames
 
-    if isinstance(package_names, six.string_types):
+    if isinstance(package_names, str):
         package_names = [package_names]
 
     if package_names is None:
@@ -188,15 +187,14 @@ def gen_summary_rst(app):
             raise exception
 
         for exclude_dirs_individual in exclude_dirs:
-            if isinstance(exclude_dirs_individual, six.string_types):
+            if isinstance(exclude_dirs_individual, str):
                 raise exception
 
     if fnames is None:
         fnames = ['outline_of_{}.rst'.format(package_name)
                   for package_name in package_names]
     else:
-        if isinstance(fnames, six.string_types) or \
-                len(fnames) != len(package_names):
+        if isinstance(fnames, str) or len(fnames) != len(package_names):
             raise TypeError('Please provide a list of filenames for each of '
                             'the packages which are to be summarised.')
 

--- a/lib/cartopy/tests/io/test_srtm.py
+++ b/lib/cartopy/tests/io/test_srtm.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2019, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -46,11 +46,11 @@ def srtm_login_or_skip(monkeypatch):
     except KeyError:
         pytest.skip('SRTM_PASSWORD environment variable is unset.')
 
-    from six.moves.urllib.request import (HTTPBasicAuthHandler,
-                                          HTTPCookieProcessor,
-                                          HTTPPasswordMgrWithDefaultRealm,
-                                          build_opener)
-    from six.moves.http_cookiejar import CookieJar
+    from urllib.request import (HTTPBasicAuthHandler,
+                                HTTPCookieProcessor,
+                                HTTPPasswordMgrWithDefaultRealm,
+                                build_opener)
+    from http.cookiejar import CookieJar
 
     password_manager = HTTPPasswordMgrWithDefaultRealm()
     password_manager.add_password(

--- a/lib/cartopy/tests/mpl/test_caching.py
+++ b/lib/cartopy/tests/mpl/test_caching.py
@@ -19,8 +19,6 @@ from __future__ import (absolute_import, division, print_function)
 
 import gc
 
-import six
-
 try:
     from owslib.wmts import WebMapTileService
 except ImportError:
@@ -165,8 +163,6 @@ def test_contourf_transform_path_counting():
         cs = plt.contourf(x, y, z, 5, transform=ccrs.PlateCarree())
         n_geom = sum([len(c.get_paths()) for c in cs.collections])
         del cs
-        if not six.PY3:
-            del c
         ax.figure.canvas.draw()
 
     # Before the performance enhancement, the count would have been 2 * n_geom,

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -13,7 +13,6 @@ import warnings
 import numpy as np
 import matplotlib.pyplot as plt
 import pytest
-import six
 
 import cartopy.crs as ccrs
 
@@ -236,19 +235,19 @@ def test_cursor_values():
     x, y = np.array([-969100.]), np.array([-4457000.])
     r = ax.format_coord(x, y)
     assert (r.encode('ascii', 'ignore') ==
-            six.b('-9.691e+05, -4.457e+06 (50.716617N, 12.267069W)'))
+            b'-9.691e+05, -4.457e+06 (50.716617N, 12.267069W)')
 
     ax = plt.axes(projection=ccrs.PlateCarree())
     x, y = np.array([-181.5]), np.array([50.])
     r = ax.format_coord(x, y)
     assert (r.encode('ascii', 'ignore') ==
-            six.b('-181.5, 50 (50.000000N, 178.500000E)'))
+            b'-181.5, 50 (50.000000N, 178.500000E)')
 
     ax = plt.axes(projection=ccrs.Robinson())
     x, y = np.array([16060595.2]), np.array([2363093.4])
     r = ax.format_coord(x, y)
-    assert re.search(six.b('1.606e\\+07, 2.363e\\+06 '
-                           '\\(22.09[0-9]{4}N, 173.70[0-9]{4}E\\)'),
+    assert re.search(b'1.606e\\+07, 2.363e\\+06 '
+                     b'\\(22.09[0-9]{4}N, 173.70[0-9]{4}E\\)',
                      r.encode('ascii', 'ignore'))
 
     plt.close()

--- a/lib/cartopy/tests/test_img_nest.py
+++ b/lib/cartopy/tests/test_img_nest.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2018, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -19,6 +19,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import io
 import os
+import pickle
 import shutil
 import sys
 import warnings
@@ -28,7 +29,6 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 from PIL import Image
 import pytest
 import shapely.geometry as sgeom
-from six.moves import cPickle as pickle
 
 from cartopy import config
 import cartopy.io.img_tiles as cimgt

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,4 @@
 numpy>=1.10
 shapely>=1.5.6
 pyshp>=1.1.4
-six>=1.3.0
 setuptools>=0.7.2


### PR DESCRIPTION
## Rationale

Once Python 2 is dropped, we won't need `six`, so remove it.

## Implications

Less dependencies.