### PR TITLE
Add example of plt.subplots to the GeoAxes docs

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -313,7 +313,8 @@ class GeoAxes(matplotlib.axes.Axes):
         geo_axes = plt.axes(projection=cartopy.crs.PlateCarree())
 
         # Set up a standard map for latlon data for multiple subplots
-        fig, geo_axes = plt.subplots(nrows=2, ncols=2, subplot_kw={'projection': ccrs.PlateCarree()})
+        fig, geo_axes = plt.subplots(nrows=2, ncols=2,
+                            subplot_kw={'projection': ccrs.PlateCarree()})
 
         # Set up an OSGB map.
         geo_axes = plt.subplot(2, 2, 1, projection=cartopy.crs.OSGB())

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -312,6 +312,9 @@ class GeoAxes(matplotlib.axes.Axes):
         # Set up a standard map for latlon data.
         geo_axes = plt.axes(projection=cartopy.crs.PlateCarree())
 
+        # Set up a standard map for latlon data for multiple subplots
+        fig, geo_axes = plt.subplots(nrows=2, ncols=2, subplot_kw={'projection': ccrs.PlateCarree()})
+
         # Set up an OSGB map.
         geo_axes = plt.subplot(2, 2, 1, projection=cartopy.crs.OSGB())
 


### PR DESCRIPTION
Fix [1005](https://github.com/SciTools/cartopy/issues/1005). 

Added 2 lines in the geoaxis documentation to show how to set up the projection with `subplot_kw` when using `plt.subplots()`.


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
