### PR TITLE
DOC: add pkg-config instructions for macOS install

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -23,6 +23,12 @@ Additional pre-built binaries can be found at a variety of sources, including:
 Building from source
 --------------------
 
+On macOS, make sure you have installed pkg-config and set the `PKG_CONFIG_PATH`
+enviornment variable as follows
+
+    brew install pkg-config
+    export PKG_CONFIG_PATH=/usr/local/bin/pkgconfig
+
 Before building Cartopy from source, you need to **first** install the
 required dependencies listed below. Once these are installed, Cartopy can be
 installed using the pip installer::

--- a/INSTALL
+++ b/INSTALL
@@ -62,7 +62,7 @@ For macOS, the required dependencies can be installed in the following way::
     pip3 install shapely --no-binary shapely
 
 Still on macOS, make sure you have installed pkg-config and set the
-`PKG_CONFIG_PATH` enviornment variable as follows
+`PKG_CONFIG_PATH` environment variable as follows
 
     brew install pkg-config
     export PKG_CONFIG_PATH=/usr/local/bin/pkgconfig

--- a/INSTALL
+++ b/INSTALL
@@ -23,12 +23,6 @@ Additional pre-built binaries can be found at a variety of sources, including:
 Building from source
 --------------------
 
-On macOS, make sure you have installed pkg-config and set the `PKG_CONFIG_PATH`
-enviornment variable as follows
-
-    brew install pkg-config
-    export PKG_CONFIG_PATH=/usr/local/bin/pkgconfig
-
 Before building Cartopy from source, you need to **first** install the
 required dependencies listed below. Once these are installed, Cartopy can be
 installed using the pip installer::
@@ -66,6 +60,16 @@ For macOS, the required dependencies can be installed in the following way::
     # shapely needs to be built from source to link to geos. If it is already
     # installed, uninstall it by: pip3 uninstall shapely
     pip3 install shapely --no-binary shapely
+
+Still on macOS, make sure you have installed pkg-config and set the
+`PKG_CONFIG_PATH` enviornment variable as follows
+
+    brew install pkg-config
+    export PKG_CONFIG_PATH=/usr/local/bin/pkgconfig
+
+Then you can install cartopy using
+
+    pip3 install cartopy
 
 If you are installing dependencies with a package manager on Linux, you may
 need to install the development packages (look for a "-dev" or "-devel" suffix) in addition


### PR DESCRIPTION
## Rationale

macOS should be able to install cartopy via `pip install cartopy` smoothly

## Implications

Better instructions will be provided to macOS users when they want to build
cartopy from the source.