### PR TITLE
Drop Python 2 doc builds on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,28 +85,6 @@ jobs:
       - store_artifacts:
           path: docs/build/html
 
-  docs-python2:
-    docker:
-      - image: continuumio/miniconda:latest
-    steps:
-      - checkout
-
-      - run: *apt-install
-      - run:
-          <<: *env-setup
-          environment:
-            PYTHON_VERSION: 2
-            EXTRA_PACKAGES: "futures"
-      - run:
-          <<: *deps-install
-          no_output_timeout: "20m"
-      - run: *cp-install
-
-      - run: *doc-build
-
-      - store_artifacts:
-          path: docs/build/html
-
 
 #########################################
 # Defining workflows gets us parallelism.
@@ -117,4 +95,3 @@ workflows:
   build:
     jobs:
       - docs-python3
-      - docs-python2


### PR DESCRIPTION
## Rationale

This times out after 5 hours and I'm not too interested in fixing it.

## Implications

No doc builds on Python 2, but they stopped working anyway.