### PR TITLE
Fix for RGBA array

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1294,24 +1294,25 @@ class GeoAxes(matplotlib.axes.Axes):
             kwargs['alpha'] = alpha
 
             # As a workaround to a matplotlib limitation, turn any images
-            # which are RGB(A) with a mask into unmasked RGBA images with the
-            # (hopefully) proper alpha channel.
+            # which are RGB(A) with a mask into unmasked RGBA images with alpha
+            # put into the A channel.
             if (isinstance(img, np.ma.MaskedArray) and
                     len(img.shape) > 2 and
                     img.mask is not False):
+                # if we don't pop alpha, imshow will apply (erroneously?) a
+                # 1D alpha to the RGBA array
+                # kwargs['alpha'] is guaranteed to be either 1D, 2D, or None
+                alpha = kwargs.pop('alpha')
                 old_img = img[:, :, 0:3]
                 img = np.zeros(img.shape[:2] + (4, ), dtype=img.dtype)
                 img[:, :, 0:3] = old_img
                 # Put an alpha channel in if the image was masked.
-                if not np.any(kwargs['alpha']):
-                    kwargs['alpha'] = 1
-                img[:, :, 3] = np.ma.filled(kwargs['alpha'], fill_value=0) * \
+                if not np.any(alpha):
+                    alpha = 1
+                img[:, :, 3] = np.ma.filled(alpha, fill_value=0) * \
                     (~np.any(old_img.mask, axis=2))
                 if img.dtype.kind == 'u':
                     img[:, :, 3] *= 255
-                # if we don't pop alpha, imshow will apply (erroneously?) a
-                # 1D alpha to the RGBA array
-                kwargs.pop('alpha')
 
             result = matplotlib.axes.Axes.imshow(self, img, *args,
                                                  extent=extent, **kwargs)

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1294,24 +1294,24 @@ class GeoAxes(matplotlib.axes.Axes):
             kwargs['alpha'] = alpha
 
             # As a workaround to a matplotlib limitation, turn any images
-            # which are RGB with a mask into RGBA images with an alpha
-            # channel.
+            # which are RGB(A) with a mask into unmasked RGBA images with the
+            # (hopefully) proper alpha channel.
             if (isinstance(img, np.ma.MaskedArray) and
-                    img.shape[2:3] == (3, ) and
+                    len(img.shape) > 2 and
                     img.mask is not False):
-                old_img = img
+                old_img = img[:, :, 0:3]
                 img = np.zeros(img.shape[:2] + (4, ), dtype=img.dtype)
                 img[:, :, 0:3] = old_img
                 # Put an alpha channel in if the image was masked.
-                img[:, :, 3] = ~ np.any(old_img.mask, axis=2)
+                if not np.any(kwargs['alpha']):
+                    kwargs['alpha'] = 1
+                img[:, :, 3] = np.ma.filled(kwargs['alpha'], fill_value=0) * \
+                    (~np.any(old_img.mask, axis=2))
                 if img.dtype.kind == 'u':
                     img[:, :, 3] *= 255
-            elif (isinstance(img, np.ma.MaskedArray) and
-                    img.shape[2:3] == (4, ) and
-                    img.mask is not False):
-                img[:, :, 3][img.mask[:, :, 3]] = 0
-                if img.dtype.kind == 'u':
-                    img[:, :, 3] *= 255
+                # if we don't pop alpha, imshow will apply (erroneously?) a
+                # 1D alpha to the RGBA array
+                kwargs.pop('alpha')
 
             result = matplotlib.axes.Axes.imshow(self, img, *args,
                                                  extent=extent, **kwargs)

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1306,6 +1306,12 @@ class GeoAxes(matplotlib.axes.Axes):
                 img[:, :, 3] = ~ np.any(old_img.mask, axis=2)
                 if img.dtype.kind == 'u':
                     img[:, :, 3] *= 255
+            elif (isinstance(img, np.ma.MaskedArray) and
+                    img.shape[2:3] == (4, ) and
+                    img.mask is not False):
+                img[:, :, 3][img.mask[:, :, 3]] = 0
+                if img.dtype.kind == 'u':
+                    img[:, :, 3] *= 255
 
             result = matplotlib.axes.Axes.imshow(self, img, *args,
                                                  extent=extent, **kwargs)

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -155,7 +155,7 @@ def test_imshow_wrapping():
 def test_imshow_rgba():
     # tests that the alpha of a RGBA array passed to imshow is set to 0
     # instead of masked
-    z = np.random.rand(100, 100)
+    z = np.ones((100, 100))*0.5
     cmap = cm.get_cmap()
     norm = colors.Normalize(vmin=0, vmax=1)
     z1 = cmap(norm(z))
@@ -164,6 +164,18 @@ def test_imshow_rgba():
     ax = plt.axes(projection=plt_crs)
     ax.set_extent([-30, -20, 60, 70], crs=latlon_crs)
     img = ax.imshow(z1, extent=[-26, -24, 64, 66], transform=latlon_crs)
+    assert sum(img.get_array().data[:, 0, 3]) == 0
+
+
+def test_imshow_rgb():
+    # tests that the alpha of a RGB array passed to imshow is set to 0
+    # instead of masked
+    z = np.ones((100, 100, 3))*0.5
+    plt_crs = ccrs.LambertAzimuthalEqualArea()
+    latlon_crs = ccrs.PlateCarree()
+    ax = plt.axes(projection=plt_crs)
+    ax.set_extent([-30, -20, 60, 70], crs=latlon_crs)
+    img = ax.imshow(z, extent=[-26, -24, 64, 66], transform=latlon_crs)
     assert sum(img.get_array().data[:, 0, 3]) == 0
 
 

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -9,6 +9,8 @@ import types
 
 import numpy as np
 import matplotlib.pyplot as plt
+import matplotlib.cm as cm
+import matplotlib.colors as colors
 from PIL import Image
 import pytest
 import shapely.geometry as sgeom
@@ -148,6 +150,21 @@ def test_imshow_wrapping():
               extent=(0, 360, -90, 90))
 
     assert ax.get_xlim() == (-180, 180)
+
+
+def test_imshow_rgba():
+    # tests that the alpha of a RGBA array passed to imshow is set to 0
+    # instead of masked
+    z = np.random.rand(100, 100)
+    cmap = cm.get_cmap()
+    norm = colors.Normalize(vmin=0, vmax=1)
+    z1 = cmap(norm(z))
+    plt_crs = ccrs.LambertAzimuthalEqualArea()
+    latlon_crs = ccrs.PlateCarree()
+    ax = plt.axes(projection=plt_crs)
+    ax.set_extent([-30, -20, 60, 70], crs=latlon_crs)
+    img = ax.imshow(z1, extent=[-26, -24, 64, 66], transform=latlon_crs)
+    assert sum(img.get_array().data[:, 0, 3]) == 0
 
 
 @pytest.mark.xfail((5, 0, 0) <= ccrs.PROJ4_VERSION < (5, 1, 0),


### PR DESCRIPTION
## Implication

Fixes  #1570. The alpha channel of RGBA arrays is set to 0 instead of masked.
