### PR TITLE
TST: Remove lock files from test directory

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ install:
   - conda config --add channels conda-forge/label/testing
   - if %PYTHON_VERSION%==3.6 conda update conda --yes
   - set ENV_NAME=test-environment
-  - set PACKAGES=%PACKAGES% filelock owslib pep8 pillow pyepsg pyshp pytest
+  - set PACKAGES=%PACKAGES% flufl.lock owslib pep8 pillow pyepsg pyshp pytest
   - set PACKAGES=%PACKAGES% requests setuptools_scm setuptools_scm_git_archive
   - set PACKAGES=%PACKAGES% shapely
   - conda create -n %ENV_NAME% python=%PYTHON_VERSION% %PACKAGES%

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
 
   # Customise the testing environment
   # ---------------------------------
-  - PACKAGES="$PACKAGES filelock owslib pep8 pillow pyepsg pyshp pytest"
+  - PACKAGES="$PACKAGES flufl.lock owslib pep8 pillow pyepsg pyshp pytest"
   - PACKAGES="$PACKAGES pytest-xdist requests setuptools_scm"
   - PACKAGES="$PACKAGES setuptools_scm_git_archive shapely"
   - |

--- a/INSTALL
+++ b/INSTALL
@@ -138,7 +138,7 @@ Testing Dependencies
 ~~~~~~~~~~~~~~~~~~~~
 These packages are required for the full Cartopy test suite to run.
 
-**filelock** (https://filelock.readthedocs.io/)
+**flufl.lock** (https://flufllock.readthedocs.io/)
     A platform independent file lock for Python.
 
 **mock** 1.0.1 (https://pypi.python.org/pypi/mock/)

--- a/lib/cartopy/tests/mpl/__init__.py
+++ b/lib/cartopy/tests/mpl/__init__.py
@@ -12,7 +12,7 @@ import glob
 import shutil
 import warnings
 
-import filelock
+import flufl.lock
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
@@ -144,9 +144,10 @@ class ImageTesting:
             if not os.path.isdir(os.path.dirname(result_path)):
                 os.makedirs(os.path.dirname(result_path))
 
-            with filelock.FileLock(result_path + '.lock').acquire():
+            with flufl.lock.Lock(result_path + '.lock'):
                 self.save_figure(figure, result_path)
                 self.do_compare(result_path, expected_path, self.tolerance)
+
 
     def save_figure(self, figure, result_fname):
         """

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,3 +1,3 @@
-filelock
+flufl.lock
 mock>=1.0.1
 pytest>=3.0.0


### PR DESCRIPTION
This cleans up the image test directory by removing the empty '.lock' files that were created.

## Rationale

Each image has an empty '.lock' file after the test suite is run. This is an attempt to clean that up.

## Implications

I am not sure if the `unlink` immediately after the `with` block will enter any race conditions on multi-threaded test runs, but I assume not because it is done immediately? It would be good for someone with more knowledge on the lockfile paradigm to make sure this is OK.