### PR TITLE
Make the gridliner doc to better conform the new labbeling system

### DIFF
--- a/docs/source/matplotlib/gridliner.rst
+++ b/docs/source/matplotlib/gridliner.rst
@@ -18,6 +18,25 @@ used to determine draw time behaviour of the gridlines and labels.
     :undoc-members:
 
 
+In this first example, gridines and tick labels are plotted in a
+non-rectangular projection, with most default values and
+no tuning of the gridliner attributes:
+
+.. plot::
+    :include-source:
+
+    import matplotlib.pyplot as plt
+    import cartopy.crs as ccrs
+
+    rotated_crs = ccrs.RotatedPole(pole_longitude=120.0, pole_latitude=70.0)
+
+    ax = plt.axes(projection=rotated_crs)
+    ax.set_extent([-6, 3, 48, 58], crs=ccrs.PlateCarree())
+    ax.coastlines(resolution='50m')
+    ax.gridlines(draw_labels=True, dms=True, x_inline=False, y_inline=False)
+
+    plt.show()
+
 
 The following contrived example makes use of many of the features of the Gridliner
 class to produce customized gridlines and tick labels:
@@ -29,7 +48,8 @@ class to produce customized gridlines and tick labels:
     import matplotlib.ticker as mticker
     import cartopy.crs as ccrs
 
-    from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
+    from cartopy.mpl.ticker import (LongitudeFormatter, LatitudeFormatter,
+                                    LatitudeLocator)
 
 
     ax = plt.axes(projection=ccrs.Mercator())
@@ -41,8 +61,9 @@ class to produce customized gridlines and tick labels:
     gl.left_labels = False
     gl.xlines = False
     gl.xlocator = mticker.FixedLocator([-180, -45, 0, 45, 180])
-    gl.xformatter = LONGITUDE_FORMATTER
-    gl.yformatter = LATITUDE_FORMATTER
+    gl.ylocator = LatitudeLocator()
+    gl.xformatter = LongitudeFormatter
+    gl.yformatter = LatitudeFormatter
     gl.xlabel_style = {'size': 15, 'color': 'gray'}
     gl.xlabel_style = {'color': 'red', 'weight': 'bold'}
 

--- a/docs/source/matplotlib/gridliner.rst
+++ b/docs/source/matplotlib/gridliner.rst
@@ -62,8 +62,8 @@ class to produce customized gridlines and tick labels:
     gl.xlines = False
     gl.xlocator = mticker.FixedLocator([-180, -45, 0, 45, 180])
     gl.ylocator = LatitudeLocator()
-    gl.xformatter = LongitudeFormatter
-    gl.yformatter = LatitudeFormatter
+    gl.xformatter = LongitudeFormatter()
+    gl.yformatter = LatitudeFormatter()
     gl.xlabel_style = {'size': 15, 'color': 'gray'}
     gl.xlabel_style = {'color': 'red', 'weight': 'bold'}
 


### PR DESCRIPTION

## Rationale

The gridliner, locators and formatters have been updated, so the doc must be updated to comply with the new features.


## Implications

The gridliner doc now has two differents exemples:

* The first one is new. It shows how to draw labels quickly.
* The second one has been updated to no longer use the LONGITUDE_FORMATTER and LATITUDE_FORMATTER.

The current web page: https://scitools.org.uk/cartopy/docs/latest/matplotlib/gridliner.html

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
