### PR TITLE
Now returning the list of Text instances from parent class clabel() m…

### DIFF
--- a/lib/cartopy/mpl/contour.py
+++ b/lib/cartopy/mpl/contour.py
@@ -90,4 +90,4 @@ class GeoContourSet(QuadContourSet):
 
         # Now that we have prepared the collection paths, call on
         # through to the underlying implementation.
-        super().clabel(*args, **kwargs)
+        return super().clabel(*args, **kwargs)


### PR DESCRIPTION
Closes Issue #1554 

Now returning the list of Text instances from parent class clabel() m…ethod. This preserves the behavior of the MPL Axes clabel() method, which promises to return such a list.

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
