### PR TITLE
Adding an autouse fixture to close plots after each test

### DIFF
--- a/lib/cartopy/tests/mpl/conftest.py
+++ b/lib/cartopy/tests/mpl/conftest.py
@@ -1,0 +1,21 @@
+# Copyright Cartopy Contributors
+#
+# This file is part of Cartopy and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+import matplotlib.pyplot as plt
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mpl_test_cleanup(request):
+    """Runs tests in a context manager and closes figures after each test"""
+    try:
+        # Run each test in a context manager so that state does not leak out
+        orig_backend = plt.get_backend()
+        plt.switch_backend('Agg')
+        with plt.rc_context():
+            yield
+    finally:
+        # Closes all open figures and switches backend back to original
+        plt.switch_backend(orig_backend)


### PR DESCRIPTION
Automatically closing figures after each test. Implemented the suggestion from https://github.com/SciTools/cartopy/pull/1625#issuecomment-668380062


## Rationale

Will automatically close figures after each test to not reuse the same figures.


## Implications


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
