### PR TITLE
Adding an option to restrict the limits of the gridlines.

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1315,7 +1315,7 @@ class GeoAxes(matplotlib.axes.Axes):
     def gridlines(self, crs=None, draw_labels=False,
                   xlocs=None, ylocs=None, dms=False,
                   x_inline=None, y_inline=None, auto_inline=True,
-                  xformatter=None, yformatter=None,
+                  xformatter=None, yformatter=None, xlim=None, ylim=None,
                   **kwargs):
         """
         Automatically add gridlines to the axes, in the given coordinate
@@ -1365,6 +1365,16 @@ class GeoAxes(matplotlib.axes.Axes):
             use of a :class:`cartopy.mpl.ticker.LatitudeFormatter` initiated
             with the ``dms`` argument, if the crs is of
             :class:`~cartopy.crs.PlateCarree` type.
+        xlim: optional
+            Set a limit for the gridlines so that they do not go all the
+            way to the edge of the boundary. xlim can be a single number or
+            a (min, max) tuple. If a single number, the limits will be
+            (-xlim, +xlim).
+        ylim: optional
+            Set a limit for the gridlines so that they do not go all the
+            way to the edge of the boundary. ylim can be a single number or
+            a (min, max) tuple. If a single number, the limits will be
+            (-ylim, +ylim).
 
         Keyword Parameters
         ------------------
@@ -1393,7 +1403,7 @@ class GeoAxes(matplotlib.axes.Axes):
             self, crs=crs, draw_labels=draw_labels, xlocator=xlocs,
             ylocator=ylocs, collection_kwargs=kwargs, dms=dms,
             x_inline=x_inline, y_inline=y_inline, auto_inline=auto_inline,
-            xformatter=xformatter, yformatter=yformatter)
+            xformatter=xformatter, yformatter=yformatter, xlim=xlim, ylim=ylim)
         self._gridliners.append(gl)
         return gl
 

--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -105,7 +105,8 @@ class Gridliner:
     def __init__(self, axes, crs, draw_labels=False, xlocator=None,
                  ylocator=None, collection_kwargs=None,
                  xformatter=None, yformatter=None, dms=False,
-                 x_inline=None, y_inline=None, auto_inline=True):
+                 x_inline=None, y_inline=None, auto_inline=True,
+                 xlim=None, ylim=None):
         """
         Object used by :meth:`cartopy.mpl.geoaxes.GeoAxes.gridlines`
         to add gridlines and tick labels to a map.
@@ -155,6 +156,16 @@ class Gridliner:
             Toggle whether the y labels drawn should be inline.
         auto_inline: optional
             Set x_inline and y_inline automatically based on projection.
+        xlim: optional
+            Set a limit for the gridlines so that they do not go all the
+            way to the edge of the boundary. xlim can be a single number or
+            a (min, max) tuple. If a single number, the limits will be
+            (-xlim, +xlim).
+        ylim: optional
+            Set a limit for the gridlines so that they do not go all the
+            way to the edge of the boundary. ylim can be a single number or
+            a (min, max) tuple. If a single number, the limits will be
+            (-ylim, +ylim).
 
         Notes
         -----
@@ -240,6 +251,11 @@ class Gridliner:
             self.y_inline = y_inline
         elif not auto_inline:
             self.y_inline = False
+
+        # Gridline limits so that the gridlines don't extend all the way
+        # to the edge of the boundary
+        self.xlim = xlim
+        self.ylim = ylim
 
         #: Whether to draw the x gridlines.
         self.xlines = True
@@ -887,5 +903,21 @@ class Gridliner:
             prct = np.abs(np.diff(lon_range) / np.diff(crs.x_limits))
             if prct > 0.9:
                 lon_range = crs.x_limits
+
+        if self.xlim is not None:
+            if np.iterable(self.xlim):
+                # tuple, list or ndarray was passed in: (-140, 160)
+                lon_range = self.xlim
+            else:
+                # A single int/float was passed in: 140
+                lon_range = (-self.xlim, self.xlim)
+
+        if self.ylim is not None:
+            if np.iterable(self.ylim):
+                # tuple, list or ndarray was passed in: (-140, 160)
+                lat_range = self.ylim
+            else:
+                # A single int/float was passed in: 140
+                lat_range = (-self.ylim, self.ylim)
 
         return lon_range, lat_range

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -6,6 +6,7 @@
 
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
+import numpy as np
 import pytest
 
 import cartopy.crs as ccrs
@@ -319,3 +320,29 @@ def test_gridliner_default_fmtloc(
     plt.close()
     assert isinstance(gl.xlocator, xloc_expected)
     assert isinstance(gl.xformatter, xfmt_expected)
+
+
+def test_gridliner_line_limits():
+    fig = plt.figure()
+    ax = plt.subplot(1, 1, 1, projection=ccrs.NorthPolarStereo())
+    ax.set_global()
+    # Test a single value passed in which represents (-lim, lim)
+    xlim, ylim = 125, 75
+    gl = ax.gridlines(xlim=xlim, ylim=ylim)
+    fig.canvas.draw_idle()
+
+    paths = gl.xline_artists[0].get_paths() + gl.yline_artists[0].get_paths()
+    for path in paths:
+        assert (np.min(path.vertices, axis=0) >= (-xlim, -ylim)).all()
+        assert (np.max(path.vertices, axis=0) <= (xlim, ylim)).all()
+
+    # Test a pair of values passed in which represents the min, max
+    xlim = (-125, 150)
+    ylim = (50, 70)
+    gl = ax.gridlines(xlim=xlim, ylim=ylim)
+    fig.canvas.draw_idle()
+
+    paths = gl.xline_artists[0].get_paths() + gl.yline_artists[0].get_paths()
+    for path in paths:
+        assert (np.min(path.vertices, axis=0) >= (xlim[0], ylim[0])).all()
+        assert (np.max(path.vertices, axis=0) <= (xlim[1], ylim[1])).all()


### PR DESCRIPTION

## Rationale

Polar projections often look better without gridlines going all the way to the poles.

Modifying the example from 1568:
```python
import cartopy
import cartopy.crs as ccrs
import numpy as np
import matplotlib.pyplot as plt
import cartopy.feature as cfeature
import matplotlib.ticker as mticker
lats = mticker.FixedLocator(np.arange(-80, 81, 5))
lons = mticker.MultipleLocator(60)
fig = plt.figure(figsize=(6, 3))

ax = fig.add_subplot(121, projection=ccrs.NorthPolarStereo())
ax.set_extent([-180, 180, 70, 90], crs=ccrs.PlateCarree())
ax.gridlines(xlocs=lons, ylocs=lats, ylim=80, xlim=120)
ax.add_feature(cfeature.COASTLINE)

ax = fig.add_subplot(122, projection=ccrs.SouthPolarStereo())
ax.set_extent([-180, 180, -90, -70], crs=ccrs.PlateCarree())
ax.gridlines(xlocs=lons, ylocs=lats, ylim=80, xlim=120)
ax.add_feature(cfeature.COASTLINE)

fig.suptitle(f'Gridlines over polar projections in cartopy v{cartopy.__version__}')
```
![Figure_1](https://user-images.githubusercontent.com/12417828/82767383-6e7cd300-9de4-11ea-8c50-7858232858be.png)


## Implications

Fixes #1568