### PR TITLE
Remove redundant Python 2 code

### DIFF
--- a/benchmarks/cases/__init__.py
+++ b/benchmarks/cases/__init__.py
@@ -4,4 +4,3 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)

--- a/benchmarks/cases/mpl_redraw.py
+++ b/benchmarks/cases/mpl_redraw.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt

--- a/benchmarks/cases/project_linear.py
+++ b/benchmarks/cases/project_linear.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import cartopy.io.shapereader as shpreader
 import cartopy.crs as ccrs

--- a/docs/make_projection.py
+++ b/docs/make_projection.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 import os
 import inspect
 import textwrap

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,8 +71,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'cartopy'
-copyright = u'2011 - 2018 British Crown Copyright'  # the template will need
+project = 'cartopy'
+copyright = '2011 - 2018 British Crown Copyright'  # the template will need
 # updating if this is changed
 
 # The version info for the project you're documenting, acts as replacement for
@@ -238,10 +238,10 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'cartopy.tex', u'Cartopy Introduction',
-   u'Philip Elson, Richard Hattersley', 'manual', False),
-  ('introductory_examples/index', 'cartopy_examples.tex', u'Cartopy examples',
-   u'Philip Elson, Richard Hattersley', 'manual', True)
+  ('index', 'cartopy.tex', 'Cartopy Introduction',
+   'Philip Elson, Richard Hattersley', 'manual', False),
+  ('introductory_examples/index', 'cartopy_examples.tex', 'Cartopy examples',
+   'Philip Elson, Richard Hattersley', 'manual', True)
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -270,8 +270,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'cartopy', u'cartopy Documentation',
-     [u'Philip Elson, Richard Hattersley'], 1)
+    ('index', 'cartopy', 'cartopy Documentation',
+     ['Philip Elson, Richard Hattersley'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -284,8 +284,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'cartopy', u'cartopy Documentation',
-   u'Philip Elson, Richard Hattersley', 'cartopy',
+  ('index', 'cartopy', 'cartopy Documentation',
+   'Philip Elson, Richard Hattersley', 'cartopy',
    'One line description of project.',
    'Miscellaneous'),
 ]
@@ -303,10 +303,10 @@ texinfo_documents = [
 # -- Options for Epub output ---------------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = u'cartopy'
-epub_author = u'Philip Elson, Richard Hattersley'
-epub_publisher = u'Philip Elson, Richard Hattersley'
-epub_copyright = u'2012, Philip Elson, Richard Hattersley'
+epub_title = 'cartopy'
+epub_author = 'Philip Elson, Richard Hattersley'
+epub_publisher = 'Philip Elson, Richard Hattersley'
+epub_copyright = '2012, Philip Elson, Richard Hattersley'
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.

--- a/docs/source/sphinxext/pre_sphinx_gallery.py
+++ b/docs/source/sphinxext/pre_sphinx_gallery.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Override sphinx_gallery's treatment of groups (folders) with cartopy's
 ``__tags__`` semantics. This is tightly bound to the sphinx_gallery
@@ -79,7 +78,7 @@ def example_groups(src_dir):
 
     for fname in sorted_listdir:
         fpath = os.path.join(src_dir, fname)
-        with open(fpath, 'r') as fh:
+        with open(fpath) as fh:
             for line in fh:
                 # Crudely extract the __tags__ line.
                 if line.startswith('__tags__ = '):
@@ -114,7 +113,7 @@ def order_examples(tagged_examples):
 
 def write_example(src_fpath, target_dir):
     target_fpath = os.path.join(target_dir, os.path.basename(src_fpath))
-    with open(src_fpath, 'r') as fh:
+    with open(src_fpath) as fh:
         with open(target_fpath, 'w') as fh_out:
             for line in fh:
                 # Crudely remove the __tags__ line.

--- a/lib/cartopy/__init__.py
+++ b/lib/cartopy/__init__.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/lib/cartopy/_epsg.py
+++ b/lib/cartopy/_epsg.py
@@ -8,7 +8,6 @@ Provide support for converting EPSG codes to Projection instances.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 import shapely.geometry as sgeom
@@ -48,7 +47,7 @@ class _EPSGProjection(ccrs.Projection):
                     other_terms.append([term[0], None])
                 else:
                     other_terms.append(term)
-        super(_EPSGProjection, self).__init__(other_terms, globe)
+        super().__init__(other_terms, globe)
 
         # Convert lat/lon bounds to projected bounds.
         # GML defines gmd:EX_GeographicBoundingBox as:

--- a/lib/cartopy/_version.py
+++ b/lib/cartopy/_version.py
@@ -91,9 +91,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False):
         if verbose:
             print("unable to find command, tried {}".format(commands))
         return None
-    stdout = p.communicate()[0].strip()
-    if sys.version_info[0] >= 3:
-        stdout = stdout.decode()
+    stdout = p.communicate()[0].strip().decode()
     if p.returncode != 0:
         if verbose:
             print("unable to run %s (error)" % dispcmd)

--- a/lib/cartopy/_version.py
+++ b/lib/cartopy/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -80,7 +79,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False):
                                  stderr=(subprocess.PIPE if hide_stderr
                                          else None))
             break
-        except EnvironmentError:
+        except OSError:
             e = sys.exc_info()[1]
             if e.errno == errno.ENOENT:
                 continue
@@ -90,7 +89,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False):
             return None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print("unable to find command, tried {}".format(commands))
         return None
     stdout = p.communicate()[0].strip()
     if sys.version_info[0] >= 3:
@@ -128,7 +127,7 @@ def git_get_keywords(versionfile_abs):
     # _version.py.
     keywords = {}
     try:
-        f = open(versionfile_abs, "r")
+        f = open(versionfile_abs)
         for line in f.readlines():
             if line.strip().startswith("git_refnames ="):
                 mo = re.search(r'=\s*"(.*)"', line)
@@ -139,7 +138,7 @@ def git_get_keywords(versionfile_abs):
                 if mo:
                     keywords["full"] = mo.group(1)
         f.close()
-    except EnvironmentError:
+    except OSError:
         pass
     return keywords
 
@@ -158,7 +157,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = {r[len(TAG):] for r in refs if r.startswith(TAG)}
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -167,7 +166,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = {r for r in refs if re.search(r'\d', r)}
         if verbose:
             print("discarding '%s', no digits" % ",".join(set(refs) - tags))
     if verbose:

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -10,7 +10,6 @@ between them.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 from abc import ABCMeta, abstractproperty
 import io
@@ -67,7 +66,7 @@ class RotatedGeodetic(CRS):
                         ('lon_0', 180 + pole_longitude),
                         ('to_meter', math.radians(1))]
         globe = globe or Globe(datum='WGS84')
-        super(RotatedGeodetic, self).__init__(proj4_params, globe=globe)
+        super().__init__(proj4_params, globe=globe)
 
 
 class Projection(CRS, metaclass=ABCMeta):
@@ -471,7 +470,7 @@ class Projection(CRS, metaclass=ABCMeta):
                 sys.stdout.write('+')
                 sys.stdout.flush()
                 print()
-                print('Processing: %s, %s' % (i, current_ls))
+                print('Processing: {}, {}'.format(i, current_ls))
 
             added_linestring = set()
             while True:
@@ -516,8 +515,8 @@ class Projection(CRS, metaclass=ABCMeta):
                     coords_to_append = list(line_to_append.coords)
 
                     # Build up the linestring.
-                    current_ls = sgeom.LineString((list(current_ls.coords) +
-                                                   coords_to_append))
+                    current_ls = sgeom.LineString(list(current_ls.coords) +
+                                                  coords_to_append)
 
                     # Catch getting stuck in an infinite loop by checking that
                     # linestring only added once.
@@ -647,7 +646,7 @@ class _RectangularProjection(Projection, metaclass=ABCMeta):
     def __init__(self, proj4_params, half_width, half_height, globe=None):
         self._half_width = half_width
         self._half_height = half_height
-        super(_RectangularProjection, self).__init__(proj4_params, globe=globe)
+        super().__init__(proj4_params, globe=globe)
 
     @property
     def boundary(self):
@@ -695,7 +694,7 @@ class PlateCarree(_CylindricalProjection):
         y_max = a_rad * 90
         # Set the threshold around 0.5 if the x max is 180.
         self._threshold = x_max / 360.
-        super(PlateCarree, self).__init__(proj4_params, x_max, y_max,
+        super().__init__(proj4_params, x_max, y_max,
                                           globe=globe)
 
     @property
@@ -747,8 +746,7 @@ class PlateCarree(_CylindricalProjection):
         return bbox, lon_0_offset
 
     def quick_vertices_transform(self, vertices, src_crs):
-        return_value = super(PlateCarree,
-                             self).quick_vertices_transform(vertices, src_crs)
+        return_value = super().quick_vertices_transform(vertices, src_crs)
 
         # Optimise the PlateCarree -> PlateCarree case where no
         # wrapping or interpolation needs to take place.
@@ -832,7 +830,7 @@ class TransverseMercator(Projection):
         else:
             if approx:
                 proj4_params += [('approx', None)]
-        super(TransverseMercator, self).__init__(proj4_params, globe=globe)
+        super().__init__(proj4_params, globe=globe)
 
     @property
     def threshold(self):
@@ -863,7 +861,7 @@ class OSGB(TransverseMercator):
                           'False after 0.18.',
                           stacklevel=2)
             approx = True
-        super(OSGB, self).__init__(central_longitude=-2, central_latitude=49,
+        super().__init__(central_longitude=-2, central_latitude=49,
                                    scale_factor=0.9996012717,
                                    false_easting=400000,
                                    false_northing=-100000,
@@ -895,7 +893,7 @@ class OSNI(TransverseMercator):
             approx = True
         globe = Globe(semimajor_axis=6377340.189,
                       semiminor_axis=6356034.447938534)
-        super(OSNI, self).__init__(central_longitude=-8,
+        super().__init__(central_longitude=-8,
                                    central_latitude=53.5,
                                    scale_factor=1.000035,
                                    false_easting=200000,
@@ -942,7 +940,7 @@ class UTM(Projection):
                         ('zone', zone)]
         if southern_hemisphere:
             proj4_params.append(('south', None))
-        super(UTM, self).__init__(proj4_params, globe=globe)
+        super().__init__(proj4_params, globe=globe)
 
     @property
     def boundary(self):
@@ -978,7 +976,7 @@ class EuroPP(UTM):
     """
     def __init__(self):
         globe = Globe(ellipse='intl')
-        super(EuroPP, self).__init__(32, globe=globe)
+        super().__init__(32, globe=globe)
 
     @property
     def x_limits(self):
@@ -1044,7 +1042,7 @@ class Mercator(Projection):
             else:
                 proj4_params.append(('k_0', scale_factor))
 
-        super(Mercator, self).__init__(proj4_params, globe=globe)
+        super().__init__(proj4_params, globe=globe)
 
         # Calculate limits.
         minlon, maxlon = self._determine_longitude_bounds(central_longitude)
@@ -1057,7 +1055,7 @@ class Mercator(Projection):
                               np.diff(self.y_limits)[0] / 360)
 
     def __eq__(self, other):
-        res = super(Mercator, self).__eq__(other)
+        res = super().__eq__(other)
         if hasattr(other, "_y_limits") and hasattr(other, "_x_limits"):
             res = res and self._y_limits == other._y_limits and \
                 self._x_limits == other._x_limits
@@ -1105,7 +1103,7 @@ class LambertCylindrical(_RectangularProjection):
     def __init__(self, central_longitude=0.0):
         proj4_params = [('proj', 'cea'), ('lon_0', central_longitude)]
         globe = Globe(semimajor_axis=math.degrees(1))
-        super(LambertCylindrical, self).__init__(proj4_params, 180,
+        super().__init__(proj4_params, 180,
                                                  math.degrees(1), globe=globe)
 
     @property
@@ -1179,7 +1177,7 @@ class LambertConformal(Projection):
         if n_parallels == 2:
             proj4_params.append(('lat_2', standard_parallels[1]))
 
-        super(LambertConformal, self).__init__(proj4_params, globe=globe)
+        super().__init__(proj4_params, globe=globe)
 
         # Compute whether this projection is at the "north pole" or the
         # "south pole" (after the central lon/lat have been taken into
@@ -1218,7 +1216,7 @@ class LambertConformal(Projection):
         self._y_limits = mins[1], maxs[1]
 
     def __eq__(self, other):
-        res = super(LambertConformal, self).__eq__(other)
+        res = super().__eq__(other)
         if hasattr(other, "cutoff"):
             res = res and self.cutoff == other.cutoff
         return res
@@ -1277,7 +1275,7 @@ class LambertAzimuthalEqualArea(Projection):
                         ('x_0', false_easting),
                         ('y_0', false_northing)]
 
-        super(LambertAzimuthalEqualArea, self).__init__(proj4_params,
+        super().__init__(proj4_params,
                                                         globe=globe)
 
         a = np.float(self.globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS)
@@ -1328,7 +1326,7 @@ class Miller(_RectangularProjection):
         proj4_params = [('proj', 'mill'), ('lon_0', central_longitude)]
         # See Snyder, 1987. Eqs (11-1) and (11-2) substituting maximums of
         # (lambda-lambda0)=180 and phi=90 to get limits.
-        super(Miller, self).__init__(proj4_params,
+        super().__init__(proj4_params,
                                      a * np.pi, a * 2.303412543376391,
                                      globe=globe)
 
@@ -1376,7 +1374,7 @@ class RotatedPole(_CylindricalProjection):
                         ('o_lat_p', pole_latitude),
                         ('lon_0', 180 + pole_longitude),
                         ('to_meter', math.radians(1))]
-        super(RotatedPole, self).__init__(proj4_params, 180, 90, globe=globe)
+        super().__init__(proj4_params, 180, 90, globe=globe)
 
     @property
     def threshold(self):
@@ -1390,7 +1388,7 @@ class Gnomonic(Projection):
                  central_longitude=0.0, globe=None):
         proj4_params = [('proj', 'gnom'), ('lat_0', central_latitude),
                         ('lon_0', central_longitude)]
-        super(Gnomonic, self).__init__(proj4_params, globe=globe)
+        super().__init__(proj4_params, globe=globe)
         self._max = 5e7
 
     @property
@@ -1454,7 +1452,7 @@ class Stereographic(Projection):
             else:
                 proj4_params.append(('k_0', scale_factor))
 
-        super(Stereographic, self).__init__(proj4_params, globe=globe)
+        super().__init__(proj4_params, globe=globe)
 
         # TODO: Let the globe return the semimajor axis always.
         a = np.float(self.globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS)
@@ -1494,7 +1492,7 @@ class Stereographic(Projection):
 class NorthPolarStereo(Stereographic):
     def __init__(self, central_longitude=0.0, true_scale_latitude=None,
                  globe=None):
-        super(NorthPolarStereo, self).__init__(
+        super().__init__(
             central_latitude=90,
             central_longitude=central_longitude,
             true_scale_latitude=true_scale_latitude,  # None is +90
@@ -1504,7 +1502,7 @@ class NorthPolarStereo(Stereographic):
 class SouthPolarStereo(Stereographic):
     def __init__(self, central_longitude=0.0, true_scale_latitude=None,
                  globe=None):
-        super(SouthPolarStereo, self).__init__(
+        super().__init__(
             central_latitude=-90,
             central_longitude=central_longitude,
             true_scale_latitude=true_scale_latitude,  # None is -90
@@ -1531,7 +1529,7 @@ class Orthographic(Projection):
 
         proj4_params = [('proj', 'ortho'), ('lon_0', central_longitude),
                         ('lat_0', central_latitude)]
-        super(Orthographic, self).__init__(proj4_params, globe=globe)
+        super().__init__(proj4_params, globe=globe)
 
         # TODO: Let the globe return the semimajor axis always.
         a = np.float(self.globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS)
@@ -1570,7 +1568,7 @@ class _WarpedRectangularProjection(Projection, metaclass=ABCMeta):
             proj4_params += [('x_0', false_easting)]
         if false_northing is not None:
             proj4_params += [('y_0', false_northing)]
-        super(_WarpedRectangularProjection, self).__init__(proj4_params,
+        super().__init__(proj4_params,
                                                            globe=globe)
 
         # Obtain boundary points
@@ -1637,7 +1635,7 @@ class _Eckert(_WarpedRectangularProjection, metaclass=ABCMeta):
         """
         proj4_params = [('proj', self._proj_name),
                         ('lon_0', central_longitude)]
-        super(_Eckert, self).__init__(proj4_params, central_longitude,
+        super().__init__(proj4_params, central_longitude,
                                       false_easting=false_easting,
                                       false_northing=false_northing,
                                       globe=globe)
@@ -1724,7 +1722,7 @@ class EckertVI(_Eckert):
 
 
 class EqualEarth(_WarpedRectangularProjection):
-    u"""
+    """
     An Equal Earth projection.
 
     This projection is pseudocylindrical, and equal area. Parallels are
@@ -1765,7 +1763,7 @@ class EqualEarth(_WarpedRectangularProjection):
                              .format('.'.join(str(v) for v in PROJ4_VERSION)))
 
         proj_params = [('proj', 'eqearth'), ('lon_0', central_longitude)]
-        super(EqualEarth, self).__init__(proj_params, central_longitude,
+        super().__init__(proj_params, central_longitude,
                                          false_easting=false_easting,
                                          false_northing=false_northing,
                                          globe=globe)
@@ -1809,7 +1807,7 @@ class Mollweide(_WarpedRectangularProjection):
 
         """
         proj4_params = [('proj', 'moll'), ('lon_0', central_longitude)]
-        super(Mollweide, self).__init__(proj4_params, central_longitude,
+        super().__init__(proj4_params, central_longitude,
                                         false_easting=false_easting,
                                         false_northing=false_northing,
                                         globe=globe)
@@ -1868,7 +1866,7 @@ class Robinson(_WarpedRectangularProjection):
                           stacklevel=2)
 
         proj4_params = [('proj', 'robin'), ('lon_0', central_longitude)]
-        super(Robinson, self).__init__(proj4_params, central_longitude,
+        super().__init__(proj4_params, central_longitude,
                                        false_easting=false_easting,
                                        false_northing=false_northing,
                                        globe=globe)
@@ -1894,7 +1892,7 @@ class Robinson(_WarpedRectangularProjection):
         if np.isnan(x) or np.isnan(y):
             result = (np.nan, np.nan)
         else:
-            result = super(Robinson, self).transform_point(x, y, src_crs)
+            result = super().transform_point(x, y, src_crs)
         return result
 
     def transform_points(self, src_crs, x, y, z=None):
@@ -1922,7 +1920,7 @@ class Robinson(_WarpedRectangularProjection):
             y[input_point_nans] = 0.0
             if z is not None:
                 z[input_point_nans] = 0.0
-        result = super(Robinson, self).transform_points(src_crs, x, y, z)
+        result = super().transform_points(src_crs, x, y, z)
         if handle_nans:
             # Result always has shape (N, 3).
             # Blank out each (whole) point where we had a NaN in the input.
@@ -1933,7 +1931,7 @@ class Robinson(_WarpedRectangularProjection):
 class InterruptedGoodeHomolosine(Projection):
     def __init__(self, central_longitude=0, globe=None):
         proj4_params = [('proj', 'igh'), ('lon_0', central_longitude)]
-        super(InterruptedGoodeHomolosine, self).__init__(proj4_params,
+        super().__init__(proj4_params,
                                                          globe=globe)
 
         minlon, maxlon = self._determine_longitude_bounds(central_longitude)
@@ -2019,7 +2017,7 @@ class _Satellite(Projection):
                         ('units', 'm')]
         if sweep_axis:
             proj4_params.append(('sweep', sweep_axis))
-        super(_Satellite, self).__init__(proj4_params, globe=globe)
+        super().__init__(proj4_params, globe=globe)
 
     def _set_boundary(self, coords):
         self._boundary = sgeom.LinearRing(coords.T)
@@ -2080,7 +2078,7 @@ class Geostationary(_Satellite):
             'x' should be used for GOES.
         """
 
-        super(Geostationary, self).__init__(
+        super().__init__(
             projection='geos',
             satellite_height=satellite_height,
             central_longitude=central_longitude,
@@ -2146,7 +2144,7 @@ class NearsidePerspective(_Satellite):
                 This projection does not handle elliptical globes.
 
         """
-        super(NearsidePerspective, self).__init__(
+        super().__init__(
             projection='nsper',
             satellite_height=satellite_height,
             central_longitude=central_longitude,
@@ -2210,7 +2208,7 @@ class AlbersEqualArea(Projection):
             except TypeError:
                 proj4_params.append(('lat_1', standard_parallels))
 
-        super(AlbersEqualArea, self).__init__(proj4_params, globe=globe)
+        super().__init__(proj4_params, globe=globe)
 
         # bounds
         minlon, maxlon = self._determine_longitude_bounds(central_longitude)
@@ -2298,7 +2296,7 @@ class AzimuthalEquidistant(Projection):
         proj4_params = [('proj', 'aeqd'), ('lon_0', central_longitude),
                         ('lat_0', central_latitude),
                         ('x_0', false_easting), ('y_0', false_northing)]
-        super(AzimuthalEquidistant, self).__init__(proj4_params, globe=globe)
+        super().__init__(proj4_params, globe=globe)
 
         # TODO: Let the globe return the semimajor axis always.
         a = np.float(self.globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS)
@@ -2357,7 +2355,7 @@ class Sinusoidal(Projection):
                         ('lon_0', central_longitude),
                         ('x_0', false_easting),
                         ('y_0', false_northing)]
-        super(Sinusoidal, self).__init__(proj4_params, globe=globe)
+        super().__init__(proj4_params, globe=globe)
 
         # Obtain boundary points
         minlon, maxlon = self._determine_longitude_bounds(central_longitude)
@@ -2448,7 +2446,7 @@ class EquidistantConic(Projection):
             except TypeError:
                 proj4_params.append(('lat_1', standard_parallels))
 
-        super(EquidistantConic, self).__init__(proj4_params, globe=globe)
+        super().__init__(proj4_params, globe=globe)
 
         # bounds
         n = 103
@@ -2488,7 +2486,7 @@ class EquidistantConic(Projection):
         return self._y_limits
 
 
-class _BoundaryPoint(object):
+class _BoundaryPoint:
     def __init__(self, distance, kind, data):
         """
         A representation for a geometric object which is
@@ -2511,8 +2509,9 @@ class _BoundaryPoint(object):
         self.data = data
 
     def __repr__(self):
-        return '_BoundaryPoint(%r, %r, %s)' % (self.distance, self.kind,
-                                               self.data)
+        return '_BoundaryPoint({!r}, {!r}, {})'.format(
+            self.distance, self.kind, self.data
+        )
 
 
 def _find_first_ge(a, x):

--- a/lib/cartopy/examples/eyja_volcano.py
+++ b/lib/cartopy/examples/eyja_volcano.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Map tile acquisition
 --------------------
@@ -44,7 +43,7 @@ def main():
     text_transform = offset_copy(geodetic_transform, units='dots', x=-25)
 
     # Add text 25 pixels to the left of the volcano.
-    ax.text(-19.613333, 63.62, u'Eyjafjallajökull',
+    ax.text(-19.613333, 63.62, 'Eyjafjallajökull',
             verticalalignment='center', horizontalalignment='right',
             transform=text_transform,
             bbox=dict(facecolor='sandybrown', alpha=0.5, boxstyle='round'))

--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -10,7 +10,6 @@ ax.add_feature().
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 from abc import ABCMeta, abstractmethod
 
@@ -112,7 +111,7 @@ class Feature(metaclass=ABCMeta):
             return self.geometries()
 
 
-class Scaler(object):
+class Scaler:
     """
     General object for handling the scale of the geometries used in a Feature.
     """
@@ -168,7 +167,7 @@ class AdaptiveScaler(Scaler):
         'fine'
 
         """
-        super(AdaptiveScaler, self).__init__(default_scale)
+        super().__init__(default_scale)
         self._default_scale = default_scale
         # Upper limit on extent in degrees.
         self._limits = limits
@@ -216,7 +215,7 @@ class ShapelyFeature(Feature):
             Keyword arguments to be used when drawing this feature.
 
         """
-        super(ShapelyFeature, self).__init__(crs, **kwargs)
+        super().__init__(crs, **kwargs)
         self._geoms = tuple(geometries)
 
     def geometries(self):
@@ -249,7 +248,7 @@ class NaturalEarthFeature(Feature):
             Keyword arguments to be used when drawing this feature.
 
         """
-        super(NaturalEarthFeature, self).__init__(cartopy.crs.PlateCarree(),
+        super().__init__(cartopy.crs.PlateCarree(),
                                                   **kwargs)
         self.category = category
         self.name = name
@@ -298,7 +297,7 @@ class NaturalEarthFeature(Feature):
         If extent is None, the method returns all geometries for this dataset.
         """
         self.scaler.scale_from_extent(extent)
-        return super(NaturalEarthFeature, self).intersecting_geometries(extent)
+        return super().intersecting_geometries(extent)
 
     def with_scale(self, new_scale):
         """
@@ -350,7 +349,7 @@ class GSHHSFeature(Feature):
 
     """
     def __init__(self, scale='auto', levels=None, **kwargs):
-        super(GSHHSFeature, self).__init__(cartopy.crs.PlateCarree(), **kwargs)
+        super().__init__(cartopy.crs.PlateCarree(), **kwargs)
 
         if scale not in ('auto', 'a', 'coarse', 'c', 'low', 'l',
                          'intermediate', 'i', 'high', 'h', 'full', 'f'):
@@ -455,7 +454,7 @@ class WFSFeature(Feature):
 
         self.source = WFSGeometrySource(wfs, features)
         crs = self.source.default_projection()
-        super(WFSFeature, self).__init__(crs, **kwargs)
+        super().__init__(crs, **kwargs)
         # Default kwargs
         self._kwargs.setdefault('edgecolor', 'black')
         self._kwargs.setdefault('facecolor', 'none')

--- a/lib/cartopy/feature/nightshade.py
+++ b/lib/cartopy/feature/nightshade.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import datetime
 
@@ -45,7 +44,7 @@ class Nightshade(ShapelyFeature):
 
         # make sure date is UTC, or naive with respect to time zones
         if date.utcoffset():
-            raise ValueError('datetime instance must be UTC, not {0}'.format(
+            raise ValueError('datetime instance must be UTC, not {}'.format(
                              date.tzname()))
 
         # Returns the Greenwich hour angle,
@@ -93,7 +92,7 @@ class Nightshade(ShapelyFeature):
         kwargs.setdefault('alpha', alpha)
 
         geom = sgeom.Polygon(np.column_stack((x, y)))
-        return super(Nightshade, self).__init__(
+        return super().__init__(
             [geom], rotated_pole, **kwargs)
 
 

--- a/lib/cartopy/geodesic/__init__.py
+++ b/lib/cartopy/geodesic/__init__.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 # NOTE: noqa for flake8 = unused import
 from cartopy.geodesic._geodesic import Geodesic  # noqa: F401

--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -9,7 +9,6 @@ transformations.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 try:

--- a/lib/cartopy/io/__init__.py
+++ b/lib/cartopy/io/__init__.py
@@ -10,7 +10,6 @@ various data formats.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import collections
 import os
@@ -66,7 +65,7 @@ class DownloadWarning(Warning):
     pass
 
 
-class Downloader(object):
+class Downloader:
     """
     Represents a resource, that can be configured easily, which knows
     how to acquire itself (perhaps via HTTP).
@@ -309,7 +308,7 @@ class LocatedImage(collections.namedtuple('LocatedImage', 'image, extent')):
     """
 
 
-class RasterSource(object):
+class RasterSource:
     """
     Define the cartopy raster fetching interface.
 
@@ -409,11 +408,11 @@ class PostprocessedRasterSource(RasterSourceContainer):
             return a single LocatedImage.
 
         """
-        super(PostprocessedRasterSource, self).__init__(contained_source)
+        super().__init__(contained_source)
         self._post_fetch_fn = img_post_process
 
     def fetch_raster(self, *args, **kwargs):
-        fetch_raster = super(PostprocessedRasterSource, self).fetch_raster
+        fetch_raster = super().fetch_raster
         located_imgs = fetch_raster(*args, **kwargs)
         if located_imgs:
             located_imgs = [self._post_fetch_fn(img) for img in located_imgs]

--- a/lib/cartopy/io/img_nest.py
+++ b/lib/cartopy/io/img_nest.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import collections
 import glob
@@ -31,7 +30,7 @@ class Img(collections.namedtuple('Img', _img_class_attrs)):
             if isinstance(item, list):
                 item = tuple(item)
             new_kwargs[k] = item
-        return super(Img, cls).__new__(cls, *new_args, **new_kwargs)
+        return super().__new__(cls, *new_args, **new_kwargs)
 
     def __init__(self, *args, **kwargs):
         """
@@ -188,7 +187,7 @@ class Img(collections.namedtuple('Img', _img_class_attrs)):
         return (min_x, max_x, min_y, max_y), pix_size
 
 
-class ImageCollection(object):
+class ImageCollection:
     def __init__(self, name, crs, images=None):
         """
         Represents a collection of images at the same logical level.
@@ -247,7 +246,7 @@ class ImageCollection(object):
             self.images.append(img_class.from_world_file(img, fworld))
 
 
-class NestedImageCollection(object):
+class NestedImageCollection:
     def __init__(self, name, crs, collections, _ancestry=None):
         """
         Represents a complex nest of ImageCollections.
@@ -274,7 +273,7 @@ class NestedImageCollection(object):
 
         """
         # NOTE: all collections must have the same crs.
-        _names = set([collection.name for collection in collections])
+        _names = {collection.name for collection in collections}
         assert len(_names) == len(collections), \
             'The collections must have unique names.'
 
@@ -362,7 +361,7 @@ class NestedImageCollection(object):
         for tile in self.find_images(target_domain, target_z):
             try:
                 img, extent, origin = self.get_image(tile)
-            except IOError:
+            except OSError:
                 continue
 
             img = np.array(img)
@@ -425,10 +424,9 @@ class NestedImageCollection(object):
                     yield start_tile
                 else:
                     for tile in self.subtiles(start_tile):
-                        for result in self.find_images(target_domain,
-                                                       target_z,
-                                                       start_tiles=[tile]):
-                            yield result
+                        yield from self.find_images(target_domain,
+                                                    target_z,
+                                                    start_tiles=[tile])
 
     def subtiles(self, collection_image):
         """

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -17,7 +17,6 @@ using tiles in this way can be found at the
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 from abc import ABCMeta, abstractmethod
 import concurrent.futures
@@ -57,7 +56,7 @@ class GoogleWTS(metaclass=ABCMeta):
         def fetch_tile(tile):
             try:
                 img, extent, origin = self.get_image(tile)
-            except IOError:
+            except OSError:
                 # Some services 404 for tiles that aren't supposed to be
                 # there (e.g. out of range).
                 raise
@@ -75,7 +74,7 @@ class GoogleWTS(metaclass=ABCMeta):
                 try:
                     img, x, y, origin = future.result()
                     tiles.append([img, x, y, origin])
-                except IOError:
+                except OSError:
                     pass
 
         img, extent, origin = _merge_tiles(tiles)
@@ -96,9 +95,8 @@ class GoogleWTS(metaclass=ABCMeta):
                 yield start_tile
             else:
                 for tile in self._subtiles(start_tile):
-                    for result in self._find_images(target_domain, target_z,
-                                                    start_tile=tile):
-                        yield result
+                    yield from self._find_images(target_domain, target_z,
+                                                 start_tile=tile)
 
     find_images = _find_images
 
@@ -222,7 +220,7 @@ World_Shaded_Relief/MapServer/tile/{z}/{y}/{x}.jpg'``
                 not Image.core.jpeg_decoder:
             msg = "The '%s' style requires pillow with jpeg decoding support."
             raise ValueError(msg % self.style)
-        return super(GoogleTiles, self).__init__(
+        return super().__init__(
             desired_tile_form=desired_tile_form)
 
     def _image_url(self, tile):
@@ -246,7 +244,7 @@ class MapQuestOSM(GoogleWTS):
     # this now requires a sign up to a plan
     def _image_url(self, tile):
         x, y, z = tile
-        url = 'https://otile1.mqcdn.com/tiles/1.0.0/osm/%s/%s/%s.jpg' % (
+        url = 'https://otile1.mqcdn.com/tiles/1.0.0/osm/{}/{}/{}.jpg'.format(
             z, x, y)
         mqdevurl = ('https://devblog.mapquest.com/2016/06/15/'
                     'modernization-of-mapquest-results-in-changes'
@@ -263,7 +261,7 @@ class MapQuestOpenAerial(GoogleWTS):
     #  Farm Service Agency"
     def _image_url(self, tile):
         x, y, z = tile
-        url = 'https://oatile1.mqcdn.com/tiles/1.0.0/sat/%s/%s/%s.jpg' % (
+        url = 'https://oatile1.mqcdn.com/tiles/1.0.0/sat/{}/{}/{}.jpg'.format(
             z, x, y)
         return url
 
@@ -273,7 +271,7 @@ class OSM(GoogleWTS):
 
     def _image_url(self, tile):
         x, y, z = tile
-        url = 'https://a.tile.openstreetmap.org/%s/%s/%s.png' % (z, x, y)
+        url = 'https://a.tile.openstreetmap.org/{}/{}/{}.png'.format(z, x, y)
         return url
 
 
@@ -298,7 +296,7 @@ class Stamen(GoogleWTS):
 
     """
     def __init__(self, style='toner', desired_tile_form='RGB'):
-        super(Stamen, self).__init__(desired_tile_form=desired_tile_form)
+        super().__init__(desired_tile_form=desired_tile_form)
         self.style = style
 
     def _image_url(self, tile):
@@ -341,7 +339,7 @@ class StamenTerrain(Stamen):
         # NOTE: This subclass of Stamen exists for legacy reasons.
         # No further Stamen subclasses will be accepted as
         # they can easily be created in user code with Stamen(style_name).
-        return super(StamenTerrain, self).__init__(style='terrain-background')
+        return super().__init__(style='terrain-background')
 
 
 class MapboxTiles(GoogleWTS):
@@ -369,7 +367,7 @@ class MapboxTiles(GoogleWTS):
         """
         self.access_token = access_token
         self.map_id = map_id
-        super(MapboxTiles, self).__init__()
+        super().__init__()
 
     def _image_url(self, tile):
         x, y, z = tile
@@ -412,7 +410,7 @@ class MapboxStyleTiles(GoogleWTS):
         self.access_token = access_token
         self.username = username
         self.map_id = map_id
-        super(MapboxStyleTiles, self).__init__()
+        super().__init__()
 
     def _image_url(self, tile):
         x, y, z = tile
@@ -542,7 +540,7 @@ class OrdnanceSurvey(GoogleWTS):
         desired_tile_form: optional
             Defaults to 'RGB'.
         """
-        super(OrdnanceSurvey, self).__init__(
+        super().__init__(
             desired_tile_form=desired_tile_form)
         self.apikey = apikey
 

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -17,7 +17,6 @@ this way can be found at :ref:`sphx_glr_gallery_wmts.py`.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import collections
 import io
@@ -409,9 +408,9 @@ class WMTSRasterSource(RasterSource):
                         break
                 if matrix_set_name is None:
                     # Fail completely.
-                    available_urns = sorted(set(
+                    available_urns = sorted({
                         self.wmts.tilematrixsets[name].crs
-                        for name in matrix_set_names))
+                        for name in matrix_set_names})
                     msg = 'Unable to find tile matrix for projection.'
                     msg += '\n    Projection: ' + str(target_projection)
                     msg += '\n    Available tile CRS URNs:'
@@ -624,7 +623,7 @@ class WMTSRasterSource(RasterSource):
         return big_img, img_extent
 
 
-class WFSGeometrySource(object):
+class WFSGeometrySource:
     """Web Feature Service (WFS) retrieval for Cartopy."""
 
     def __init__(self, service, features, getfeature_extra_kwargs=None):
@@ -675,8 +674,8 @@ class WFSGeometrySource(object):
         """
         # Using first element in crsOptions (default).
         if self._default_urn is None:
-            default_urn = set(self.service.contents[feature].crsOptions[0] for
-                              feature in self.features)
+            default_urn = {self.service.contents[feature].crsOptions[0] for
+                           feature in self.features}
             if len(default_urn) != 1:
                 ValueError('Failed to find a single common default SRS '
                            'across all features (typenames).')

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -28,7 +28,6 @@ geometry representation of shapely:
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import glob
 import io
@@ -50,7 +49,7 @@ except ImportError:
 __all__ = ['Reader', 'Record']
 
 
-class Record(object):
+class Record:
     """
     A single logical entry from a shapefile, combining the attributes with
     their associated geometry.
@@ -74,10 +73,14 @@ class Record(object):
         self._fields = fields
 
     def __repr__(self):
-        return '<Record: %r, %r, <fields>>' % (self.geometry, self.attributes)
+        return '<Record: {!r}, {!r}, <fields>>'.format(
+            self.geometry, self.attributes
+        )
 
     def __str__(self):
-        return 'Record(%s, %s, <fields>)' % (self.geometry, self.attributes)
+        return 'Record({}, {}, <fields>)'.format(
+            self.geometry, self.attributes
+        )
 
     @property
     def bounds(self):
@@ -116,7 +119,7 @@ class FionaRecord(Record):
         self._bounds = geometry.bounds
 
 
-class BasicReader(object):
+class BasicReader:
     """
     Provide an interface for accessing the contents of a shapefile.
 
@@ -171,7 +174,7 @@ class BasicReader(object):
             yield Record(shape_record.shape, attributes, fields)
 
 
-class FionaReader(object):
+class FionaReader:
     """
     Provides an interface for accessing the contents of a shapefile
     with the fiona library, which has a much faster reader than pyshp.
@@ -418,7 +421,7 @@ class GSHHSShpDownloader(Downloader):
                  url_template=_GSHHS_URL_TEMPLATE,
                  target_path_template=None,
                  pre_downloaded_path_template=''):
-        super(GSHHSShpDownloader, self).__init__(url_template,
+        super().__init__(url_template,
                                                  target_path_template,
                                                  pre_downloaded_path_template)
 

--- a/lib/cartopy/io/srtm.py
+++ b/lib/cartopy/io/srtm.py
@@ -14,7 +14,6 @@ database of Earth prior to the release of the ASTER GDEM in 2009.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import io
 import os
@@ -194,7 +193,7 @@ class SRTM3Source(_SRTMSource):
             producing a taller composite for this RasterSource.
 
         """
-        super(SRTM3Source, self).__init__(resolution=3, downloader=downloader,
+        super().__init__(resolution=3, downloader=downloader,
                                           max_nx=max_nx, max_ny=max_ny)
 
 
@@ -221,7 +220,7 @@ class SRTM1Source(_SRTMSource):
             producing a taller composite for this RasterSource.
 
         """
-        super(SRTM1Source, self).__init__(resolution=1, downloader=downloader,
+        super().__init__(resolution=1, downloader=downloader,
                                           max_nx=max_nx, max_ny=max_ny)
 
 
@@ -432,7 +431,7 @@ class SRTMDownloader(Downloader):
 
         if SRTMDownloader._SRTM_LOOKUP_MASK[lon, colat]:
             return (SRTMDownloader._SRTM_BASE_URL +
-                    u'{y}{x}.SRTMGL{resolution}.hgt.zip').format(**format_dict)
+                    '{y}{x}.SRTMGL{resolution}.hgt.zip').format(**format_dict)
         else:
             return None
 
@@ -448,7 +447,7 @@ class SRTMDownloader(Downloader):
         srtm_online = self._urlopen(url)
         zfh = ZipFile(io.BytesIO(srtm_online.read()), 'r')
 
-        zip_member_path = u'{y}{x}.hgt'.format(**format_dict)
+        zip_member_path = '{y}{x}.hgt'.format(**format_dict)
         member = zfh.getinfo(zip_member_path)
         with open(target_path, 'wb') as fh:
             fh.write(zfh.open(member).read())

--- a/lib/cartopy/mpl/__init__.py
+++ b/lib/cartopy/mpl/__init__.py
@@ -4,4 +4,3 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)

--- a/lib/cartopy/mpl/clip_path.py
+++ b/lib/cartopy/mpl/clip_path.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import warnings
 

--- a/lib/cartopy/mpl/contour.py
+++ b/lib/cartopy/mpl/contour.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 from matplotlib.contour import QuadContourSet
 import matplotlib.path as mpath
@@ -91,4 +90,4 @@ class GeoContourSet(QuadContourSet):
 
         # Now that we have prepared the collection paths, call on
         # through to the underlying implementation.
-        super(GeoContourSet, self).clabel(*args, **kwargs)
+        super().clabel(*args, **kwargs)

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -10,7 +10,6 @@ This module defines the :class:`FeatureArtist` class, for drawing
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 from collections import OrderedDict
 import warnings
@@ -24,7 +23,7 @@ import cartopy.mpl.patch as cpatch
 from .style import merge as style_merge, finalize as style_finalize
 
 
-class _GeomKey(object):
+class _GeomKey:
     """
     Provide id() based equality and hashing for geometries.
 
@@ -101,7 +100,7 @@ class FeatureArtist(matplotlib.artist.Artist):
             will override those shared with the feature.
 
         """
-        super(FeatureArtist, self).__init__()
+        super().__init__()
 
         if kwargs is None:
             kwargs = {}

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -12,7 +12,6 @@ plot results from source coordinates to the GeoAxes' target projection.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import collections
 import contextlib
@@ -233,7 +232,7 @@ class InterProjectionTransform(mtransforms.Transform):
 class _ViewClippedPathPatch(mpatches.PathPatch):
     def __init__(self, axes, **kwargs):
         self._original_path = mpath.Path(np.empty((0, 2)))
-        super(_ViewClippedPathPatch, self).__init__(self._original_path,
+        super().__init__(self._original_path,
                                                     **kwargs)
         self._axes = axes
 
@@ -249,14 +248,14 @@ class _ViewClippedPathPatch(mpatches.PathPatch):
     @matplotlib.artist.allow_rasterization
     def draw(self, renderer, *args, **kwargs):
         self._adjust_location()
-        super(_ViewClippedPathPatch, self).draw(renderer, *args, **kwargs)
+        super().draw(renderer, *args, **kwargs)
 
 
 class GeoSpine(mspines.Spine):
     def __init__(self, axes, **kwargs):
         self._original_path = mpath.Path(np.empty((0, 2)))
         kwargs.setdefault('clip_on', False)
-        super(GeoSpine, self).__init__(axes, 'geo', self._original_path,
+        super().__init__(axes, 'geo', self._original_path,
                                        **kwargs)
         self.set_capstyle('butt')
 
@@ -273,12 +272,12 @@ class GeoSpine(mspines.Spine):
         # make sure the location is updated so that transforms etc are
         # correct:
         self._adjust_location()
-        return super(GeoSpine, self).get_window_extent(renderer=renderer)
+        return super().get_window_extent(renderer=renderer)
 
     @matplotlib.artist.allow_rasterization
     def draw(self, renderer):
         self._adjust_location()
-        ret = super(GeoSpine, self).draw(renderer)
+        ret = super().draw(renderer)
         self.stale = False
         return ret
 
@@ -346,7 +345,7 @@ class GeoAxes(matplotlib.axes.Axes):
         self.projection = kwargs.pop('map_projection')
         """The :class:`cartopy.crs.Projection` of this GeoAxes."""
 
-        super(GeoAxes, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._gridliners = []
         self.img_factories = []
         self._done_img_factory = False
@@ -404,7 +403,7 @@ class GeoAxes(matplotlib.axes.Axes):
             # Args and kwargs not allowed.
             assert not bool(args) and not bool(kwargs)
             image = factory
-            super(GeoAxes, self).add_image(image)
+            super().add_image(image)
             return image
 
     @contextlib.contextmanager
@@ -903,7 +902,7 @@ class GeoAxes(matplotlib.axes.Axes):
         # Switch on drawing of x axis
         self.xaxis.set_visible(True)
 
-        return super(GeoAxes, self).set_xticks(xticks, minor=minor)
+        return super().set_xticks(xticks, minor=minor)
 
     def set_yticks(self, ticks, minor=False, crs=None):
         """
@@ -950,7 +949,7 @@ class GeoAxes(matplotlib.axes.Axes):
         # Switch on drawing of y axis
         self.yaxis.set_visible(True)
 
-        return super(GeoAxes, self).set_yticks(yticks, minor=minor)
+        return super().set_yticks(yticks, minor=minor)
 
     def stock_img(self, name='ne_shaded'):
         """
@@ -1123,7 +1122,7 @@ class GeoAxes(matplotlib.axes.Axes):
                                  'raster', 'natural_earth')
         json_file = os.path.join(bgdir, 'images.json')
 
-        with open(json_file, 'r') as js_obj:
+        with open(json_file) as js_obj:
             dict_in = json.load(js_obj)
         for img_type in dict_in:
             _USER_BG_IMGS[img_type] = dict_in[img_type]

--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import operator
 import warnings
@@ -27,7 +26,7 @@ degree_locator = mticker.MaxNLocator(nbins=9, steps=[1, 1.5, 1.8, 2, 3, 6, 10])
 classic_locator = mticker.MaxNLocator(nbins=9)
 classic_formatter = mticker.ScalarFormatter
 
-_DEGREE_SYMBOL = u'\u00B0'
+_DEGREE_SYMBOL = '\u00B0'
 _X_INLINE_PROJS = (
     cartopy.crs.InterruptedGoodeHomolosine,
     cartopy.crs.LambertConformal,
@@ -78,14 +77,14 @@ def _lat_hemisphere(latitude):
 
 
 def _east_west_formatted(longitude, num_format='g'):
-    fmt_string = u'{longitude:{num_format}}{degree}{hemisphere}'
+    fmt_string = '{longitude:{num_format}}{degree}{hemisphere}'
     return fmt_string.format(longitude=abs(longitude), num_format=num_format,
                              hemisphere=_lon_hemisphere(longitude),
                              degree=_DEGREE_SYMBOL)
 
 
 def _north_south_formatted(latitude, num_format='g'):
-    fmt_string = u'{latitude:{num_format}}{degree}{hemisphere}'
+    fmt_string = '{latitude:{num_format}}{degree}{hemisphere}'
     return fmt_string.format(latitude=abs(latitude), num_format=num_format,
                              hemisphere=_lat_hemisphere(latitude),
                              degree=_DEGREE_SYMBOL)
@@ -99,7 +98,7 @@ LATITUDE_FORMATTER = mticker.FuncFormatter(lambda v, pos:
                                            _north_south_formatted(v))
 
 
-class Gridliner(object):
+class Gridliner:
     # NOTE: In future, one of these objects will be add-able to a GeoAxes (and
     # maybe even a plain old mpl axes) and it will call the "_draw_gridliner"
     # method on draw. This will enable automatic gridline resolution

--- a/lib/cartopy/mpl/patch.py
+++ b/lib/cartopy/mpl/patch.py
@@ -15,7 +15,6 @@ and `Matplotlib Path API <https://matplotlib.org/api/path_api.html>`_.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 import matplotlib

--- a/lib/cartopy/mpl/slippy_image_artist.py
+++ b/lib/cartopy/mpl/slippy_image_artist.py
@@ -10,7 +10,6 @@ dragging and zooming of raster data.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 from matplotlib.image import AxesImage
 import matplotlib.artist
@@ -31,7 +30,7 @@ class SlippyImageArtist(AxesImage):
         if matplotlib.__version__ >= '3':
             # This artist fills the Axes, so should not influence layout.
             kwargs.setdefault('in_layout', False)
-        super(SlippyImageArtist, self).__init__(ax, **kwargs)
+        super().__init__(ax, **kwargs)
         self.cache = []
 
         ax.figure.canvas.mpl_connect('button_press_event', self.on_press)
@@ -67,7 +66,7 @@ class SlippyImageArtist(AxesImage):
             self.set_array(img)
             with ax.hold_limits():
                 self.set_extent(extent)
-            super(SlippyImageArtist, self).draw(renderer, *args, **kwargs)
+            super().draw(renderer, *args, **kwargs)
 
     def can_composite(self):
         # As per https://github.com/SciTools/cartopy/issues/689, disable

--- a/lib/cartopy/mpl/style.py
+++ b/lib/cartopy/mpl/style.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 """
 Handles matplotlib styling in a single consistent place.

--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -5,7 +5,6 @@
 # licensing details.
 """This module contains tools for handling tick marks in cartopy."""
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from matplotlib.ticker import Formatter, MaxNLocator
@@ -23,9 +22,9 @@ class _PlateCarreeFormatter(Formatter):
 
     _target_projection = ccrs.PlateCarree()
 
-    def __init__(self, degree_symbol=u'\u00B0', number_format='g',
+    def __init__(self, degree_symbol='\u00B0', number_format='g',
                  transform_precision=1e-8, dms=False,
-                 minute_symbol=u"'", second_symbol=u"''",
+                 minute_symbol="'", second_symbol="''",
                  seconds_number_format='g',
                  auto_hide=True):
         """
@@ -85,7 +84,7 @@ class _PlateCarreeFormatter(Formatter):
         value, deg, mn, sec = self._get_dms(abs(value))
 
         # Format
-        label = u''
+        label = ''
         if sec:
             label = self._format_seconds(sec)
 
@@ -150,20 +149,20 @@ class _PlateCarreeFormatter(Formatter):
             number_format = 'd'
         else:
             number_format = self._degrees_number_format
-        return u'{value:{number_format}}{symbol}'.format(
+        return '{value:{number_format}}{symbol}'.format(
             value=abs(deg),
             number_format=number_format,
             symbol=self._degree_symbol)
 
     def _format_minutes(self, mn):
         """Format minutes as an integer"""
-        return u'{value:d}{symbol}'.format(
+        return '{value:d}{symbol}'.format(
             value=int(mn),
             symbol=self._minute_symbol)
 
     def _format_seconds(self, sec):
         """Format seconds as an float"""
-        return u'{value:{fmt}}{symbol}'.format(
+        return '{value:{fmt}}{symbol}'.format(
             value=sec,
             fmt=self._seconds_num_format,
             symbol=self._second_symbol)
@@ -191,9 +190,9 @@ class _PlateCarreeFormatter(Formatter):
 
 class LatitudeFormatter(_PlateCarreeFormatter):
     """Tick formatter for latitude axes."""
-    def __init__(self, degree_symbol=u'\u00B0', number_format='g',
+    def __init__(self, degree_symbol='\u00B0', number_format='g',
                  transform_precision=1e-8, dms=False,
-                 minute_symbol=u"'", second_symbol=u"''",
+                 minute_symbol="'", second_symbol="''",
                  seconds_number_format='g', auto_hide=True,
                  ):
         """
@@ -265,7 +264,7 @@ class LatitudeFormatter(_PlateCarreeFormatter):
             labels = [lat_formatter(value) for value in ticks]
 
         """
-        super(LatitudeFormatter, self).__init__(
+        super().__init__(
             degree_symbol=degree_symbol,
             number_format=number_format,
             transform_precision=transform_precision,
@@ -295,12 +294,12 @@ class LongitudeFormatter(_PlateCarreeFormatter):
     def __init__(self,
                  zero_direction_label=False,
                  dateline_direction_label=False,
-                 degree_symbol=u'\u00B0',
+                 degree_symbol='\u00B0',
                  number_format='g',
                  transform_precision=1e-8,
                  dms=False,
-                 minute_symbol=u"'",
-                 second_symbol=u"''",
+                 minute_symbol="'",
+                 second_symbol="''",
                  seconds_number_format='g',
                  auto_hide=True,
                  ):
@@ -381,7 +380,7 @@ class LongitudeFormatter(_PlateCarreeFormatter):
             lon_formatter.set_locs(ticks)
             labels = [lon_formatter(value) for value in ticks]
         """
-        super(LongitudeFormatter, self).__init__(
+        super().__init__(
             degree_symbol=degree_symbol,
             number_format=number_format,
             transform_precision=transform_precision,

--- a/lib/cartopy/sphinxext/__init__.py
+++ b/lib/cartopy/sphinxext/__init__.py
@@ -4,4 +4,3 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)

--- a/lib/cartopy/sphinxext/summarise_package.py
+++ b/lib/cartopy/sphinxext/summarise_package.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import inspect
 import itertools

--- a/lib/cartopy/tests/__init__.py
+++ b/lib/cartopy/tests/__init__.py
@@ -4,4 +4,3 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)

--- a/lib/cartopy/tests/conftest.py
+++ b/lib/cartopy/tests/conftest.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 
 def pytest_configure(config):

--- a/lib/cartopy/tests/crs/__init__.py
+++ b/lib/cartopy/tests/crs/__init__.py
@@ -8,7 +8,6 @@ Tests for specific Cartopy CRS subclasses.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import pytest
 

--- a/lib/cartopy/tests/crs/helpers.py
+++ b/lib/cartopy/tests/crs/helpers.py
@@ -8,7 +8,6 @@ Helpers for Cartopy CRS subclass tests.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 
 def check_proj_params(name, crs, other_args):

--- a/lib/cartopy/tests/crs/test_albers_equal_area.py
+++ b/lib/cartopy/tests/crs/test_albers_equal_area.py
@@ -8,7 +8,6 @@ Tests for the Albers Equal Area coordinate system.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
@@ -18,7 +17,7 @@ import cartopy.crs as ccrs
 from .helpers import check_proj_params
 
 
-class TestAlbersEqualArea(object):
+class TestAlbersEqualArea:
     def test_default(self):
         aea = ccrs.AlbersEqualArea()
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',

--- a/lib/cartopy/tests/crs/test_azimuthal_equidistant.py
+++ b/lib/cartopy/tests/crs/test_azimuthal_equidistant.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
@@ -13,7 +12,7 @@ import cartopy.crs as ccrs
 from .helpers import check_proj_params
 
 
-class TestAzimuthalEquidistant(object):
+class TestAzimuthalEquidistant:
     def test_default(self):
         aeqd = ccrs.AzimuthalEquidistant()
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',

--- a/lib/cartopy/tests/crs/test_eckert.py
+++ b/lib/cartopy/tests/crs/test_eckert.py
@@ -8,7 +8,6 @@ Tests for the Eckert family of coordinate systems.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal

--- a/lib/cartopy/tests/crs/test_equal_earth.py
+++ b/lib/cartopy/tests/crs/test_equal_earth.py
@@ -8,7 +8,6 @@ Tests for the Equal Earth coordinate system.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal

--- a/lib/cartopy/tests/crs/test_equidistant_conic.py
+++ b/lib/cartopy/tests/crs/test_equidistant_conic.py
@@ -8,7 +8,6 @@ Tests for the Equidistant Conic coordinate system.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
@@ -18,7 +17,7 @@ import cartopy.crs as ccrs
 from .helpers import check_proj_params
 
 
-class TestEquidistantConic(object):
+class TestEquidistantConic:
     def test_default(self):
         eqdc = ccrs.EquidistantConic()
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',

--- a/lib/cartopy/tests/crs/test_geostationary.py
+++ b/lib/cartopy/tests/crs/test_geostationary.py
@@ -8,7 +8,6 @@ Tests for the Geostationary projection.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 from numpy.testing import assert_almost_equal
 
@@ -16,7 +15,7 @@ import cartopy.crs as ccrs
 from .helpers import check_proj_params
 
 
-class TestGeostationary(object):
+class TestGeostationary:
     test_class = ccrs.Geostationary
     expected_proj_name = 'geos'
 

--- a/lib/cartopy/tests/crs/test_gnomonic.py
+++ b/lib/cartopy/tests/crs/test_gnomonic.py
@@ -8,7 +8,6 @@ Tests for the Gnomonic coordinate system.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal

--- a/lib/cartopy/tests/crs/test_interrupted_goode_homolosine.py
+++ b/lib/cartopy/tests/crs/test_interrupted_goode_homolosine.py
@@ -8,7 +8,6 @@ Tests for the InterruptedGoodeHomolosine coordinate system.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal

--- a/lib/cartopy/tests/crs/test_lambert_azimuthal_equal_area.py
+++ b/lib/cartopy/tests/crs/test_lambert_azimuthal_equal_area.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal
@@ -14,7 +13,7 @@ import cartopy.crs as ccrs
 from .helpers import check_proj_params
 
 
-class TestLambertAzimuthalEqualArea(object):
+class TestLambertAzimuthalEqualArea:
     def test_default(self):
         crs = ccrs.LambertAzimuthalEqualArea()
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'x_0=0.0',

--- a/lib/cartopy/tests/crs/test_lambert_conformal.py
+++ b/lib/cartopy/tests/crs/test_lambert_conformal.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 from numpy.testing import assert_array_almost_equal
 import pytest
@@ -53,7 +52,7 @@ def test_specific_lambert():
     check_proj_params('lcc', crs, other_args)
 
 
-class Test_LambertConformal_standard_parallels(object):
+class Test_LambertConformal_standard_parallels:
     def test_single_value(self):
         crs = ccrs.LambertConformal(standard_parallels=[1.])
         other_args = {'ellps=WGS84', 'lon_0=-96.0', 'lat_0=39.0',

--- a/lib/cartopy/tests/crs/test_mercator.py
+++ b/lib/cartopy/tests/crs/test_mercator.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 from numpy.testing import assert_almost_equal
 import pytest

--- a/lib/cartopy/tests/crs/test_miller.py
+++ b/lib/cartopy/tests/crs/test_miller.py
@@ -8,7 +8,6 @@ Tests for the Miller coordinate system.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal

--- a/lib/cartopy/tests/crs/test_mollweide.py
+++ b/lib/cartopy/tests/crs/test_mollweide.py
@@ -8,7 +8,6 @@ Tests for the Mollweide coordinate system.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal

--- a/lib/cartopy/tests/crs/test_nearside_perspective.py
+++ b/lib/cartopy/tests/crs/test_nearside_perspective.py
@@ -8,7 +8,6 @@ Tests for the NearsidePerspective projection.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 from numpy.testing import assert_almost_equal
 

--- a/lib/cartopy/tests/crs/test_orthographic.py
+++ b/lib/cartopy/tests/crs/test_orthographic.py
@@ -8,7 +8,6 @@ Tests for the Orthographic coordinate system.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal

--- a/lib/cartopy/tests/crs/test_robinson.py
+++ b/lib/cartopy/tests/crs/test_robinson.py
@@ -8,7 +8,6 @@ Tests for Robinson projection.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_almost_equal

--- a/lib/cartopy/tests/crs/test_rotated_geodetic.py
+++ b/lib/cartopy/tests/crs/test_rotated_geodetic.py
@@ -8,7 +8,6 @@ Tests for the Transverse Mercator projection, including OSGB and OSNI.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import cartopy.crs as ccrs
 from .helpers import check_proj_params

--- a/lib/cartopy/tests/crs/test_rotated_pole.py
+++ b/lib/cartopy/tests/crs/test_rotated_pole.py
@@ -8,7 +8,6 @@ Tests for the Rotated Geodetic coordinate system.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import cartopy.crs as ccrs
 from .helpers import check_proj_params

--- a/lib/cartopy/tests/crs/test_sinusoidal.py
+++ b/lib/cartopy/tests/crs/test_sinusoidal.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal
@@ -14,7 +13,7 @@ import cartopy.crs as ccrs
 from .helpers import check_proj_params
 
 
-class TestSinusoidal(object):
+class TestSinusoidal:
     def test_default(self):
         crs = ccrs.Sinusoidal()
         other_args = {'ellps=WGS84', 'lon_0=0.0', 'x_0=0.0', 'y_0=0.0'}

--- a/lib/cartopy/tests/crs/test_stereographic.py
+++ b/lib/cartopy/tests/crs/test_stereographic.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal
@@ -13,7 +12,7 @@ import cartopy.crs as ccrs
 from .helpers import check_proj_params
 
 
-class TestStereographic(object):
+class TestStereographic:
     def test_default(self):
         stereo = ccrs.Stereographic()
         other_args = {'ellps=WGS84', 'lat_0=0.0', 'lon_0=0.0', 'x_0=0.0',

--- a/lib/cartopy/tests/crs/test_transverse_mercator.py
+++ b/lib/cartopy/tests/crs/test_transverse_mercator.py
@@ -8,7 +8,6 @@ Tests for the Transverse Mercator projection, including OSGB and OSNI.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 import pytest
@@ -17,7 +16,7 @@ import cartopy.crs as ccrs
 
 
 @pytest.mark.parametrize('approx', [True, False])
-class TestTransverseMercator(object):
+class TestTransverseMercator:
     def setup_class(self):
         self.point_a = (-3.474083, 50.727301)
         self.point_b = (0.5, 50.5)
@@ -59,7 +58,7 @@ class TestTransverseMercator(object):
         assert np.all(np.isnan(res))
 
 
-class TestOSGB(object):
+class TestOSGB:
     def setup_class(self):
         self.point_a = (-3.474083, 50.727301)
         self.point_b = (0.5, 50.5)
@@ -84,7 +83,7 @@ class TestOSGB(object):
         assert np.all(np.isnan(res))
 
 
-class TestOSNI(object):
+class TestOSNI:
     def setup_class(self):
         self.point_a = (-6.826286, 54.725116)
         self.src_crs = ccrs.PlateCarree()

--- a/lib/cartopy/tests/crs/test_utm.py
+++ b/lib/cartopy/tests/crs/test_utm.py
@@ -8,7 +8,6 @@ Tests for the UTM coordinate system.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal

--- a/lib/cartopy/tests/feature/__init__.py
+++ b/lib/cartopy/tests/feature/__init__.py
@@ -4,4 +4,3 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)

--- a/lib/cartopy/tests/feature/test_nightshade.py
+++ b/lib/cartopy/tests/feature/test_nightshade.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 from datetime import datetime
 

--- a/lib/cartopy/tests/io/__init__.py
+++ b/lib/cartopy/tests/io/__init__.py
@@ -4,4 +4,3 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)

--- a/lib/cartopy/tests/io/test_downloaders.py
+++ b/lib/cartopy/tests/io/test_downloaders.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import contextlib
 import os
@@ -119,7 +118,7 @@ def test_downloading_simple_ascii(download_to_temp):
                              'raised. Got {}.'.format(len(w)))
         assert issubclass(w[0].category, cio.DownloadWarning)
 
-    with open(tmp_fname, 'r') as fh:
+    with open(tmp_fname) as fh:
         fh.readline()
         assert fh.readline() == " * jQuery JavaScript Library v1.8.2\n"
 

--- a/lib/cartopy/tests/io/test_ogc_clients.py
+++ b/lib/cartopy/tests/io/test_ogc_clients.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 try:
     from unittest import mock
@@ -32,7 +31,7 @@ RESOLUTION = (30, 30)
 
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
-class TestWMSRasterSource(object):
+class TestWMSRasterSource:
     URI = 'http://vmap0.tiles.osgeo.org/wms/vmap0'
     layer = 'basic'
     layers = ['basic', 'ocean']
@@ -137,7 +136,7 @@ class TestWMSRasterSource(object):
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
 @pytest.mark.xfail(raises=KeyError, reason='OWSLib WMTS support is broken.')
-class TestWMTSRasterSource(object):
+class TestWMTSRasterSource:
     URI = 'https://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi'
     layer_name = 'VIIRS_CityLights_2012'
     projection = ccrs.PlateCarree()
@@ -211,7 +210,7 @@ class TestWMTSRasterSource(object):
 
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
-class TestWFSGeometrySource(object):
+class TestWFSGeometrySource:
     URI = 'https://nsidc.org/cgi-bin/atlas_south?service=WFS'
     typename = 'land_excluding_antarctica'
     native_projection = ccrs.Stereographic(central_latitude=-90,

--- a/lib/cartopy/tests/io/test_srtm.py
+++ b/lib/cartopy/tests/io/test_srtm.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import warnings
 
@@ -54,7 +53,7 @@ def srtm_login_or_skip(monkeypatch):
     monkeypatch.setattr(cartopy.io, 'urlopen', opener.open)
 
 
-class TestRetrieve(object):
+class TestRetrieve:
     @pytest.mark.parametrize('Source, read_SRTM, max_, min_, pt', [
         (cartopy.io.srtm.SRTM3Source, cartopy.io.srtm.read_SRTM3,
          602, -34, 78),
@@ -102,7 +101,7 @@ class TestRetrieve(object):
     'srtm3',
     'srtm1',
 ])
-class TestSRTMSource__single_tile(object):
+class TestSRTMSource__single_tile:
     def test_out_of_range(self, Source):
         source = Source()
         match = r'No srtm tile found for those coordinates\.'
@@ -137,7 +136,7 @@ class TestSRTMSource__single_tile(object):
     'srtm3',
     'srtm1',
 ])
-class TestSRTMSource__combined(object):
+class TestSRTMSource__combined:
     def test_trivial(self, Source):
         source = Source()
 

--- a/lib/cartopy/tests/mpl/__init__.py
+++ b/lib/cartopy/tests/mpl/__init__.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import base64
 import contextlib
@@ -25,7 +24,7 @@ import matplotlib.testing.compare as mcompare
 MPL_VERSION = distutils.version.LooseVersion(mpl.__version__)
 
 
-class ImageTesting(object):
+class ImageTesting:
     """
     Provides a convenient class for running visual Matplotlib tests.
 
@@ -74,7 +73,7 @@ class ImageTesting(object):
     image_output_directory = os.path.join(root_image_results, 'output')
     if not os.access(image_output_directory, os.W_OK):
         if not os.access(os.getcwd(), os.W_OK):
-            raise IOError('Write access to a local disk is required to run '
+            raise OSError('Write access to a local disk is required to run '
                           'image tests.  Run the tests from a current working '
                           'directory you have write access to to avoid this '
                           'issue.')

--- a/lib/cartopy/tests/mpl/test_axes.py
+++ b/lib/cartopy/tests/mpl/test_axes.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 from matplotlib.testing.decorators import cleanup
 import matplotlib.path as mpath
@@ -21,7 +20,7 @@ from cartopy.mpl.geoaxes import InterProjectionTransform, GeoAxes
 from cartopy.tests.mpl.test_caching import CallCounter
 
 
-class TestNoSpherical(object):
+class TestNoSpherical:
     def setup_method(self):
         self.ax = plt.axes(projection=ccrs.PlateCarree())
         self.data = np.arange(12).reshape((3, 4))

--- a/lib/cartopy/tests/mpl/test_caching.py
+++ b/lib/cartopy/tests/mpl/test_caching.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import gc
 
@@ -24,7 +23,7 @@ import cartopy.mpl.patch
 from cartopy.examples.waves import sample_data
 
 
-class CallCounter(object):
+class CallCounter:
     """
     Exposes a context manager which can count the number of calls to a specific
     function. (useful for cache checking!)

--- a/lib/cartopy/tests/mpl/test_contour.py
+++ b/lib/cartopy/tests/mpl/test_contour.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import cleanup

--- a/lib/cartopy/tests/mpl/test_crs.py
+++ b/lib/cartopy/tests/mpl/test_crs.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import cleanup

--- a/lib/cartopy/tests/mpl/test_examples.py
+++ b/lib/cartopy/tests/mpl/test_examples.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import matplotlib.pyplot as plt
 import pytest

--- a/lib/cartopy/tests/mpl/test_feature_artist.py
+++ b/lib/cartopy/tests/mpl/test_feature_artist.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 import pytest

--- a/lib/cartopy/tests/mpl/test_features.py
+++ b/lib/cartopy/tests/mpl/test_features.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import matplotlib.pyplot as plt
 import pytest

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import os
 import types

--- a/lib/cartopy/tests/mpl/test_img_transform.py
+++ b/lib/cartopy/tests/mpl/test_img_transform.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import operator
 import os
@@ -21,7 +20,7 @@ import cartopy.img_transform as im_trans
 from functools import reduce
 
 
-class TestRegrid(object):
+class TestRegrid:
     def test_array_dims(self):
         # Source data
         source_nx = 100

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import math
 import re

--- a/lib/cartopy/tests/mpl/test_nightshade.py
+++ b/lib/cartopy/tests/mpl/test_nightshade.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 from datetime import datetime
 

--- a/lib/cartopy/tests/mpl/test_patch.py
+++ b/lib/cartopy/tests/mpl/test_patch.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import matplotlib
 from matplotlib.path import Path
@@ -14,7 +13,7 @@ import shapely.geometry as sgeom
 import cartopy.mpl.patch as cpatch
 
 
-class Test_path_to_geos(object):
+class Test_path_to_geos:
     def test_empty_polygon(self):
         p = Path(
             [

--- a/lib/cartopy/tests/mpl/test_plots.py
+++ b/lib/cartopy/tests/mpl/test_plots.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 from io import BytesIO
 

--- a/lib/cartopy/tests/mpl/test_pseudo_color.py
+++ b/lib/cartopy/tests/mpl/test_pseudo_color.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import io
 import matplotlib.pyplot as plt

--- a/lib/cartopy/tests/mpl/test_quiver.py
+++ b/lib/cartopy/tests/mpl/test_quiver.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 try:
     from unittest import mock
@@ -21,7 +20,7 @@ import cartopy.crs as ccrs
 
 # Note, other tests for quiver exist in test_mpl_integration.
 
-class TestQuiverShapes(object):
+class TestQuiverShapes:
     def setup_method(self):
         self.x = np.linspace(-60, 42.5, 10)
         self.y = np.linspace(30, 72.5, 7)
@@ -40,7 +39,7 @@ class TestQuiverShapes(object):
                            self.u.ravel(), self.v.ravel(), transform=self.rp)
         args, kwargs = patch.call_args
         assert len(args) == 5
-        assert sorted(kwargs.keys()) == [u'transform']
+        assert sorted(kwargs.keys()) == ['transform']
         shapes = [arg.shape for arg in args[1:]]
         # Assert that all the shapes have been broadcast.
         assert shapes == [(70, )] * 4
@@ -51,7 +50,7 @@ class TestQuiverShapes(object):
             self.ax.quiver(self.x, self.y, self.u, self.v, transform=self.rp)
         args, kwargs = patch.call_args
         assert len(args) == 5
-        assert sorted(kwargs.keys()) == [u'transform']
+        assert sorted(kwargs.keys()) == ['transform']
         shapes = [arg.shape for arg in args[1:]]
         # Assert that all the shapes have been broadcast.
         assert shapes == [(7, 10)] * 4

--- a/lib/cartopy/tests/mpl/test_set_extent.py
+++ b/lib/cartopy/tests/mpl/test_set_extent.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 from matplotlib.testing.decorators import cleanup
 import matplotlib.pyplot as plt

--- a/lib/cartopy/tests/mpl/test_shapely_to_mpl.py
+++ b/lib/cartopy/tests/mpl/test_shapely_to_mpl.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/lib/cartopy/tests/mpl/test_style.py
+++ b/lib/cartopy/tests/mpl/test_style.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import pytest
 

--- a/lib/cartopy/tests/mpl/test_ticker.py
+++ b/lib/cartopy/tests/mpl/test_ticker.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 try:
     from unittest.mock import Mock
@@ -45,8 +44,8 @@ def test_LatitudeFormatter():
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=p))
     test_ticks = [-90, -60, -30, 0, 30, 60, 90]
     result = [formatter(tick) for tick in test_ticks]
-    expected = [u'90\u00B0S', u'60\u00B0S', u'30\u00B0S', u'0\u00B0',
-                u'30\u00B0N', u'60\u00B0N', u'90\u00B0N']
+    expected = ['90\u00B0S', '60\u00B0S', '30\u00B0S', '0\u00B0',
+                '30\u00B0N', '60\u00B0N', '90\u00B0N']
     assert result == expected
 
 
@@ -56,8 +55,8 @@ def test_LatitudeFormatter_degree_symbol():
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=p))
     test_ticks = [-90, -60, -30, 0, 30, 60, 90]
     result = [formatter(tick) for tick in test_ticks]
-    expected = [u'90S', u'60S', u'30S', u'0',
-                u'30N', u'60N', u'90N']
+    expected = ['90S', '60S', '30S', '0',
+                '30N', '60N', '90N']
     assert result == expected
 
 
@@ -67,9 +66,9 @@ def test_LatitudeFormatter_number_format():
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=p))
     test_ticks = [-90, -60, -30, 0, 30, 60, 90]
     result = [formatter(tick) for tick in test_ticks]
-    expected = [u'90.00\u00B0S', u'60.00\u00B0S', u'30.00\u00B0S',
-                u'0.00\u00B0', u'30.00\u00B0N', u'60.00\u00B0N',
-                u'90.00\u00B0N']
+    expected = ['90.00\u00B0S', '60.00\u00B0S', '30.00\u00B0S',
+                '0.00\u00B0', '30.00\u00B0N', '60.00\u00B0N',
+                '90.00\u00B0N']
     assert result == expected
 
 
@@ -81,8 +80,8 @@ def test_LatitudeFormatter_mercator():
                   -3482189.085407435, 0.0, 3482189.085407435,
                   8362698.548496634, 15496570.739707898]
     result = [formatter(tick) for tick in test_ticks]
-    expected = [u'80\u00B0S', u'60\u00B0S', u'30\u00B0S', u'0\u00B0',
-                u'30\u00B0N', u'60\u00B0N', u'80\u00B0N']
+    expected = ['80\u00B0S', '60\u00B0S', '30\u00B0S', '0\u00B0',
+                '30\u00B0N', '60\u00B0N', '80\u00B0N']
     assert result == expected
 
 
@@ -92,8 +91,8 @@ def test_LatitudeFormatter_small_numbers():
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=p))
     test_ticks = [40.1275150, 40.1275152, 40.1275154]
     result = [formatter(tick) for tick in test_ticks]
-    expected = [u'40.1275150\u00B0N', u'40.1275152\u00B0N',
-                u'40.1275154\u00B0N']
+    expected = ['40.1275150\u00B0N', '40.1275152\u00B0N',
+                '40.1275154\u00B0N']
     assert result == expected
 
 
@@ -103,8 +102,8 @@ def test_LongitudeFormatter_central_longitude_0():
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=p))
     test_ticks = [-180, -120, -60, 0, 60, 120, 180]
     result = [formatter(tick) for tick in test_ticks]
-    expected = [u'180\u00B0W', u'120\u00B0W', u'60\u00B0W', u'0\u00B0',
-                u'60\u00B0E', u'120\u00B0E', u'180\u00B0E']
+    expected = ['180\u00B0W', '120\u00B0W', '60\u00B0W', '0\u00B0',
+                '60\u00B0E', '120\u00B0E', '180\u00B0E']
     assert result == expected
 
 
@@ -114,8 +113,8 @@ def test_LongitudeFormatter_central_longitude_180():
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=p))
     test_ticks = [-180, -120, -60, 0, 60, 120, 180]
     result = [formatter(tick) for tick in test_ticks]
-    expected = [u'0\u00B0E', u'60\u00B0E', u'120\u00B0E', u'180\u00B0',
-                u'120\u00B0W', u'60\u00B0W', u'0\u00B0W']
+    expected = ['0\u00B0E', '60\u00B0E', '120\u00B0E', '180\u00B0',
+                '120\u00B0W', '60\u00B0W', '0\u00B0W']
     assert result == expected
 
 
@@ -125,8 +124,8 @@ def test_LongitudeFormatter_central_longitude_120():
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=p))
     test_ticks = [-180, -120, -60, 0, 60, 120, 180]
     result = [formatter(tick) for tick in test_ticks]
-    expected = [u'60\u00B0W', u'0\u00B0', u'60\u00B0E', u'120\u00B0E',
-                u'180\u00B0', u'120\u00B0W', u'60\u00B0W']
+    expected = ['60\u00B0W', '0\u00B0', '60\u00B0E', '120\u00B0E',
+                '180\u00B0', '120\u00B0W', '60\u00B0W']
     assert result == expected
 
 
@@ -137,7 +136,7 @@ def test_LongitudeFormatter_degree_symbol():
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=p))
     test_ticks = [-180, -120, -60, 0, 60, 120, 180]
     result = [formatter(tick) for tick in test_ticks]
-    expected = [u'180W', u'120W', u'60W', u'0', u'60E', u'120E', u'180E']
+    expected = ['180W', '120W', '60W', '0', '60E', '120E', '180E']
     assert result == expected
 
 
@@ -148,9 +147,9 @@ def test_LongitudeFormatter_number_format():
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=p))
     test_ticks = [-180, -120, -60, 0, 60, 120, 180]
     result = [formatter(tick) for tick in test_ticks]
-    expected = [u'180.00\u00B0W', u'120.00\u00B0W', u'60.00\u00B0W',
-                u'0.00\u00B0', u'60.00\u00B0E', u'120.00\u00B0E',
-                u'180.00\u00B0E']
+    expected = ['180.00\u00B0W', '120.00\u00B0W', '60.00\u00B0W',
+                '0.00\u00B0', '60.00\u00B0E', '120.00\u00B0E',
+                '180.00\u00B0E']
     assert result == expected
 
 
@@ -162,8 +161,8 @@ def test_LongitudeFormatter_mercator():
                   -6679169.447594353, 0.0, 6679169.447594353,
                   13358338.895188706, 20037508.342783064]
     result = [formatter(tick) for tick in test_ticks]
-    expected = [u'180\u00B0W', u'120\u00B0W', u'60\u00B0W', u'0\u00B0',
-                u'60\u00B0E', u'120\u00B0E', u'180\u00B0E']
+    expected = ['180\u00B0W', '120\u00B0W', '60\u00B0W', '0\u00B0',
+                '60\u00B0E', '120\u00B0E', '180\u00B0E']
     assert result == expected
 
 
@@ -173,8 +172,8 @@ def test_LongitudeFormatter_small_numbers_0():
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=p))
     test_ticks = [-17.1142343, -17.1142340, -17.1142337]
     result = [formatter(tick) for tick in test_ticks]
-    expected = [u'17.1142343\u00B0W', u'17.1142340\u00B0W',
-                u'17.1142337\u00B0W']
+    expected = ['17.1142343\u00B0W', '17.1142340\u00B0W',
+                '17.1142337\u00B0W']
     assert result == expected
 
 
@@ -185,20 +184,20 @@ def test_LongitudeFormatter_small_numbers_180():
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=p))
     test_ticks = [-17.1142343, -17.1142340, -17.1142337]
     result = [formatter(tick) for tick in test_ticks]
-    expected = [u'162.8857657\u00B0E', u'162.8857660\u00B0E',
-                u'162.8857663\u00B0E']
+    expected = ['162.8857657\u00B0E', '162.8857660\u00B0E',
+                '162.8857663\u00B0E']
     assert result == expected
 
 
 @pytest.mark.parametrize("test_ticks,expected",
                          [pytest.param([-3.75, -3.5],
-                                       [u"3\u00B0W45'", u"3\u00B0W30'"],
+                                       ["3\u00B0W45'", "3\u00B0W30'"],
                                        id='minutes_no_hide'),
                           pytest.param([-3.5, -3.],
-                                       [u"30'", u"3\u00B0W"],
+                                       ["30'", "3\u00B0W"],
                                        id='minutes_hide'),
                           pytest.param([-3. - 2 * ONE_MIN - 30 * ONE_SEC],
-                                       [u"3\u00B0W2'30''"],
+                                       ["3\u00B0W2'30''"],
                                        id='seconds'),
                           ])
 def test_LongitudeFormatter_minutes_seconds(test_ticks, expected):
@@ -210,7 +209,7 @@ def test_LongitudeFormatter_minutes_seconds(test_ticks, expected):
 
 @pytest.mark.parametrize("test_ticks,expected",
                          [pytest.param([-3.75, -3.5],
-                                       [u"3\u00B0S45'", u"3\u00B0S30'"],
+                                       ["3\u00B0S45'", "3\u00B0S30'"],
                                        id='minutes_no_hide'),
                           ])
 def test_LatitudeFormatter_minutes_seconds(test_ticks, expected):

--- a/lib/cartopy/tests/mpl/test_ticks.py
+++ b/lib/cartopy/tests/mpl/test_ticks.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import math
 

--- a/lib/cartopy/tests/mpl/test_web_services.py
+++ b/lib/cartopy/tests/mpl/test_web_services.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import cleanup

--- a/lib/cartopy/tests/test_coastline.py
+++ b/lib/cartopy/tests/test_coastline.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import pytest
 
@@ -13,7 +12,7 @@ import cartopy.io.shapereader as shp
 
 
 @pytest.mark.natural_earth
-class TestCoastline(object):
+class TestCoastline:
     def test_robust(self):
         COASTLINE_PATH = shp.natural_earth()
 

--- a/lib/cartopy/tests/test_coding_standards.py
+++ b/lib/cartopy/tests/test_coding_standards.py
@@ -7,8 +7,6 @@
 
 from datetime import datetime
 from fnmatch import fnmatch
-import io
-from itertools import chain
 import os
 import re
 import subprocess
@@ -102,56 +100,3 @@ class TestLicenseHeaders:
                     failed.append(full_fname)
 
         assert failed == [], 'There were license header failures.'
-
-
-class TestFutureImports:
-    excluded = (
-        '*/cartopy/examples/*.py',
-        '*/docs/source/examples/*.py',
-        '*/cartopy/_crs.py',   # A file created by setuptools for so loading.
-        '*/cartopy/trace.py',  # Ditto.
-        '*/cartopy/geodesic/_geodesic.py',
-        '*/cartopy/_version.py',
-    )
-
-    future_imports_pattern = re.compile(
-        r"^from __future__ import \(absolute_import,\s*division,\s*"
-        r"print_function(,\s*unicode_literals)?\)$",
-        flags=re.MULTILINE)
-
-    def test_future_imports(self):
-        # Tests that every single Python file includes the appropriate
-        # __future__ import to enforce consistent behaviour.
-        check_paths = [CARTOPY_DIR]
-
-        failed = False
-        for dirpath, _, files in chain.from_iterable(os.walk(path)
-                                                     for path in check_paths):
-            for fname in files:
-                full_fname = os.path.join(dirpath, fname)
-                if not full_fname.endswith('.py'):
-                    continue
-                if not os.path.isfile(full_fname):
-                    continue
-                if any(fnmatch(full_fname, pat) for pat in self.excluded):
-                    continue
-
-                is_empty = os.path.getsize(full_fname) == 0
-
-                with open(full_fname, "r", encoding='utf-8') as fh:
-                    content = fh.read()
-
-                has_future_import = re.search(
-                    self.future_imports_pattern, content) is not None
-
-                if is_empty:
-                    pass
-                elif not has_future_import:
-                    print('The file {} has no valid __future__ imports '
-                          'and has not been excluded from the imports '
-                          'test.'.format(full_fname))
-                    failed = True
-
-        if failed:
-            raise ValueError('There were __future__ import check failures. '
-                             'See stdout.')

--- a/lib/cartopy/tests/test_coding_standards.py
+++ b/lib/cartopy/tests/test_coding_standards.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 from datetime import datetime
 from fnmatch import fnmatch
@@ -41,7 +40,7 @@ REPO_DIR = os.getenv('CARTOPY_GIT_DIR',
                      os.path.dirname(os.path.dirname(CARTOPY_DIR)))
 
 
-class TestLicenseHeaders(object):
+class TestLicenseHeaders:
     @staticmethod
     def list_tracked_files():
         """
@@ -96,7 +95,7 @@ class TestLicenseHeaders(object):
                     # Allow completely empty files (e.g. ``__init__.py``)
                     continue
 
-                with io.open(full_fname, encoding='utf-8') as fh:
+                with open(full_fname, encoding='utf-8') as fh:
                     content = fh.read()
 
                 if not bool(LICENSE_RE.match(content)):
@@ -105,7 +104,7 @@ class TestLicenseHeaders(object):
         assert failed == [], 'There were license header failures.'
 
 
-class TestFutureImports(object):
+class TestFutureImports:
     excluded = (
         '*/cartopy/examples/*.py',
         '*/docs/source/examples/*.py',
@@ -139,7 +138,7 @@ class TestFutureImports(object):
 
                 is_empty = os.path.getsize(full_fname) == 0
 
-                with io.open(full_fname, "r", encoding='utf-8') as fh:
+                with open(full_fname, "r", encoding='utf-8') as fh:
                     content = fh.read()
 
                 has_future_import = re.search(

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import copy
 from io import BytesIO
@@ -23,7 +22,7 @@ import shapely.geometry as sgeom
 import cartopy.crs as ccrs
 
 
-class TestCRS(object):
+class TestCRS:
     def test_hash(self):
         stereo = ccrs.Stereographic(90)
         north = ccrs.NorthPolarStereo()

--- a/lib/cartopy/tests/test_crs_transform_vectors.py
+++ b/lib/cartopy/tests/test_crs_transform_vectors.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import warnings
 
@@ -15,7 +14,7 @@ import pytest
 import cartopy.crs as ccrs
 
 
-class TestTransformVectors(object):
+class TestTransformVectors:
 
     def test_transform(self):
         # Test some simple vectors to make sure they are transformed

--- a/lib/cartopy/tests/test_features.py
+++ b/lib/cartopy/tests/test_features.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import cartopy.feature as cfeature
 import pytest
@@ -18,7 +17,7 @@ auto_scaler = cfeature.AdaptiveScaler('110m', (('50m', 50), ('10m', 15)))
 auto_land = cfeature.NaturalEarthFeature('physical', 'land', auto_scaler)
 
 
-class TestFeatures(object):
+class TestFeatures:
     def test_change_scale(self):
         # Check that features can easily be retrieved with a different
         # scale.

--- a/lib/cartopy/tests/test_geodesic.py
+++ b/lib/cartopy/tests/test_geodesic.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
@@ -14,7 +13,7 @@ import shapely.geometry as sgeom
 from cartopy import geodesic
 
 
-class TestGeodesic(object):
+class TestGeodesic:
     def setup_class(self):
         """
         Data sampled from the GeographicLib Test Data for Geodesics at:

--- a/lib/cartopy/tests/test_img_nest.py
+++ b/lib/cartopy/tests/test_img_nest.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import io
 import os
@@ -225,7 +224,7 @@ def test_nest(nest_from_config):
     # floating point values badly
     for img in z1.images:
         if not z0.images[0].bbox().contains(img.bbox()):
-            raise IOError('The test images aren\'t all "contained" by the '
+            raise OSError('The test images aren\'t all "contained" by the '
                           'z0 images, the nest cannot possibly work.\n '
                           'img {!s} not contained by {!s}\nExtents: {!s}; '
                           '{!s}'.format(img, z0.images[0], img.extent,
@@ -307,9 +306,9 @@ def wmts_data():
 
     test_data_version = None
     try:
-        with open(data_version_fname, 'r') as fh:
+        with open(data_version_fname) as fh:
             test_data_version = int(fh.read().strip())
-    except IOError:
+    except OSError:
         pass
     finally:
         if test_data_version != _TEST_DATA_VERSION:

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import os
 import types

--- a/lib/cartopy/tests/test_img_transform.py
+++ b/lib/cartopy/tests/test_img_transform.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_array_equal

--- a/lib/cartopy/tests/test_line_string.py
+++ b/lib/cartopy/tests/test_line_string.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import itertools
 import time
@@ -16,7 +15,7 @@ import shapely.geometry as sgeom
 import cartopy.crs as ccrs
 
 
-class TestLineString(object):
+class TestLineString:
     def test_out_of_bounds(self):
         # Check that a line that is completely out of the map boundary produces
         # a valid LineString
@@ -97,7 +96,7 @@ class FakeProjection(ccrs.PlateCarree):
                                  (-w + self.left_offset, -h)])
 
 
-class TestBisect(object):
+class TestBisect:
     # A bunch of tests to check the bisection algorithm is robust for a
     # variety of simple and/or pathological cases.
 
@@ -197,7 +196,7 @@ class TestBisect(object):
                     'Unexpected NaN in projected coords.'
 
 
-class TestMisc(object):
+class TestMisc:
     def test_misc(self):
         projection = ccrs.TransverseMercator(central_longitude=-90,
                                              approx=False)
@@ -231,7 +230,7 @@ class TestMisc(object):
         assert len(multi_line_string) > 0
 
 
-class TestSymmetry(object):
+class TestSymmetry:
     @pytest.mark.xfail
     def test_curve(self):
         # Obtain a simple, curved path.

--- a/lib/cartopy/tests/test_linear_ring.py
+++ b/lib/cartopy/tests/test_linear_ring.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 import pytest
@@ -13,7 +12,7 @@ import shapely.geometry as sgeom
 import cartopy.crs as ccrs
 
 
-class TestBoundary(object):
+class TestBoundary:
     def test_cuts(self):
         # Check that fragments do not start or end with one of the
         # original ... ?
@@ -75,7 +74,7 @@ class TestBoundary(object):
                     assert mlinestr.is_empty
 
 
-class TestMisc(object):
+class TestMisc:
     def test_small(self):
         # What happens when a small (i.e. < threshold) feature crosses the
         # boundary?

--- a/lib/cartopy/tests/test_polygon.py
+++ b/lib/cartopy/tests/test_polygon.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 import pytest
@@ -15,7 +14,7 @@ import shapely.wkt
 import cartopy.crs as ccrs
 
 
-class TestBoundary(object):
+class TestBoundary:
     def test_no_polygon_boundary_reversal(self):
         # Check that polygons preserve their clockwise or counter-clockwise
         # ordering when they are attached to the boundary.
@@ -60,7 +59,7 @@ class TestBoundary(object):
             assert len(multi_polygon) == expected_polys
 
 
-class TestMisc(object):
+class TestMisc:
     def test_misc(self):
         projection = ccrs.TransverseMercator(central_longitude=-90,
                                              approx=False)
@@ -251,7 +250,7 @@ class TestMisc(object):
         assert abs(1200 - projected.area) < 1e-5
 
 
-class TestQuality(object):
+class TestQuality:
     def setup_class(self):
         projection = ccrs.RotatedPole(pole_longitude=177.5,
                                       pole_latitude=37.5)
@@ -299,7 +298,7 @@ class TestQuality(object):
             assert abs(num_incr - num_decr) < 3, 'Too much asymmetry.'
 
 
-class PolygonTests(object):
+class PolygonTests:
     def _assert_bounds(self, bounds, x1, y1, x2, y2, delta=1):
         assert abs(bounds[0] - x1) < delta
         assert abs(bounds[1] - y1) < delta

--- a/lib/cartopy/tests/test_shapereader.py
+++ b/lib/cartopy/tests/test_shapereader.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import os.path
 
@@ -15,7 +14,7 @@ import pytest
 import cartopy.io.shapereader as shp
 
 
-class TestLakes(object):
+class TestLakes:
     def setup_class(self):
         LAKES_PATH = os.path.join(os.path.dirname(__file__),
                                   'lakes_shapefile', 'ne_110m_lakes.shp')
@@ -72,7 +71,7 @@ class TestLakes(object):
 
 
 @pytest.mark.natural_earth
-class TestRivers(object):
+class TestRivers:
     def setup_class(self):
         RIVERS_PATH = shp.natural_earth(resolution='110m',
                                         category='physical',

--- a/lib/cartopy/tests/test_util.py
+++ b/lib/cartopy/tests/test_util.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 import numpy.ma as ma
@@ -14,7 +13,7 @@ import pytest
 from cartopy.util import add_cyclic_point
 
 
-class Test_add_cyclic_point(object):
+class Test_add_cyclic_point:
 
     @classmethod
     def setup_class(cls):

--- a/lib/cartopy/tests/test_vector_transform.py
+++ b/lib/cartopy/tests/test_vector_transform.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
@@ -29,7 +28,7 @@ def _sample_plate_carree_vector_field():
     return u, v
 
 
-class Test_interpolate_to_grid(object):
+class Test_interpolate_to_grid:
 
     @classmethod
     def setup_class(cls):
@@ -95,7 +94,7 @@ class Test_interpolate_to_grid(object):
         assert_array_almost_equal(s_grid3, expected_s_grid)
 
 
-class Test_vector_scalar_to_grid(object):
+class Test_vector_scalar_to_grid:
 
     @classmethod
     def setup_class(cls):

--- a/lib/cartopy/util.py
+++ b/lib/cartopy/util.py
@@ -9,7 +9,6 @@ cartopy.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 import numpy.ma as ma

--- a/lib/cartopy/vector_transform.py
+++ b/lib/cartopy/vector_transform.py
@@ -9,7 +9,6 @@ transforms.
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from scipy.interpolate import griddata

--- a/setup.py
+++ b/setup.py
@@ -413,6 +413,7 @@ setup(
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
+            'Programming Language :: Python :: 3 :: Only',
             'Topic :: Scientific/Engineering',
             'Topic :: Scientific/Engineering :: GIS',
             'Topic :: Scientific/Engineering :: Visualization',

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ PYTHON_MIN_VERSION = (3, 5)
 
 if sys.version_info < PYTHON_MIN_VERSION:
     error = """
-Beginning with Cartopy 0.19, Python {0} or above is required.
-You are using Python {1}.
+Beginning with Cartopy 0.19, Python {} or above is required.
+You are using Python {}.
 
 This may be due to an out of date pip.
 
@@ -147,14 +147,14 @@ def find_proj_version_by_program(conda=None):
     proj = find_executable('proj')
     if proj is None:
         print(
-            'Proj %s must be installed.' % (
-                '.'.join(str(v) for v in PROJ_MIN_VERSION), ),
+            'Proj {} must be installed.'.format(
+                '.'.join(str(v) for v in PROJ_MIN_VERSION)),
             file=sys.stderr)
         exit(1)
 
     if conda is not None and conda not in proj:
         print(
-            'Proj %s must be installed in Conda environment "%s".' % (
+            'Proj {} must be installed in Conda environment "{}".'.format(
                 '.'.join(str(v) for v in PROJ_MIN_VERSION), conda),
             file=sys.stderr)
         exit(1)
@@ -250,7 +250,7 @@ else:
 # Python dependencies
 extras_require = {}
 for name in os.listdir(os.path.join(HERE, 'requirements')):
-    with open(os.path.join(HERE, 'requirements', name), 'r') as fh:
+    with open(os.path.join(HERE, 'requirements', name)) as fh:
         section, ext = os.path.splitext(name)
         extras_require[section] = []
         for line in fh:
@@ -277,7 +277,7 @@ if not sys.platform.startswith('win'):
 
 # Description
 # ===========
-with open(os.path.join(HERE, 'README.md'), 'r') as fh:
+with open(os.path.join(HERE, 'README.md')) as fh:
     description = ''.join(fh.readlines())
 
 

--- a/tools/feature_download.py
+++ b/tools/feature_download.py
@@ -14,7 +14,6 @@ For detail on how to use this tool, execute it with the `-h` option:
 
 """
 
-from __future__ import (absolute_import, division, print_function)
 
 import argparse
 


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

New version of https://github.com/SciTools/cartopy/pull/1237.

Python 2 is no longer supported, remove redundant code.

Add "Programming Language :: Python :: 3 :: Only" Trove classifier for clarity.

Fixes https://github.com/SciTools/cartopy/issues/1186.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

Python 2 is no longer supported.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
