### PR TITLE
Explicitly list functions that spherical transforms aren't allowed for

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -300,7 +300,12 @@ def _add_transform(func):
         transform = kwargs.get('transform', None)
         if transform is None:
             transform = self.projection
-        if (isinstance(transform, ccrs.CRS) and
+        # Raise an error if any of these functions try to use
+        # a spherical source CRS.
+        non_spherical_funcs = ['contour', 'contourf', 'pcolormesh', 'pcolor',
+                               'quiver', 'barbs', 'streamplot']
+        if (func.__name__ in non_spherical_funcs and
+                isinstance(transform, ccrs.CRS) and
                 not isinstance(transform, ccrs.Projection)):
             raise ValueError('Invalid transform: Spherical {} '
                              'is not supported - consider using '


### PR DESCRIPTION
Fixes #1583 

## Rationale

Adding the transform decorator in #1431 added a regression by removing the capability to scatter plot from a Geodetic source CRS. I've now explicitly listed which functions don't support the spherical plotting capabilities.