### PR TITLE
Fixing a problem with lost resolution in imshow

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1314,7 +1314,21 @@ class GeoAxes(matplotlib.axes.Axes):
                 raise ValueError('Expected a projection subclass. Cannot '
                                  'handle a %s in imshow.' % type(transform))
 
-            target_extent = self.get_extent(self.projection)
+            # |target_extent| is the area the image will cover in
+            # target projection coordinates. This affects the
+            # resolution of the rescaled image.
+            if extent is None:
+                # This assumes it will cover the current visible area.
+                target_extent = self.get_extent(self.projection)
+            else:
+                box = sgeom.box(extent[0], extent[2], extent[1], extent[3])
+                target_geometry = transform.project_geometry(box,
+                                                             self.projection)
+                target_extent = (target_geometry.bounds[0],
+                                 target_geometry.bounds[2],
+                                 target_geometry.bounds[1],
+                                 target_geometry.bounds[3])
+
             regrid_shape = kwargs.pop('regrid_shape', 750)
             regrid_shape = self._regrid_shape_aspect(regrid_shape,
                                                      target_extent)


### PR DESCRIPTION
imshow would assume an image would cover the whole plot which sometimes,
when the intent was to just plot in a small part of the image resulted in
a lot of lost resolution.

This happened because the created mesh grid was stretched to cover the
whole screen, and then only a small part of the mesh was actually used.

The lost resolution was proportional to the amount of space the image
used in the plot, so an image that was set to show in 10% of the width,
only kept 10% of its resolution.

There are other factors, like regrid_shape, that can also affect the
resolution of the output and a very, very large regrid_shape could
compensate for this problem at the cost of computation time.

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

I was trying to plot lots of very high resolution images on a map where they each covered just a small fraction of the full plot. This turned out to result in 95% of the original pixels getting lost. I think it's better to not lose pixels.

## Implications

This should have very little effect when images cover most of the plot, but when they don't, it can either result in higher resolution or the same resolution. If extent is larger than the visible area it will result in a more sparse remesh grid but in those cases the source data did not have enough pixels anyway so I think it will primarily result in fewer duplicate pixels (and maybe higher performance).

There is also the risk that there is a logical bug in what I have done that will result in the earth imploding. 

I don't know enough about testing in cartopy, or testing coverage, to make a test for it, but maybe someone can assist me.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
