### PR TITLE
Pcolormesh wrapping fix

### DIFF
--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -478,6 +478,22 @@ def test_pcolormesh_single_column_wrap():
     ax.set_global()
 
 
+def test_pcolormesh_diagonal_wrap():
+    # Check that a cell with the top edge on one side of the domain
+    # and the bottom edge on the other gets wrapped properly
+    xs = [[160, 170], [190, 200]]
+    ys = [[-10, -10], [10, 10]]
+    zs = [[0, 1], [0, 1]]
+
+    ax = plt.axes(projection=ccrs.PlateCarree())
+    mesh = ax.pcolormesh(xs, ys, zs)
+
+    # Check that the quadmesh is masked
+    assert np.ma.is_masked(mesh.get_array())
+    # And that the wrapped_collection is added
+    assert hasattr(mesh, "_wrapped_collection_fix")
+
+
 @pytest.mark.xfail(MPL_VERSION < '2.1.0', reason='Matplotlib is broken.')
 @pytest.mark.natural_earth
 @ImageTesting(['pcolormesh_goode_wrap'])


### PR DESCRIPTION
This implements the diagonal test that @htonchia put in #1467 and adds them as a coauthor to that commit.
I additionally added a simple test to demonstrate that works as expected.

There was some additional things in that other PR that can still be implemented later if desired.

## Rationale

Fixes several issues with identifying cells to mask and then uses pcolor to draw them properly.

Fixes #1416
Fixes #1447
Fixes #1328


## Implications

Slight difference in edge length calculation determining what the maximum cell diagonal vs edge length is compared to before. That is why I set this at 2*sqrt(2) now, otherwise the Goode image will fail if it is just half the distance like previous edge distances.