### PR TITLE
Pcolormesh update for interpolation with wrapped coordinates

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -641,6 +641,8 @@ class Projection(CRS, metaclass=ABCMeta):
         'MultiLineString': '_project_multiline',
         'MultiPolygon': '_project_multipolygon',
     }
+    # Whether or not this projection can handle wrapped coordinates
+    _wrappable = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1248,6 +1250,8 @@ class _RectangularProjection(Projection, metaclass=ABCMeta):
     is symmetric about the origin.
 
     """
+    _wrappable = True
+
     def __init__(self, proj4_params, half_width, half_height, globe=None):
         self._half_width = half_width
         self._half_height = half_height
@@ -1273,6 +1277,7 @@ class _CylindricalProjection(_RectangularProjection, metaclass=ABCMeta):
     want to allow x values to wrap around.
 
     """
+    _wrappable = True
 
 
 def _ellipse_boundary(semimajor=2, semiminor=1, easting=0, northing=0, n=201):
@@ -1386,6 +1391,8 @@ class TransverseMercator(Projection):
     A Transverse Mercator projection.
 
     """
+    _wrappable = True
+
     def __init__(self, central_longitude=0.0, central_latitude=0.0,
                  false_easting=0.0, false_northing=0.0,
                  scale_factor=1.0, globe=None, approx=None):
@@ -1579,6 +1586,7 @@ class Mercator(Projection):
     A Mercator projection.
 
     """
+    _wrappable = True
 
     def __init__(self, central_longitude=0.0,
                  min_latitude=-80.0, max_latitude=84.0,
@@ -1826,6 +1834,7 @@ class LambertAzimuthalEqualArea(Projection):
     A Lambert Azimuthal Equal-Area projection.
 
     """
+    _wrappable = True
 
     def __init__(self, central_longitude=0.0, central_latitude=0.0,
                  false_easting=0.0, false_northing=0.0,
@@ -1969,6 +1978,8 @@ class Gnomonic(Projection):
 
 
 class Stereographic(Projection):
+    _wrappable = True
+
     def __init__(self, central_latitude=0.0, central_longitude=0.0,
                  false_easting=0.0, false_northing=0.0,
                  true_scale_latitude=None,
@@ -2082,6 +2093,8 @@ class Orthographic(Projection):
 
 
 class _WarpedRectangularProjection(Projection, metaclass=ABCMeta):
+    _wrappable = True
+
     def __init__(self, proj4_params, central_longitude,
                  false_easting=None, false_northing=None, globe=None):
         if false_easting is not None:
@@ -2428,6 +2441,8 @@ class InterruptedGoodeHomolosine(Projection):
     A central_longitude value of -160 is recommended for the oceanic view.
 
     """
+    _wrappable = True
+
     def __init__(self, central_longitude=0, globe=None, emphasis='land'):
         """
         Parameters
@@ -2804,6 +2819,7 @@ class AzimuthalEquidistant(Projection):
     This projection provides accurate angles about and distances through the
     central position. Other angles, distances, or areas may be distorted.
     """
+    _wrappable = True
 
     def __init__(self, central_longitude=0.0, central_latitude=0.0,
                  false_easting=0.0, false_northing=0.0,

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -68,16 +68,6 @@ A dictionary of background images in the directory specified by the
 CARTOPY_USER_BACKGROUNDS environment variable.
 """
 
-# A list of projections that can have wrapped coordinates.
-_WRAP_PROJECTIONS = (ccrs._RectangularProjection,
-                     ccrs._WarpedRectangularProjection,
-                     ccrs.InterruptedGoodeHomolosine,
-                     ccrs.Mercator,
-                     ccrs.LambertAzimuthalEqualArea,
-                     ccrs.AzimuthalEquidistant,
-                     ccrs.TransverseMercator,
-                     ccrs.Stereographic)
-
 
 # XXX call this InterCRSTransform
 class InterProjectionTransform(mtransforms.Transform):
@@ -1816,7 +1806,7 @@ class GeoAxes(matplotlib.axes.Axes):
         """
         if (kwargs.get('shading', 'auto') in ('nearest', 'auto') and
                 len(args) == 3 and
-                isinstance(kwargs.get('transform'), _WRAP_PROJECTIONS)):
+                getattr(kwargs.get('transform'), '_wrappable', False)):
             X = np.asanyarray(args[0])
             Y = np.asanyarray(args[1])
             nrows, ncols = np.asanyarray(args[2]).shape
@@ -1863,8 +1853,8 @@ class GeoAxes(matplotlib.axes.Axes):
         cross the boundary of the projection.
         """
         t = kwargs.get('transform', None)
-        if not (isinstance(t, _WRAP_PROJECTIONS) and
-                isinstance(self.projection, _WRAP_PROJECTIONS)):
+        if not (getattr(t, '_wrappable', False) and
+                getattr(self.projection, '_wrappable', False)):
             # Nothing to do
             return collection
 

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -571,7 +571,9 @@ def test_pcolormesh_single_column_wrap():
     plt.figure(figsize=(10, 6))
 
     ax = plt.subplot(111, projection=ccrs.PlateCarree(180))
-    plt.pcolormesh(xbnds, ybnds, data, transform=rp, cmap='Spectral')
+    # TODO: Remove snap when updating this image
+    plt.pcolormesh(xbnds, ybnds, data, transform=rp, cmap='Spectral',
+                   snap=False)
     ax.coastlines()
     ax.set_global()
 
@@ -615,7 +617,8 @@ def test_pcolormesh_goode_wrap():
     Z = Z[:-1, :-1]
     ax = plt.axes(projection=ccrs.InterruptedGoodeHomolosine(emphasis='land'))
     ax.coastlines()
-    ax.pcolormesh(x, y, Z, transform=ccrs.PlateCarree())
+    # TODO: Remove snap when updating this image
+    ax.pcolormesh(x, y, Z, transform=ccrs.PlateCarree(), snap=False)
 
 
 @pytest.mark.natural_earth

--- a/lib/cartopy/tests/mpl/test_pseudo_color.py
+++ b/lib/cartopy/tests/mpl/test_pseudo_color.py
@@ -53,3 +53,34 @@ def test_savefig_tight():
     buf = io.BytesIO()
     plt.savefig(buf, format='png', bbox_inches='tight')
     plt.close()
+
+
+def test_pcolormesh_arg_interpolation():
+    # Test that making the edges from center point inputs
+    # properly accounts for the wrapped coordinates appearing
+    # in the middle of an array
+    x = [359, 1, 3]
+    y = [-10, 10]
+
+    xs, ys = np.meshgrid(x, y)
+    # Z with the same shape as X/Y to force the interpolation
+    z = np.zeros(xs.shape)
+
+    ax = plt.subplot(211, projection=ccrs.PlateCarree())
+    coll = ax.pcolormesh(xs, ys, z, shading='auto',
+                         transform=ccrs.PlateCarree())
+
+    # Compare the output coordinates of the generated mesh
+    expected = np.array([[[358, -20],
+                          [360, -20],
+                          [2, -20],
+                          [4, -20]],
+                         [[358, 0],
+                          [360, 0],
+                          [2, 0],
+                          [4, 0]],
+                         [[358, 20],
+                          [360, 20],
+                          [2, 20],
+                          [4, 20]]])
+    np.testing.assert_array_almost_equal(expected, coll._coordinates)


### PR DESCRIPTION
Fixes #1638 

## Rationale
The new shading keyword argument in MPL 3.3 causes an interpolation that creates new edges. With coordinates that could potentially be wrapped, as in map projections, this could cause new erroneous interpolation points to be inserted into the coordinates.

## Implications

A big refactor of pcolormesh to avoid calling private MPL functions. We still have to use the private `_coordinates` Quadmesh attribute to get the coordinates, I couldn't find a way around that for now.

We also now calculate some edges in Cartopy, meaning more code to maintain.