### PR TITLE
Don't use `_shp`-suffixed Natural Earth files.

### DIFF
--- a/lib/cartopy/examples/hurricane_katrina.py
+++ b/lib/cartopy/examples/hurricane_katrina.py
@@ -49,7 +49,7 @@ def main():
 
     ax.set_extent([-125, -66.5, 20, 50], ccrs.Geodetic())
 
-    shapename = 'admin_1_states_provinces_lakes_shp'
+    shapename = 'admin_1_states_provinces_lakes'
     states_shp = shpreader.natural_earth(resolution='110m',
                                          category='cultural', name=shapename)
 

--- a/tools/feature_download.py
+++ b/tools/feature_download.py
@@ -57,7 +57,7 @@ FEATURE_DEFN_GROUPS = {
         ('cultural', 'admin_0_scale_rank', '110m'),
         ('cultural', 'admin_0_tiny_countries', '110m'),
         ('cultural', 'admin_0_pacific_groupings', '110m'),
-        ('cultural', 'admin_1_states_provinces_shp', '110m'),
+        ('cultural', 'admin_1_states_provinces', '110m'),
         ('cultural', 'admin_1_states_provinces_lines', '110m'),
     ),
 }


### PR DESCRIPTION
## Rationale

At some point, they seemed to have removed the suffix.

## Implications

Avoids issues like #1501.