### PR TITLE
Avoid reusing the kwargs variable name in draw

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -469,11 +469,12 @@ class GeoAxes(matplotlib.axes.Axes):
         #       caching the resulting image;
         #       buffering the result by 10%...;
         if not self._done_img_factory:
-            for factory, args, kwargs in self.img_factories:
+            for factory, factory_args, factory_kwargs in self.img_factories:
                 img, extent, origin = factory.image_for_domain(
-                    self._get_extent_geom(factory.crs), args[0])
+                    self._get_extent_geom(factory.crs), factory_args[0])
                 self.imshow(img, extent=extent, origin=origin,
-                            transform=factory.crs, *args[1:], **kwargs)
+                            transform=factory.crs, *factory_args[1:],
+                            **factory_kwargs)
         self._done_img_factory = True
 
         return matplotlib.axes.Axes.draw(self, renderer=renderer, **kwargs)


### PR DESCRIPTION
## Rationale

This fixes #1563 by changing the now duplicate variable name `kwargs` in `GeoAxes.draw` so that factory keyword arguments do not overwrite top-level keyword arguments that we pass on to matplotlib. Currently users will see a traceback if you pass a cartopy-specific keyword to an image factory because the factory keywords overrid the draw-level keywords and are mistakenly passed on to matplotlib which doesn't recognise them.

This was introduced in 210ee4becd63d1410e7260533c7412d8284bfb1b (#1534). I have remedied by prefixing factory args/kwargs with `factory_` as it seems the simplest and easiest to read way of doing it.

## Implications

Fixes #1563.
