### PR TITLE
BUG: Add globe property to CRS definition

### DIFF
--- a/lib/cartopy/_crs.pxd
+++ b/lib/cartopy/_crs.pxd
@@ -28,5 +28,6 @@ cdef class CRS:
     cdef projPJ proj4
     cdef readonly proj4_init
     cdef proj4_params
+    cdef readonly globe
 
     cpdef is_geodetic(self)

--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -275,6 +275,7 @@ cdef class CRS:
         state.pop('proj4', None)
         state.pop('proj4_init', None)
         state['proj4_params'] = self.proj4_params
+        state['globe'] = self.globe
         return state
 
     def __setstate__(self, state):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "lib/cartopy/_crs.pyx", line 160, in cartopy._crs.CRS.__init__
AttributeError: 'cartopy._crs.CRS' object has no attribute 'globe'

```