### PR TITLE
Add gridliner/ticklabels example to the gallery

### DIFF
--- a/lib/cartopy/examples/gridliner.py
+++ b/lib/cartopy/examples/gridliner.py
@@ -1,0 +1,40 @@
+"""
+Gridlines and tick Labels
+-------------------------
+
+Theses examples demonstrate how to quickly add longitude
+and latitude gridlines and tick labels on a non-rectangular projection.
+
+As you can see on the first example,
+longitude labels may be drawn on left and right sides,
+and latitude labels may be drawn on bottom and top sides.
+Thanks to the ``dms`` keyword, minutes are used when appropriate
+to exprimate fractions of degree.
+
+
+In the second example, labels are still drawn at the map edges
+despite its complexity.
+
+"""
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+import matplotlib.pyplot as plt
+
+
+def main():
+
+    rotated_crs = ccrs.RotatedPole(pole_longitude=120.0, pole_latitude=70.0)
+
+    ax0 = plt.axes(projection=rotated_crs)
+    ax0.set_extent([-3, 2, 48, 52], crs=ccrs.PlateCarree())
+    ax0.add_feature(cfeature.LAND)
+    ax0.gridlines(draw_labels=True, dms=True, x_inline=False, y_inline=False)
+
+
+    plt.figure(figsize=(6.9228, 3))
+    ax1 = plt.axes(projection=ccrs.InterruptedGoodeHomolosine())
+    ax1.coastlines(resolution='110m')
+    ax1.gridlines(draw_labels=True)
+
+if __name__ == '__main__':
+    main()

--- a/lib/cartopy/examples/gridliner.py
+++ b/lib/cartopy/examples/gridliner.py
@@ -1,19 +1,20 @@
 """
-Gridlines and tick Labels
+Gridlines and tick labels
 -------------------------
 
-Theses examples demonstrate how to quickly add longitude
+These examples demonstrate how to quickly add longitude
 and latitude gridlines and tick labels on a non-rectangular projection.
 
 As you can see on the first example,
 longitude labels may be drawn on left and right sides,
 and latitude labels may be drawn on bottom and top sides.
 Thanks to the ``dms`` keyword, minutes are used when appropriate
-to exprimate fractions of degree.
+to display fractions of degree.
 
 
 In the second example, labels are still drawn at the map edges
-despite its complexity.
+despite its complexity, and some others are also drawn within the map
+boundary.
 
 """
 import cartopy.crs as ccrs
@@ -24,17 +25,16 @@ import matplotlib.pyplot as plt
 def main():
 
     rotated_crs = ccrs.RotatedPole(pole_longitude=120.0, pole_latitude=70.0)
-
     ax0 = plt.axes(projection=rotated_crs)
     ax0.set_extent([-3, 2, 48, 52], crs=ccrs.PlateCarree())
     ax0.add_feature(cfeature.LAND)
     ax0.gridlines(draw_labels=True, dms=True, x_inline=False, y_inline=False)
 
-
     plt.figure(figsize=(6.9228, 3))
     ax1 = plt.axes(projection=ccrs.InterruptedGoodeHomolosine())
     ax1.coastlines(resolution='110m')
     ax1.gridlines(draw_labels=True)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/cartopy/examples/gridliner.py
+++ b/lib/cartopy/examples/gridliner.py
@@ -21,19 +21,26 @@ import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import matplotlib.pyplot as plt
 
+__tags__ = ['Gridlines', 'Tick labels', 'Lines and polygons']
+
 
 def main():
 
     rotated_crs = ccrs.RotatedPole(pole_longitude=120.0, pole_latitude=70.0)
     ax0 = plt.axes(projection=rotated_crs)
-    ax0.set_extent([-3, 2, 48, 52], crs=ccrs.PlateCarree())
-    ax0.add_feature(cfeature.LAND)
+    ax0.set_extent([-6, 1, 47.5, 51.5], crs=ccrs.PlateCarree())
+    ocean = cfeature.NaturalEarthFeature(
+        'physical', 'land', '110m', edgecolor='face',
+        facecolor=cfeature.COLORS['land'], zorder=-1)
+    ax0.add_feature(ocean)
     ax0.gridlines(draw_labels=True, dms=True, x_inline=False, y_inline=False)
 
     plt.figure(figsize=(6.9228, 3))
     ax1 = plt.axes(projection=ccrs.InterruptedGoodeHomolosine())
     ax1.coastlines(resolution='110m')
     ax1.gridlines(draw_labels=True)
+
+    plt.show()
 
 
 if __name__ == '__main__':

--- a/lib/cartopy/examples/gridliner.py
+++ b/lib/cartopy/examples/gridliner.py
@@ -29,10 +29,7 @@ def main():
     rotated_crs = ccrs.RotatedPole(pole_longitude=120.0, pole_latitude=70.0)
     ax0 = plt.axes(projection=rotated_crs)
     ax0.set_extent([-6, 1, 47.5, 51.5], crs=ccrs.PlateCarree())
-    ocean = cfeature.NaturalEarthFeature(
-        'physical', 'land', '110m', edgecolor='face',
-        facecolor=cfeature.COLORS['land'], zorder=-1)
-    ax0.add_feature(ocean)
+    ax0.add_feature(cfeature.LAND.with_scale('110m'))
     ax0.gridlines(draw_labels=True, dms=True, x_inline=False, y_inline=False)
 
     plt.figure(figsize=(6.9228, 3))


### PR DESCRIPTION

## Rationale

An example added to the gallery to show the power of the new tick labeller
system.

This PR may be seen as an extension of #1522.

## Implications

So users clearly know how it can works.

Should we remove the other gallery example on the subjects?

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
