### PR TITLE
Add simple cache mechanism to GoogleWTS class

### DIFF
--- a/lib/cartopy/__init__.py
+++ b/lib/cartopy/__init__.py
@@ -5,6 +5,7 @@
 # licensing details.
 
 from ._version import version as __version__  # noqa: F401
+import tempfile
 
 __document_these__ = ['config']
 
@@ -17,9 +18,11 @@ import os.path
 _writable_dir = os.path.join(os.path.expanduser('~'), '.local', 'share')
 _data_dir = os.path.join(os.environ.get("XDG_DATA_HOME", _writable_dir),
                          'cartopy')
+_cache_dir = os.path.join(tempfile.gettempdir(), 'cartopy_cache_dir')
 
 config = {'pre_existing_data_dir': '',
           'data_dir': _data_dir,
+          'cache_dir': _cache_dir,
           'repo_data_dir': os.path.join(os.path.dirname(__file__), 'data'),
           'downloaders': {},
           }
@@ -67,6 +70,7 @@ Keys in the config dictionary:
 
 del _data_dir
 del _writable_dir
+del _cache_dir
 
 
 # Try importing a siteconfig file which exposes an update_config function,

--- a/lib/cartopy/__init__.py
+++ b/lib/cartopy/__init__.py
@@ -56,6 +56,14 @@ Keys in the config dictionary:
     cartopy will download the appropriate file(s) to a subdirectory of this
     directory, therefore ``data_dir`` should be writable by the user.
 
+``cache_dir``
+    The absolute path to a directory where tiles data are cached when a
+    GoogleWTS sub-class is initialized with `cache=True`. If it is not found
+    cartopy will create it, therefore ``cache_dir`` should be writable by the
+    user. Note that the default cache dir might be accessible by all users,
+    depending on your OS and local configuration. If private cache is
+    mandatory, set cache_dir to a private location.
+
 ``repo_data_dir``
     The absolute path to the directory where the data delivered with the
     cartopy repository is stored.  Typically this will only be set by OS

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -41,7 +41,7 @@ class GoogleWTS(metaclass=ABCMeta):
     _MAX_THREADS = 24
 
     def __init__(self, desired_tile_form='RGB',
-                 user_agent='CartoPy/' + cartopy.__version__, cache_path=None):
+                 user_agent='CartoPy/' + cartopy.__version__, cache=False):
         self.imgs = []
         self.crs = ccrs.Mercator.GOOGLE
         self.desired_tile_form = desired_tile_form
@@ -49,7 +49,12 @@ class GoogleWTS(metaclass=ABCMeta):
         # some providers like osm need a user_agent in the request issue #1341
         # osm may reject requests if there are too many of them, in which case
         # a change of user_agent may fix the issue.
-        self.cache_path = cache_path
+        if cache is True:
+            self.cache_path = cartopy.config["cache_dir"]
+        elif cache is False:
+            self.cache_path = None
+        else:
+            self.cache_path = cache
         self.cache = set({})
         self._load_cache()
 
@@ -225,7 +230,7 @@ class GoogleTiles(GoogleWTS):
     def __init__(self, desired_tile_form='RGB', style="street",
                  url=('https://mts0.google.com/vt/lyrs={style}'
                       '@177000000&hl=en&src=api&x={x}&y={y}&z={z}&s=G'),
-                 cache_path=None):
+                 cache=False):
         """
         Parameters
         ----------
@@ -257,7 +262,7 @@ World_Shaded_Relief/MapServer/tile/{z}/{y}/{x}.jpg'``
             msg = "The '%s' style requires pillow with jpeg decoding support."
             raise ValueError(msg % self.style)
         return super().__init__(desired_tile_form=desired_tile_form,
-                                cache_path=cache_path)
+                                cache=cache)
 
     def _image_url(self, tile):
         style_dict = {
@@ -332,9 +337,9 @@ class Stamen(GoogleWTS):
 
     """
     def __init__(self, style='toner',
-                 desired_tile_form='RGB', cache_path=None):
+                 desired_tile_form='RGB', cache=False):
         super().__init__(desired_tile_form=desired_tile_form,
-                         cache_path=cache_path)
+                         cache=cache)
         self.style = style
 
     def _image_url(self, tile):
@@ -367,7 +372,7 @@ class StamenTerrain(Stamen):
 
 
     """
-    def __init__(self, cache_path=None):
+    def __init__(self, cache=False):
         warnings.warn(
             "The StamenTerrain class was deprecated in v0.17. "
             "Please use Stamen('terrain-background') instead.",
@@ -378,7 +383,7 @@ class StamenTerrain(Stamen):
         # No further Stamen subclasses will be accepted as
         # they can easily be created in user code with Stamen(style_name).
         return super().__init__(style='terrain-background',
-                                cache_path=cache_path)
+                                cache=cache)
 
 
 class MapboxTiles(GoogleWTS):
@@ -388,7 +393,7 @@ class MapboxTiles(GoogleWTS):
     For terms of service, see https://www.mapbox.com/tos/.
 
     """
-    def __init__(self, access_token, map_id, cache_path=None):
+    def __init__(self, access_token, map_id, cache=False):
         """
         Set up a new Mapbox tiles instance.
 
@@ -406,7 +411,7 @@ class MapboxTiles(GoogleWTS):
         """
         self.access_token = access_token
         self.map_id = map_id
-        super().__init__(cache_path=cache_path)
+        super().__init__(cache=cache)
 
     def _image_url(self, tile):
         x, y, z = tile
@@ -426,7 +431,7 @@ class MapboxStyleTiles(GoogleWTS):
     For terms of service, see https://www.mapbox.com/tos/.
 
     """
-    def __init__(self, access_token, username, map_id, cache_path=None):
+    def __init__(self, access_token, username, map_id, cache=False):
         """
         Set up a new instance to retrieve tiles from a Mapbox style.
 
@@ -449,7 +454,7 @@ class MapboxStyleTiles(GoogleWTS):
         self.access_token = access_token
         self.username = username
         self.map_id = map_id
-        super().__init__(cache_path=cache_path)
+        super().__init__(cache=cache)
 
     def _image_url(self, tile):
         x, y, z = tile
@@ -568,7 +573,7 @@ class OrdnanceSurvey(GoogleWTS):
                  apikey,
                  layer='Road',
                  desired_tile_form='RGB',
-                 cache_path=None):
+                 cache=False):
         """
         Parameters
         ----------
@@ -585,7 +590,7 @@ class OrdnanceSurvey(GoogleWTS):
             Defaults to 'RGB'.
         """
         super().__init__(desired_tile_form=desired_tile_form,
-                         cache_path=cache_path)
+                         cache=cache)
         self.apikey = apikey
 
         if layer not in ['Outdoor', 'Road', 'Light', 'Night', 'Leisure']:

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -22,6 +22,7 @@ import concurrent.futures
 import io
 import json
 import os
+from uuid import uuid4
 import warnings
 
 from PIL import Image
@@ -52,12 +53,7 @@ class GoogleWTS(metaclass=ABCMeta):
         # a change of user_agent may fix the issue.
         self.cache_path = cache_path
         self.cache = {}
-        if self.cache_path is not None:
-            try:
-                os.makedirs(self.cache_path)
-            except OSError:
-                pass
-            self._load_cache()
+        self._load_cache()
 
     def image_for_domain(self, target_domain, target_z):
         tiles = []
@@ -88,8 +84,7 @@ class GoogleWTS(metaclass=ABCMeta):
 
         img, extent, origin = _merge_tiles(tiles)
 
-        if self.cache_path is not None:
-            self._save_cache()
+        self._save_cache()
 
         return img, extent, origin
 
@@ -107,7 +102,8 @@ class GoogleWTS(metaclass=ABCMeta):
     def _save_cache(self):
         """Save the cache"""
         if self.cache_path is not None and self.cache:
-            from uuid import uuid4
+            if not os.path.exists(self.cache_path):
+                os.makedirs(self.cache_path)
             files = self._cache_files()
             already_cached = self._fetch_cache(files)
 

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -18,6 +18,7 @@ using tiles in this way can be found at the
 """
 
 from abc import ABCMeta, abstractmethod
+from builtins import FileExistsError
 import concurrent.futures
 import io
 import json
@@ -101,10 +102,7 @@ class GoogleWTS(metaclass=ABCMeta):
         already_cached = {}
         if os.path.exists(files):
             with open(files) as f:
-                try:
-                    already_cached = json.load(f)
-                except:
-                    already_cached = {}
+                already_cached = json.load(f)
         return already_cached
 
     def _save_cache(self):
@@ -252,7 +250,8 @@ class GoogleWTS(metaclass=ABCMeta):
 class GoogleTiles(GoogleWTS):
     def __init__(self, desired_tile_form='RGB', style="street",
                  url=('https://mts0.google.com/vt/lyrs={style}'
-                      '@177000000&hl=en&src=api&x={x}&y={y}&z={z}&s=G'), cache_path=None):
+                      '@177000000&hl=en&src=api&x={x}&y={y}&z={z}&s=G'),
+                 cache_path=None):
         """
         Parameters
         ----------
@@ -587,7 +586,11 @@ class OrdnanceSurvey(GoogleWTS):
     https://developer.ordnancesurvey.co.uk/os-api-framework-agreement.
     """
     # API Documentation: https://apidocs.os.uk/docs/os-maps-wmts
-    def __init__(self, apikey, layer='Road', desired_tile_form='RGB', cache_path=None):
+    def __init__(self,
+                 apikey,
+                 layer='Road',
+                 desired_tile_form='RGB',
+                 cache_path=None):
         """
         Parameters
         ----------

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -81,7 +81,6 @@ class GoogleWTS(metaclass=ABCMeta):
                     pass
 
         img, extent, origin = _merge_tiles(tiles)
-
         return img, extent, origin
 
     @property
@@ -257,7 +256,8 @@ World_Shaded_Relief/MapServer/tile/{z}/{y}/{x}.jpg'``
                 not Image.core.jpeg_decoder:
             msg = "The '%s' style requires pillow with jpeg decoding support."
             raise ValueError(msg % self.style)
-        return super().__init__(desired_tile_form=desired_tile_form, cache_path=cache_path)
+        return super().__init__(desired_tile_form=desired_tile_form,
+                                cache_path=cache_path)
 
     def _image_url(self, tile):
         style_dict = {
@@ -331,8 +331,10 @@ class Stamen(GoogleWTS):
     attribute this imagery.
 
     """
-    def __init__(self, style='toner', desired_tile_form='RGB', cache_path=None):
-        super().__init__(desired_tile_form=desired_tile_form, cache_path=cache_path)
+    def __init__(self, style='toner',
+                 desired_tile_form='RGB', cache_path=None):
+        super().__init__(desired_tile_form=desired_tile_form,
+                         cache_path=cache_path)
         self.style = style
 
     def _image_url(self, tile):
@@ -375,7 +377,8 @@ class StamenTerrain(Stamen):
         # NOTE: This subclass of Stamen exists for legacy reasons.
         # No further Stamen subclasses will be accepted as
         # they can easily be created in user code with Stamen(style_name).
-        return super().__init__(style='terrain-background', cache_path=cache_path)
+        return super().__init__(style='terrain-background',
+                                cache_path=cache_path)
 
 
 class MapboxTiles(GoogleWTS):
@@ -581,7 +584,8 @@ class OrdnanceSurvey(GoogleWTS):
         desired_tile_form: optional
             Defaults to 'RGB'.
         """
-        super().__init__(desired_tile_form=desired_tile_form, cache_path=cache_path)
+        super().__init__(desired_tile_form=desired_tile_form,
+                         cache_path=cache_path)
         self.apikey = apikey
 
         if layer not in ['Outdoor', 'Road', 'Light', 'Night', 'Leisure']:

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -18,7 +18,6 @@ using tiles in this way can be found at the
 """
 
 from abc import ABCMeta, abstractmethod
-from builtins import FileExistsError
 import concurrent.futures
 import io
 import json
@@ -56,7 +55,7 @@ class GoogleWTS(metaclass=ABCMeta):
         if self.cache_path is not None:
             try:
                 os.makedirs(self.cache_path)
-            except FileExistsError:
+            except OSError:
                 pass
             self._load_cache()
 

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -7,6 +7,7 @@
 import hashlib
 import os
 import types
+import warnings
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal as assert_arr_almost
@@ -301,7 +302,8 @@ def test_cache(cache_dir, tmpdir):
         config["cache_dir"] = tmpdir.strpath
 
     # Fetch tiles and save them in the cache
-    gt = cimgt.GoogleTiles(cache=tmpdir_str)
+    with warnings.catch_warnings(record=True) as w:
+        gt = cimgt.GoogleTiles(cache=tmpdir_str)
     gt._image_url = types.MethodType(GOOGLE_IMAGE_URL_REPLACEMENT, gt)
 
     ll_target_domain = sgeom.box(-10, 50, 10, 60)
@@ -314,6 +316,12 @@ def test_cache(cache_dir, tmpdir):
     if cache_dir is False:
         assert gt.cache_path is None
         return
+
+    # Check that the warning is properly raised (only when cache is True)
+    if cache_dir is True:
+        assert len(w) == 1
+    else:
+        assert len(w) == 0
 
     # Define expected results
     x_y_z_f_h = [

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -295,7 +295,7 @@ def test_cache(tmpdir):
     tmpdir_str = tmpdir.strpath
 
     # Fetch tiles and save them in the cache
-    gt = cimgt.GoogleTiles(cache=tmpdir_str)
+    gt = cimgt.GoogleTiles(cache_path=tmpdir_str)
     gt._image_url = types.MethodType(GOOGLE_IMAGE_URL_REPLACEMENT, gt)
 
     ll_target_domain = sgeom.box(-10, 50, 10, 60)
@@ -324,9 +324,9 @@ def test_cache(tmpdir):
         (33, 21, 6, '8ea3e1caff873c7947d2ef4f7f353ae4')
     ]
     base_url = (
-        'https://chart.googleapis.com/chart?chst=d_text_outline&chs=256x256&chf=bg,'
-        's,00000055&chld=FFFFFF|16|h|000000|b||||Google:%20%20({},{})|Zoom%20{}||||'
-        '||____________________________'
+        'https://chart.googleapis.com/chart?chst=d_text_outline&chs=256x256&'
+        'chf=bg,s,00000055&chld=FFFFFF|16|h|000000|b||||Google:%20%20({},{})'
+        '|Zoom%20{}||||||____________________________'
     )
 
     # Check the results
@@ -341,12 +341,12 @@ def test_cache(tmpdir):
     url_ids = json.load(open(os.path.join(tmpdir_str, "files")))
 
     assert sorted(hashes.values()) == sorted([
-        h for _, _, _, h in x_y_z_h
+        h for x, y, z, h in x_y_z_h
     ])
 
     assert sorted(url_ids.keys()) == sorted([
         base_url.format(x, y, z)
-        for x, y, z, _ in x_y_z_h
+        for x, y, z, h in x_y_z_h
     ])
 
     url_hashes = {url: hashes[uid + ".tiff"] for url, uid in url_ids.items()}
@@ -361,8 +361,9 @@ def test_cache(tmpdir):
         img = Image.new('RGB', (255, 255), "white")
         img.save(filename)
 
-    gt_cache = cimgt.GoogleTiles(cache=tmpdir_str)
-    gt_cache._image_url = types.MethodType(GOOGLE_IMAGE_URL_REPLACEMENT, gt_cache)
+    gt_cache = cimgt.GoogleTiles(cache_path=tmpdir_str)
+    gt_cache._image_url = types.MethodType(
+        GOOGLE_IMAGE_URL_REPLACEMENT, gt_cache)
     img_cache, _, _ = gt_cache.image_for_domain(target_domain, 6)
 
     # Check that the new image_for_domain() call used cached images

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -1,21 +1,15 @@
-<<<<<<< HEAD
 # Copyright Cartopy Contributors
-=======
-# (C) British Crown Copyright 2011 - 2020, Met Office
->>>>>>> Fix licence headers
 #
 # This file is part of Cartopy and is released under the LGPL license.
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
 import hashlib
-import json
 import os
 import types
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal as assert_arr_almost
-from PIL import Image
 import pytest
 import shapely.geometry as sgeom
 
@@ -309,61 +303,49 @@ def test_cache(tmpdir):
     img_init, _, _ = gt.image_for_domain(target_domain, 6)
 
     # Define expected results
-    x_y_z_h = [
-        (30, 18, 6, '3f4aad7c536b7d43a16b891283c6ec02'),
-        (30, 19, 6, '308d0a772f08e4e0ee6285ca8595913d'),
-        (30, 20, 6, 'bb613f149ca6cec329591bd3f50e5a9f'),
-        (30, 21, 6, '4f1bb78eb1fe225b77dde6ee1cc33afe'),
-        (31, 18, 6, 'e6e2343ff5c6a3f3632a57e673b4a155'),
-        (31, 19, 6, '943ec0bc1f55b3b4e7b5c6a17313a6c8'),
-        (31, 20, 6, 'e835fd11f30d9976f8aa722205d47af8'),
-        (31, 21, 6, 'f9b54ce321ce2a351480f440f70a31eb'),
-        (32, 18, 6, 'dd065d5502411e5752dac7bd596cca02'),
-        (32, 19, 6, '641b162bc052785d6e1270a49aa42a10'),
-        (32, 20, 6, '1de7433ab6f6ce272f269a46c214ff08'),
-        (32, 21, 6, 'faa04e22f983e842496fdee07bd67435'),
-        (33, 18, 6, 'c097aedf3d78bbe898950244e5e1b82c'),
-        (33, 19, 6, '606473c53c86eeda09b06f729f04246d'),
-        (33, 20, 6, '541bcd6b12609c2423f0bf141f7f6705'),
-        (33, 21, 6, '8ea3e1caff873c7947d2ef4f7f353ae4')
+    x_y_z_f_h = [
+        (30, 18, 6, '30_18_6.npy', '5f4bcb9e2d21931ad67086a96b0ea679'),
+        (30, 19, 6, '30_19_6.npy', '5c26cd7585f869e6d9a6d32530c4ff62'),
+        (30, 20, 6, '30_20_6.npy', 'e0861f5af0c3ede62c25213a482b69bf'),
+        (30, 21, 6, '30_21_6.npy', '562e0ed47fb5b89b04e26db712ddd224'),
+        (31, 18, 6, '31_18_6.npy', '0b8d038ad535d1d0b9671d11e1fed688'),
+        (31, 19, 6, '31_19_6.npy', '403bee164411405daea04be26f53af82'),
+        (31, 20, 6, '31_20_6.npy', '9a65b7852c4fb7cf38df8c14ded37cea'),
+        (31, 21, 6, '31_21_6.npy', '8431309ba8f05e76fd1df47807fd1134'),
+        (32, 18, 6, '32_18_6.npy', 'f11e04a071a60266cd197fc46b301f32'),
+        (32, 19, 6, '32_19_6.npy', 'ba956e8daf68968d97ce04994d8a5be2'),
+        (32, 20, 6, '32_20_6.npy', 'e269f50f4cc79858e4f31bd39bdbad07'),
+        (32, 21, 6, '32_21_6.npy', '76f23795f0724af4522a78e9c9d0fa9c'),
+        (33, 18, 6, '33_18_6.npy', '132ec5f64985b783c79facdd85de1927'),
+        (33, 19, 6, '33_19_6.npy', 'e4e855d2376cf2faa20a8d7da4114a61'),
+        (33, 20, 6, '33_20_6.npy', '02009bce9adab5f05a64f4bed3fa5218'),
+        (33, 21, 6, '33_21_6.npy', '309beaef09160ce1d849ba77a2d79246')
     ]
-    base_url = (
-        'https://chart.googleapis.com/chart?chst=d_text_outline&chs=256x256&'
-        'chf=bg,s,00000055&chld=FFFFFF|16|h|000000|b||||Google:%20%20({},{})'
-        '|Zoom%20{}||||||____________________________'
-    )
 
     # Check the results
-    files = [i for i in os.listdir(tmpdir_str) if i != "files"]
+    cache_dir = os.path.join(tmpdir_str, "GoogleTiles")
+    files = [i for i in os.listdir(cache_dir)]
     hashes = {
         f:
         hashlib.md5(
-            open(os.path.join(tmpdir_str, f), mode="rb").read()
+            open(os.path.join(cache_dir, f), mode="rb").read()
         ).hexdigest()
         for f in files
     }
-    url_ids = json.load(open(os.path.join(tmpdir_str, "files")))
+
+    assert sorted(files) == [f for x, y, z, f, h in x_y_z_f_h]
+    assert set(files) == gt.cache
 
     assert sorted(hashes.values()) == sorted([
-        h for x, y, z, h in x_y_z_h
+        h for x, y, z, f, h in x_y_z_f_h
     ])
-
-    assert sorted(url_ids.keys()) == sorted([
-        base_url.format(x, y, z)
-        for x, y, z, h in x_y_z_h
-    ])
-
-    url_hashes = {url: hashes[uid + ".tiff"] for url, uid in url_ids.items()}
-    assert url_hashes == {
-        base_url.format(x, y, z): h
-        for x, y, z, h in x_y_z_h
-    }
 
     # Update images in cache (all white)
     for f in files:
-        filename = os.path.join(tmpdir_str, f)
-        img = Image.new('RGB', (255, 255), "white")
-        img.save(filename)
+        filename = os.path.join(cache_dir, f)
+        img = np.load(filename, allow_pickle=True)
+        img.fill(255)
+        np.save(filename, img, allow_pickle=True)
 
     gt_cache = cimgt.GoogleTiles(cache_path=tmpdir_str)
     gt_cache._image_url = types.MethodType(
@@ -371,5 +353,5 @@ def test_cache(tmpdir):
     img_cache, _, _ = gt_cache.image_for_domain(target_domain, 6)
 
     # Check that the new image_for_domain() call used cached images
-    assert gt_cache.cache.keys() == gt.cache.keys()
+    assert gt_cache.cache == gt.cache
     assert (img_cache == 255).all()

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 # Copyright Cartopy Contributors
+=======
+# (C) British Crown Copyright 2011 - 2020, Met Office
+>>>>>>> Fix licence headers
 #
 # This file is part of Cartopy and is released under the LGPL license.
 # See COPYING and COPYING.LESSER in the root of the repository for full

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -304,22 +304,22 @@ def test_cache(tmpdir):
 
     # Define expected results
     x_y_z_f_h = [
-        (30, 18, 6, '30_18_6.npy', '5f4bcb9e2d21931ad67086a96b0ea679'),
-        (30, 19, 6, '30_19_6.npy', '5c26cd7585f869e6d9a6d32530c4ff62'),
-        (30, 20, 6, '30_20_6.npy', 'e0861f5af0c3ede62c25213a482b69bf'),
-        (30, 21, 6, '30_21_6.npy', '562e0ed47fb5b89b04e26db712ddd224'),
-        (31, 18, 6, '31_18_6.npy', '0b8d038ad535d1d0b9671d11e1fed688'),
-        (31, 19, 6, '31_19_6.npy', '403bee164411405daea04be26f53af82'),
-        (31, 20, 6, '31_20_6.npy', '9a65b7852c4fb7cf38df8c14ded37cea'),
-        (31, 21, 6, '31_21_6.npy', '8431309ba8f05e76fd1df47807fd1134'),
-        (32, 18, 6, '32_18_6.npy', 'f11e04a071a60266cd197fc46b301f32'),
-        (32, 19, 6, '32_19_6.npy', 'ba956e8daf68968d97ce04994d8a5be2'),
-        (32, 20, 6, '32_20_6.npy', 'e269f50f4cc79858e4f31bd39bdbad07'),
-        (32, 21, 6, '32_21_6.npy', '76f23795f0724af4522a78e9c9d0fa9c'),
-        (33, 18, 6, '33_18_6.npy', '132ec5f64985b783c79facdd85de1927'),
-        (33, 19, 6, '33_19_6.npy', 'e4e855d2376cf2faa20a8d7da4114a61'),
-        (33, 20, 6, '33_20_6.npy', '02009bce9adab5f05a64f4bed3fa5218'),
-        (33, 21, 6, '33_21_6.npy', '309beaef09160ce1d849ba77a2d79246')
+        (30, 18, 6, '30_18_6.npy', '545db25f1aa348ad85e1f437fd0db0d9'),
+        (30, 19, 6, '30_19_6.npy', '10355add0674bfa33f673ea27a6d1206'),
+        (30, 20, 6, '30_20_6.npy', 'ab3e7f2ed8d71977ac176094973695ae'),
+        (30, 21, 6, '30_21_6.npy', '3e8947b93a6ffa07f22cfea4042a4740'),
+        (31, 18, 6, '31_18_6.npy', 'd0fa58b9146aa99b273eb75256b328cc'),
+        (31, 19, 6, '31_19_6.npy', '9255bd0cd22736bd2c25a9087bd47b20'),
+        (31, 20, 6, '31_20_6.npy', 'ac0f7e32bdf8edb50d1dccf3ec0ef446'),
+        (31, 21, 6, '31_21_6.npy', 'f36b8cc1825bf267b2daead837facae9'),
+        (32, 18, 6, '32_18_6.npy', '9f4ddd90cd1ae76ef2bbc8f0252ead91'),
+        (32, 19, 6, '32_19_6.npy', 'a995803578bb94ecfca8563754717196'),
+        (32, 20, 6, '32_20_6.npy', 'def9e71d77fd6007c77c2a14dfae858f'),
+        (32, 21, 6, '32_21_6.npy', 'a3d7935037019ec58ae78f60e6fb924e'),
+        (33, 18, 6, '33_18_6.npy', '4e51e32da73fb99229817dcd7b7e1f4f'),
+        (33, 19, 6, '33_19_6.npy', 'b9b5057fa012c5788cbbe1e18c9bb512'),
+        (33, 20, 6, '33_20_6.npy', 'b55a7c0a8d86167df496732f85bddcf9'),
+        (33, 21, 6, '33_21_6.npy', '4208ba897c460e9bb0d2469552e127ff')
     ]
 
     # Check the results
@@ -328,7 +328,7 @@ def test_cache(tmpdir):
     hashes = {
         f:
         hashlib.md5(
-            open(os.path.join(cache_dir, f), mode="rb").read()
+            np.load(os.path.join(cache_dir, f), allow_pickle=True).data
         ).hexdigest()
         for f in files
     }


### PR DESCRIPTION
## Rationale

During my development I made many tests implying fetching tiles from Google. In the end, my IP address got banned for some time...
I propose a very simple cache mechanism to store tiles so that it is not needed to request tiles from the server at each test.
With this, it is possible to write:
`gt_cache = cimgt.GoogleTiles(cache="\tmp\cartopy_cache")`
and all tiles downloaded downloaded by this `GoogleWTS` object will be stored in the given directory for later use.

## Implications

* Avoid being banned from tile providers during heavy load tests.
* Allow to work offline if the tiles have already been cached.