### PR TITLE
Remove mock dependency.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -141,10 +141,6 @@ These packages are required for the full Cartopy test suite to run.
 **flufl.lock** (https://flufllock.readthedocs.io/)
     A platform independent file lock for Python.
 
-**mock** 1.0.1 (https://pypi.python.org/pypi/mock/)
-    Python mocking and patching package for testing. Note that this package
-    is only required to support the Cartopy unit tests.
-
 **pytest** 3.1.0 or later (https://docs.pytest.org/en/latest/)
     Python package for software testing.
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,3 +1,2 @@
 flufl.lock
-mock>=1.0.1
 pytest>=3.0.0


### PR DESCRIPTION
## Rationale

We require Python 3.5 now and use `unittest.mock`, so the separate library is unneeded.

## Implications

One less test dependency.