### PR TITLE
Fix mesh_projection when an extent is 0.

### DIFF
--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2011 - 2018, Met Office
+# (C) British Crown Copyright 2011 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -34,8 +34,8 @@ import cartopy.crs as ccrs
 
 
 def mesh_projection(projection, nx, ny,
-                    x_extents=[None, None],
-                    y_extents=[None, None]):
+                    x_extents=(None, None),
+                    y_extents=(None, None)):
     """
     Return sample points in the given projection which span the entire
     projection range evenly.
@@ -69,11 +69,17 @@ def mesh_projection(projection, nx, ny,
 
     """
 
+    def extent(specified, default, index):
+        if specified[index] is not None:
+            return specified[index]
+        else:
+            return default[index]
+
     # Establish the x-direction and y-direction extents.
-    x_lower = x_extents[0] or projection.x_limits[0]
-    x_upper = x_extents[1] or projection.x_limits[1]
-    y_lower = y_extents[0] or projection.y_limits[0]
-    y_upper = y_extents[1] or projection.y_limits[1]
+    x_lower = extent(x_extents, projection.x_limits, 0)
+    x_upper = extent(x_extents, projection.x_limits, 1)
+    y_lower = extent(y_extents, projection.y_limits, 0)
+    y_upper = extent(y_extents, projection.y_limits, 1)
 
     # Calculate evenly spaced sample points spanning the
     # extent - excluding endpoint.

--- a/lib/cartopy/tests/test_img_transform.py
+++ b/lib/cartopy/tests/test_img_transform.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2017, Met Office
+# (C) British Crown Copyright 2014 - 2020, Met Office
 #
 # This file is part of cartopy.
 #
@@ -19,9 +19,41 @@ from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_array_equal
+import pytest
 
 import cartopy.img_transform as img_trans
 import cartopy.crs as ccrs
+
+
+@pytest.mark.parametrize('xmin, xmax', [
+    (-90, 0), (-90, 90), (-90, None),
+    (0, 90), (0, None),
+    (None, 0), (None, 90), (None, None)])
+@pytest.mark.parametrize('ymin, ymax', [
+    (-45, 0), (-45, 45), (-45, None),
+    (0, 45), (0, None),
+    (None, 0), (None, 45), (None, None)])
+def test_mesh_projection_extent(xmin, xmax, ymin, ymax):
+    proj = ccrs.PlateCarree()
+    nx = 4
+    ny = 2
+
+    target_x, target_y, extent = img_trans.mesh_projection(
+        proj, nx, ny,
+        x_extents=(xmin, xmax),
+        y_extents=(ymin, ymax))
+
+    if xmin is None:
+        xmin = proj.x_limits[0]
+    if xmax is None:
+        xmax = proj.x_limits[1]
+    if ymin is None:
+        ymin = proj.y_limits[0]
+    if ymax is None:
+        ymax = proj.y_limits[1]
+    assert_array_equal(extent, [xmin, xmax, ymin, ymax])
+    assert_array_equal(np.diff(target_x, axis=1), (xmax - xmin) / nx)
+    assert_array_equal(np.diff(target_y, axis=0), (ymax - ymin) / ny)
 
 
 def test_griding_data_std_range():


### PR DESCRIPTION
## Rationale

This incorrectly falls back to the projection limit, when the intention was to default only on `None`.

## Implications

Fixes #1483.