### PR TITLE
Update dependency to pyshp v2.1.1 to correctly display shapefiles with multi-polygon holes

### DIFF
--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -53,7 +53,7 @@ class Record:
     their associated geometry.
 
     """
-    def __init__(self, shape, attributes):
+    def __init__(self, shape, attributes, fields):
         self._shape = shape
 
         self._bounds = None
@@ -67,6 +67,8 @@ class Record:
 
         self.attributes = attributes
         """A dictionary mapping attribute names to attribute values."""
+        
+        self._fields = fields
 
     def __repr__(self):
         return '<Record: {!r}, {!r}, <fields>>'.format(
@@ -160,9 +162,12 @@ class BasicReader:
         Return an iterator of :class:`~Record` instances.
 
         """
+        # Ignore the "DeletionFlag" field which always comes first
+        fields = self._reader.fields[1:]
+        field_names = [field[0] for field in fields]
         for shape_record in self._reader.iterShapeRecords():
             attributes = shape_record.record.as_dict()
-            yield Record(shape_record.shape, attributes)
+            yield Record(shape_record.shape, attributes, field_names)
 
 
 class FionaReader:

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -160,7 +160,7 @@ class BasicReader:
         Return an iterator of :class:`~Record` instances.
 
         """
-        for shape_record in self._reader.iterShapeRecords()):
+        for shape_record in self._reader.iterShapeRecords():
             attributes = shape_record.record.as_dict()
             yield Record(shape_record.shape, attributes)
 

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -53,7 +53,7 @@ class Record:
     their associated geometry.
 
     """
-    def __init__(self, shape, attributes, fields):
+    def __init__(self, shape, attributes):
         self._shape = shape
 
         self._bounds = None
@@ -67,8 +67,6 @@ class Record:
 
         self.attributes = attributes
         """A dictionary mapping attribute names to attribute values."""
-
-        self._fields = fields
 
     def __repr__(self):
         return '<Record: {!r}, {!r}, <fields>>'.format(
@@ -162,12 +160,9 @@ class BasicReader:
         Return an iterator of :class:`~Record` instances.
 
         """
-        # Ignore the "DeletionFlag" field which always comes first
-        fields = self._reader.fields[1:]
-        field_names = [field[0] for field in fields]
         for shape_record in self._reader.iterShapeRecords()):
             attributes = shape_record.record.as_dict()
-            yield Record(shape_record.shape, attributes, fields)
+            yield Record(shape_record.shape, attributes)
 
 
 class FionaReader:

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -138,7 +138,7 @@ class BasicReader:
         return self._reader.close()
 
     def __len__(self):
-        return self._reader.numRecords
+        return len(self._reader)
 
     def geometries(self):
         """
@@ -152,8 +152,7 @@ class BasicReader:
         :meth:`~Record.geometry` method.
 
         """
-        for i in range(self._reader.numRecords):
-            shape = self._reader.shape(i)
+        for shape in self._reader.iterShapes():
             # Skip the shape that can not be represented as geometry.
             if shape.shapeType != shapefile.NULL:
                 yield sgeom.shape(shape)
@@ -166,9 +165,8 @@ class BasicReader:
         # Ignore the "DeletionFlag" field which always comes first
         fields = self._reader.fields[1:]
         field_names = [field[0] for field in fields]
-        for i in range(self._reader.numRecords):
-            shape_record = self._reader.shapeRecord(i)
-            attributes = dict(zip(field_names, shape_record.record))
+        for shape_record in self._reader.iterShapeRecords()):
+            attributes = shape_record.record.as_dict()
             yield Record(shape_record.shape, attributes, fields)
 
 

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -67,7 +67,7 @@ class Record:
 
         self.attributes = attributes
         """A dictionary mapping attribute names to attribute values."""
-        
+
         self._fields = fields
 
     def __repr__(self):
@@ -167,7 +167,7 @@ class BasicReader:
         field_names = [field[0] for field in fields]
         for shape_record in self._reader.iterShapeRecords():
             attributes = shape_record.record.as_dict()
-            yield Record(shape_record.shape, attributes, field_names)
+            yield Record(shape_record.shape, attributes, fields)
 
 
 class FionaReader:

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
 numpy>=1.10
 shapely>=1.5.6
-pyshp>=2.1.1
+pyshp>=2
 setuptools>=0.7.2

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
 numpy>=1.10
 shapely>=1.5.6
-pyshp>=1.1.4
+pyshp>=2.1.1
 setuptools>=0.7.2


### PR DESCRIPTION
## Rationale

The new v0.18 introduced problems with rendering some shapefiles (#1578). This was due to how the pyshp dependency converted the internal shapefile shape structure to GeoJSON for multipolygons with holes, sometimes assigning the holes to the wrong polygon. A new version of PyShp has since fixed this issue, including several other shapefile bug fixes, and this PR updates the dependency to use the newest PyShp version. The PR also cleans up some of the code that uses pyshp. 


## Implications

This bugfix PR will make it a requirement for all cartopy users to upgrade their pyshp version to >= v2.1.1, in order to ensure that all Cartopy users get the correct rendering (#1578). I'm not sure to what degree requiring such an upgrade is a nuisance, or if the added benefit is sufficient for such a change. 

As part of cleaning up the code that uses pyshp, I also removed the io.shapereader.Record's `fields` argument and private `._fields` attribute, as this did not seem to be used anywhere else in the codebase, and shouldn't have any benefit, since the record's fieldnames are already stored as the keys to the `attributes` dict. Anything that relies on this seemingly unused `fields` arg/attr would break, but I see no reason why anyone would need it and the attribute is private anyway. 


