### PR TITLE
Filter warnings that we can expect

### DIFF
--- a/lib/cartopy/tests/io/test_ogc_clients.py
+++ b/lib/cartopy/tests/io/test_ogc_clients.py
@@ -129,6 +129,7 @@ class TestWMSRasterSource:
         assert img.shape == (40, 20, 4)
 
 
+@pytest.mark.filterwarnings("ignore:TileMatrixLimits")
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
 @pytest.mark.xfail(raises=KeyError, reason='OWSLib WMTS support is broken.')

--- a/lib/cartopy/tests/mpl/test_caching.py
+++ b/lib/cartopy/tests/mpl/test_caching.py
@@ -110,7 +110,7 @@ def test_shapefile_transform_cache():
     # a5caae040ee11e72a62a53100fe5edc355304419 added shapefile mpl
     # geometry caching based on geometry object id. This test ensures
     # it is working.
-    coastline_path = cartopy.io.shapereader.natural_earth(resolution="50m",
+    coastline_path = cartopy.io.shapereader.natural_earth(resolution="110m",
                                                           category='physical',
                                                           name='coastline')
     geoms = cartopy.io.shapereader.Reader(coastline_path).geometries()
@@ -191,6 +191,7 @@ def test_contourf_transform_path_counting():
     plt.close()
 
 
+@pytest.mark.filterwarnings("ignore:TileMatrixLimits")
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
 @pytest.mark.xfail(raises=KeyError, reason='OWSLib WMTS support is broken.')

--- a/lib/cartopy/tests/mpl/test_features.py
+++ b/lib/cartopy/tests/mpl/test_features.py
@@ -14,6 +14,7 @@ from cartopy.io.ogc_clients import _OWSLIB_AVAILABLE
 from cartopy.tests.mpl import MPL_VERSION, ImageTesting
 
 
+@pytest.mark.filterwarnings("ignore:Downloading")
 @pytest.mark.natural_earth
 @ImageTesting(['natural_earth'])
 def test_natural_earth():
@@ -28,6 +29,7 @@ def test_natural_earth():
     ax.set_ylim((-40, 40))
 
 
+@pytest.mark.filterwarnings("ignore:Downloading")
 @pytest.mark.natural_earth
 @ImageTesting(['natural_earth_custom'])
 def test_natural_earth_custom():

--- a/lib/cartopy/tests/mpl/test_web_services.py
+++ b/lib/cartopy/tests/mpl/test_web_services.py
@@ -13,6 +13,7 @@ import cartopy.crs as ccrs
 from cartopy.io.ogc_clients import _OWSLIB_AVAILABLE
 
 
+@pytest.mark.filterwarnings("ignore:TileMatrixLimits")
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
 @pytest.mark.xfail(raises=KeyError, reason='OWSLib WMTS support is broken.')

--- a/lib/cartopy/tests/test_coastline.py
+++ b/lib/cartopy/tests/test_coastline.py
@@ -10,6 +10,7 @@ import cartopy
 import cartopy.io.shapereader as shp
 
 
+@pytest.mark.filterwarnings("ignore:Downloading")
 @pytest.mark.natural_earth
 class TestCoastline:
     def test_robust(self):

--- a/lib/cartopy/tests/test_shapereader.py
+++ b/lib/cartopy/tests/test_shapereader.py
@@ -69,6 +69,7 @@ class TestLakes:
             'The geometry was loaded in order to create the bounds.'
 
 
+@pytest.mark.filterwarnings("ignore:Downloading")
 @pytest.mark.natural_earth
 class TestRivers:
     def setup_class(self):


### PR DESCRIPTION
This helps to filter out CI logs due to always issuing DownloadWarning and TileMatrixLimits that we know can be emitted in new environments.

I noticed that there is also a DownloadWarning issued when importing the shapereader module. This is due to running the docstring that happens to download the NaturalEarth there. I'm not clear how to filter that warning or not run the docstring while in pytest.

## Rationale

Cleaner logs when running tests.

## Implications

No more warnings about these things.