### PR TITLE
DOC: Increase timeout for install step on CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,9 @@ jobs:
           environment:
             PYTHON_VERSION: 2
             EXTRA_PACKAGES: "futures"
-      - run: *deps-install
+      - run:
+          <<: *deps-install
+          no_output_timeout: "20m"
       - run: *cp-install
 
       - run: *doc-build


### PR DESCRIPTION
## Rationale

On Python 2, conda needs a lot of time to solve due to all the old packages. The default 10m timeout is often too short, but since it usually is able to pass, it's probably only just a little bit slower. So increase timeout to 20m.

## Implications

Less CI failures.