### PR TITLE
Updating tolerance of tight gridliner test

### DIFF
--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -241,7 +241,9 @@ def test_grid_labels():
     MPL_VERSION < '2.0.0',
     reason='Impossible to override tight layout algorithm in mpl < 2.0.0')
 @pytest.mark.natural_earth
-@ImageTesting(['gridliner_labels_tight'], tolerance=grid_label_tol)
+@ImageTesting(['gridliner_labels_tight'],
+              tolerance=grid_label_tol if ccrs.PROJ4_VERSION < (7, 1, 0)
+              else 4)
 def test_grid_labels_tight():
 
     # Ensure tight layout accounts for gridlines


### PR DESCRIPTION
With PROJ version 7.1, the 0 degree line shifted slightly. This is the failed difference image.
![result-gridliner_labels_tight-failed-diff](https://user-images.githubusercontent.com/12417828/89590037-3e9a7480-d804-11ea-949c-e7f90071f353.png)

## Rationale

This expands the tolerance for this specific test if the PROJ version is 7.1 or newer.