### PR TITLE
Remove more Python 2 imports

### DIFF
--- a/lib/cartopy/examples/aurora_forecast.py
+++ b/lib/cartopy/examples/aurora_forecast.py
@@ -13,15 +13,12 @@ data spaced equally in degrees from -180 to 180 and -90 to 90.
 
 """
 __tags__ = ["Scalar data"]
-try:
-    from urllib2 import urlopen
-except ImportError:
-    from urllib.request import urlopen
 
+from datetime import datetime
 from io import StringIO
+from urllib.request import urlopen
 
 import numpy as np
-from datetime import datetime
 import cartopy.crs as ccrs
 from cartopy.feature.nightshade import Nightshade
 import matplotlib.pyplot as plt

--- a/lib/cartopy/examples/eccentric_ellipse.py
+++ b/lib/cartopy/examples/eccentric_ellipse.py
@@ -10,11 +10,8 @@ The image is reprojected on-the-fly onto a geostationary projection with
 matching eccentricity.
 
 """
-try:
-    from urllib2 import urlopen
-except ImportError:
-    from urllib.request import urlopen
 from io import BytesIO
+from urllib.request import urlopen
 
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt

--- a/lib/cartopy/examples/geostationary.py
+++ b/lib/cartopy/examples/geostationary.py
@@ -13,11 +13,8 @@ cartopy into a global Miller map.
 """
 __tags__ = ["Scalar data"]
 
-try:
-    from urllib2 import urlopen
-except ImportError:
-    from urllib.request import urlopen
 from io import BytesIO
+from urllib.request import urlopen
 
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt

--- a/lib/cartopy/tests/io/test_ogc_clients.py
+++ b/lib/cartopy/tests/io/test_ogc_clients.py
@@ -4,10 +4,7 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import numpy as np
 try:

--- a/lib/cartopy/tests/mpl/test_axes.py
+++ b/lib/cartopy/tests/mpl/test_axes.py
@@ -4,13 +4,11 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
+from unittest import mock
+
 from matplotlib.testing.decorators import cleanup
 import matplotlib.path as mpath
 import matplotlib.pyplot as plt
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import numpy as np
 import pytest
 

--- a/lib/cartopy/tests/mpl/test_feature_artist.py
+++ b/lib/cartopy/tests/mpl/test_feature_artist.py
@@ -4,14 +4,12 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
+from unittest import mock
+
 import numpy as np
 import pytest
 import shapely.geometry as sgeom
 from matplotlib.transforms import IdentityTransform
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 import cartopy.crs as ccrs
 import cartopy.mpl.geoaxes as geoaxes

--- a/lib/cartopy/tests/mpl/test_pseudo_color.py
+++ b/lib/cartopy/tests/mpl/test_pseudo_color.py
@@ -5,11 +5,9 @@
 # licensing details.
 
 import io
+from unittest import mock
+
 import matplotlib.pyplot as plt
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import numpy as np
 import pytest
 

--- a/lib/cartopy/tests/mpl/test_quiver.py
+++ b/lib/cartopy/tests/mpl/test_quiver.py
@@ -4,10 +4,7 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/lib/cartopy/tests/mpl/test_ticker.py
+++ b/lib/cartopy/tests/mpl/test_ticker.py
@@ -4,10 +4,8 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from mock import Mock
+from unittest.mock import Mock
+
 import matplotlib.pyplot as plt
 import pytest
 import numpy as np


### PR DESCRIPTION
## Rationale

We're dropping Python 2 support.

## Implications

Tests and examples won't use legacy imports.