### PR TITLE
MAINT: Getting rid of Flake8 errors

### DIFF
--- a/lib/cartopy/tests/mpl/__init__.py
+++ b/lib/cartopy/tests/mpl/__init__.py
@@ -5,7 +5,6 @@
 # licensing details.
 
 import base64
-import contextlib
 import distutils
 import os
 import glob
@@ -147,7 +146,6 @@ class ImageTesting:
             with flufl.lock.Lock(result_path + '.lock'):
                 self.save_figure(figure, result_path)
                 self.do_compare(result_path, expected_path, self.tolerance)
-
 
     def save_figure(self, figure, result_fname):
         """

--- a/lib/cartopy/tests/mpl/test_axes.py
+++ b/lib/cartopy/tests/mpl/test_axes.py
@@ -125,7 +125,8 @@ def test_geoaxes_subplot():
 @ImageTesting(['geoaxes_subslice'])
 def test_geoaxes_no_subslice():
     """Test that we do not trigger matplotlib's line subslice optimization."""
-    # This behavior caused lines with > 1000 points and sorted data to disappear
+    # This behavior caused lines with > 1000 points and
+    # sorted data to disappear
 
     fig, axes = plt.subplots(1, 2, subplot_kw={'projection': ccrs.Mercator()})
     for ax, num_points in zip(axes, [1000, 1001]):

--- a/lib/cartopy/tests/mpl/test_examples.py
+++ b/lib/cartopy/tests/mpl/test_examples.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import pytest
 
 import cartopy.crs as ccrs
-from cartopy.tests.mpl import MPL_VERSION, ImageTesting
+from cartopy.tests.mpl import ImageTesting
 
 
 class ExampleImageTesting(ImageTesting):

--- a/lib/cartopy/tests/mpl/test_pseudo_color.py
+++ b/lib/cartopy/tests/mpl/test_pseudo_color.py
@@ -9,7 +9,6 @@ from unittest import mock
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pytest
 
 import cartopy.crs as ccrs
 


### PR DESCRIPTION
## Rationale

As the name suggests, fixing flake8 errors.

## Implications

Maybe we should make flake8 check the test directory as well, since these were all over there?