### PR TITLE
Update color limits for _wrapped_collection_fix automatically fixing #1654

### DIFF
--- a/lib/cartopy/mpl/geocollection.py
+++ b/lib/cartopy/mpl/geocollection.py
@@ -43,4 +43,4 @@ class GeoQuadMesh(QuadMesh):
             self._wrapped_collection_fix.set_clim(vmin, vmax)
 
         # Update color limits for the rest of the cells.
-        super(QuadMesh, self).set_clim(vmin, vmax)
+        super().set_clim(vmin, vmax)

--- a/lib/cartopy/mpl/geocollection.py
+++ b/lib/cartopy/mpl/geocollection.py
@@ -36,3 +36,11 @@ class GeoQuadMesh(QuadMesh):
         # Now that we have prepared the collection data, call on
         # through to the underlying implementation.
         super(QuadMesh, self).set_array(A)
+
+    def set_clim(self, vmin=None, vmax=None):
+        # Update _wrapped_collection_fix color limits if it is there.
+        if hasattr(self, '_wrapped_collection_fix'):
+            self._wrapped_collection_fix.set_clim(vmin, vmax)
+
+        # Update color limits for the rest of the cells.
+        super(QuadMesh, self).set_clim(vmin, vmax)

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -447,6 +447,7 @@ def test_pcolormesh_set_array_with_mask():
     ax.coastlines()
     ax.set_global()  # make sure everything is visible
 
+
 @pytest.mark.natural_earth
 @ImageTesting(['pcolormesh_global_wrap3'], tolerance=tolerance)
 def test_pcolormesh_set_clim_with_mask():

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -470,7 +470,8 @@ def test_pcolormesh_set_clim_with_mask():
     bad_initial_norm = plt.Normalize(-100, 100)
 
     ax = plt.subplot(311, projection=ccrs.PlateCarree(-45))
-    c = plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(), norm=bad_initial_norm)
+    c = plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(),
+                       norm=bad_initial_norm)
     assert c._wrapped_collection_fix is not None, \
         'No pcolormesh wrapping was done when it should have been.'
 


### PR DESCRIPTION
Hi everyone. This is my first PR to cartopy but I've been interested in doing so for a while. I apologize if I've followed any guidelines incorrectly.  

This PR fixes #1654. It adds an override to GeoQuadMesh such that if the `_wrapped_collection_fix` attribute exists `set_clim()` also gets called on `self._wrapped_collection_fix`.

## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
After #1622 cells that cross the antimeridian are a part of a different collection (`_wrapped_collection_fix`). Therefore, to update color limits on those cells, `set_clim()` must be explicitly called.

## Implications

I'm not aware of any, however, if the `_wrapped_collection_fix` collection is removed, so should these changes.


Let me know if you have any questions, or if you'd like any changes.
