### PR TITLE
Cleaning up test warnings

### DIFF
--- a/lib/cartopy/tests/io/test_downloaders.py
+++ b/lib/cartopy/tests/io/test_downloaders.py
@@ -148,7 +148,8 @@ def test_natural_earth_downloader(tmpdir):
 
     # check that the file gets downloaded the first time path is called
     with CallCounter(dnld_item, 'acquire_resource') as counter:
-        shp_path = dnld_item.path(format_dict)
+        with pytest.warns(cartopy.io.DownloadWarning, match="Downloading:"):
+            shp_path = dnld_item.path(format_dict)
     assert counter.count == 1, 'Item not downloaded.'
 
     assert shp_path_template.format(**format_dict) == shp_path

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -165,6 +165,7 @@ def test_imshow_rgba():
     ax.set_extent([-30, -20, 60, 70], crs=latlon_crs)
     img = ax.imshow(z1, extent=[-26, -24, 64, 66], transform=latlon_crs)
     assert sum(img.get_array().data[:, 0, 3]) == 0
+    plt.close()
 
 
 def test_imshow_rgb():
@@ -177,6 +178,7 @@ def test_imshow_rgb():
     ax.set_extent([-30, -20, 60, 70], crs=latlon_crs)
     img = ax.imshow(z, extent=[-26, -24, 64, 66], transform=latlon_crs)
     assert sum(img.get_array().data[:, 0, 3]) == 0
+    plt.close()
 
 
 @pytest.mark.xfail((5, 0, 0) <= ccrs.PROJ4_VERSION < (5, 1, 0),
@@ -229,3 +231,4 @@ def test_alpha_2d_warp():
     image_alpha = image.get_alpha()
 
     assert image_data.shape == image_alpha.shape
+    plt.close()


### PR DESCRIPTION
This cleans up the warnings from the test suite.

First commit: Deprecation warning from MPL for reusing the same axes. They aren't image tests, so weren't closing the figures. Fixed this by calling close after each non-image comparison test.

Second commit: Catch the expected DownloadWarning with pytest to remove that warning.

## Rationale

Fewer warnings

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
