### PR TITLE
Add example with label only on top and left sides

### DIFF
--- a/lib/cartopy/examples/gridliner.py
+++ b/lib/cartopy/examples/gridliner.py
@@ -1,21 +1,17 @@
 """
 Gridlines and tick labels
 -------------------------
-
 These examples demonstrate how to quickly add longitude
 and latitude gridlines and tick labels on a non-rectangular projection.
-
 As you can see on the first example,
 longitude labels may be drawn on left and right sides,
 and latitude labels may be drawn on bottom and top sides.
 Thanks to the ``dms`` keyword, minutes are used when appropriate
 to display fractions of degree.
-
-
 In the second example, labels are still drawn at the map edges
 despite its complexity, and some others are also drawn within the map
 boundary.
-
+In the third example, labels are drawn only on the left and bottom side.
 """
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
@@ -37,6 +33,12 @@ def main():
     ax1.coastlines(resolution='110m')
     ax1.gridlines(draw_labels=True)
 
+    plt.figure(figsize=(7, 3))
+    ax2 = plt.axes(projection=ccrs.PlateCarree())
+    ax2.coastlines(resolution='110m')
+    gl = ax2.gridlines(draw_labels=True)
+    gl.top_labels = False
+    gl.right_labels = False
     plt.show()
 
 

--- a/lib/cartopy/examples/gridliner.py
+++ b/lib/cartopy/examples/gridliner.py
@@ -3,18 +3,22 @@ Gridlines and tick labels
 -------------------------
 These examples demonstrate how to quickly add longitude
 and latitude gridlines and tick labels on a non-rectangular projection.
+
 As you can see on the first example,
 longitude labels may be drawn on left and right sides,
 and latitude labels may be drawn on bottom and top sides.
 Thanks to the ``dms`` keyword, minutes are used when appropriate
 to display fractions of degree.
+
 In the second example, labels are still drawn at the map edges
 despite its complexity, and some others are also drawn within the map
 boundary.
+
 In the third example, labels are drawn only on the left and bottom sides.
 """
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
+
 import matplotlib.pyplot as plt
 
 __tags__ = ['Gridlines', 'Tick labels', 'Lines and polygons']

--- a/lib/cartopy/examples/gridliner.py
+++ b/lib/cartopy/examples/gridliner.py
@@ -11,7 +11,7 @@ to display fractions of degree.
 In the second example, labels are still drawn at the map edges
 despite its complexity, and some others are also drawn within the map
 boundary.
-In the third example, labels are drawn only on the left and bottom side.
+In the third example, labels are drawn only on the left and bottom sides.
 """
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature


### PR DESCRIPTION
Fix [1511](https://github.com/SciTools/cartopy/issues/1511).

Added a third example in [gridliner.py](https://scitools.org.uk/cartopy/docs/latest/gallery/gridliner.html#sphx-glr-gallery-gridliner-py) to show how to *only* show labels on specific sides of a figure.