### PR TITLE
Add option to remove 'E', 'W', 'N', 'S' from axis labels. Fixes #1635

### DIFF
--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -275,6 +275,7 @@ class LatitudeFormatter(_PlateCarreeFormatter):
 
         """
         super().__init__(
+            direction_label=direction_label,
             degree_symbol=degree_symbol,
             number_format=number_format,
             transform_precision=transform_precision,
@@ -285,15 +286,10 @@ class LatitudeFormatter(_PlateCarreeFormatter):
             auto_hide=auto_hide,
         )
 
-        self._direction_labels = direction_label
-
     def _apply_transform(self, value, target_proj, source_crs):
         return target_proj.transform_point(0, value, source_crs)[1]
 
     def _hemisphere(self, value, value_source_crs):
-
-        if not self._direction_labels:
-            return ''
 
         if value > 0:
             hemisphere = 'N'
@@ -403,6 +399,7 @@ class LongitudeFormatter(_PlateCarreeFormatter):
             labels = [lon_formatter(value) for value in ticks]
         """
         super().__init__(
+            direction_label=direction_label,
             degree_symbol=degree_symbol,
             number_format=number_format,
             transform_precision=transform_precision,
@@ -412,7 +409,6 @@ class LongitudeFormatter(_PlateCarreeFormatter):
             seconds_number_format=seconds_number_format,
             auto_hide=auto_hide,
         )
-        self._direction_labels = direction_label
         self._zero_direction_labels = zero_direction_label
         self._dateline_direction_labels = dateline_direction_label
 
@@ -446,9 +442,6 @@ class LongitudeFormatter(_PlateCarreeFormatter):
         return _PlateCarreeFormatter._format_degrees(self, self._fix_lons(deg))
 
     def _hemisphere(self, value, value_source_crs):
-
-        if not self._direction_labels:
-            return ''
 
         value = self._fix_lons(value)
         # Perform basic hemisphere detection.

--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -101,7 +101,7 @@ class _PlateCarreeFormatter(Formatter):
             label = self._format_minutes(mn) + label
 
         if not self._auto_hide_degrees or not label:
-            label = self._format_degrees(deg) + hemisphere + label
+            label = sign + self._format_degrees(deg) + hemisphere + label
 
         return label
 

--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -21,8 +21,8 @@ class _PlateCarreeFormatter(Formatter):
 
     _target_projection = ccrs.PlateCarree()
 
-    def __init__(self, degree_symbol='\u00B0', number_format='g',
-                 transform_precision=1e-8, dms=False,
+    def __init__(self, direction_label=True, degree_symbol='\u00B0',
+                 number_format='g', transform_precision=1e-8, dms=False,
                  minute_symbol="'", second_symbol="''",
                  seconds_number_format='g',
                  auto_hide=True):
@@ -31,6 +31,7 @@ class _PlateCarreeFormatter(Formatter):
         for latitude and longitude axes.
 
         """
+        self._direction_labels = direction_label
         self._degree_symbol = degree_symbol
         self._degrees_number_format = number_format
         self._transform_precision = transform_precision
@@ -74,7 +75,10 @@ class _PlateCarreeFormatter(Formatter):
         return self._format_value(projected_value, value)
 
     def _format_value(self, value, original_value):
-        hemisphere = self._hemisphere(value, original_value)
+
+        hemisphere = ''
+        if self._direction_labels:
+            hemisphere = self._hemisphere(value, original_value)
 
         if not self._dms:
             return (self._format_degrees(abs(value)) +

--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -115,7 +115,7 @@ class _PlateCarreeFormatter(Formatter):
         degs = np.round(x, self._precision).astype('i')
         y = (x - degs) * 60
         mins = np.round(y, self._precision).astype('i')
-        secs = np.round((y - mins)*60, self._precision - 3)
+        secs = np.round((y - mins) * 60, self._precision - 3)
         return x, degs, mins, secs
 
     def set_locs(self, locs):
@@ -123,7 +123,7 @@ class _PlateCarreeFormatter(Formatter):
         if not self._auto_hide:
             return
         self.locs, degs, mins, secs = self._get_dms(self.locs)
-        secs = np.round(secs, self._precision-3).astype('i')
+        secs = np.round(secs, self._precision - 3).astype('i')
         secs0 = secs == 0
         mins0 = mins == 0
 
@@ -189,7 +189,9 @@ class _PlateCarreeFormatter(Formatter):
 
 class LatitudeFormatter(_PlateCarreeFormatter):
     """Tick formatter for latitude axes."""
-    def __init__(self, degree_symbol='\u00B0', number_format='g',
+
+    def __init__(self, direction_label=True,
+                 degree_symbol='\u00B0', number_format='g',
                  transform_precision=1e-8, dms=False,
                  minute_symbol="'", second_symbol="''",
                  seconds_number_format='g', auto_hide=True,
@@ -203,6 +205,11 @@ class LatitudeFormatter(_PlateCarreeFormatter):
 
         Parameters
         ----------
+        direction_label: optional
+            If *True* a direction label (N or S) will be drawn next to
+            latitude labels. If *False* then these
+            labels will not be drawn. Defaults to *True* (draw direction
+            labels).
         degree_symbol: optional
             The character(s) used to represent the degree symbol in the
             tick labels. Defaults to u'\u00B0' which is the unicode
@@ -274,10 +281,16 @@ class LatitudeFormatter(_PlateCarreeFormatter):
             auto_hide=auto_hide,
         )
 
+        self._direction_labels = direction_label
+
     def _apply_transform(self, value, target_proj, source_crs):
         return target_proj.transform_point(0, value, source_crs)[1]
 
     def _hemisphere(self, value, value_source_crs):
+
+        if not self._direction_labels:
+            return ''
+
         if value > 0:
             hemisphere = 'N'
         elif value < 0:
@@ -291,6 +304,7 @@ class LongitudeFormatter(_PlateCarreeFormatter):
     """Tick formatter for a longitude axis."""
 
     def __init__(self,
+                 direction_label=True,
                  zero_direction_label=False,
                  dateline_direction_label=False,
                  degree_symbol='\u00B0',
@@ -310,6 +324,11 @@ class LongitudeFormatter(_PlateCarreeFormatter):
 
         Parameters
         ----------
+        direction_label: optional
+            If *True* a direction label (E or W) will be drawn next to
+            longitude labels. If *False* then these
+            labels will not be drawn. Defaults to *True* (draw direction
+            labels).
         zero_direction_label: optional
             If *True* a direction label (E or W) will be drawn next to
             longitude labels with the value 0. If *False* then these
@@ -389,6 +408,7 @@ class LongitudeFormatter(_PlateCarreeFormatter):
             seconds_number_format=seconds_number_format,
             auto_hide=auto_hide,
         )
+        self._direction_labels = direction_label
         self._zero_direction_labels = zero_direction_label
         self._dateline_direction_labels = dateline_direction_label
 
@@ -422,6 +442,10 @@ class LongitudeFormatter(_PlateCarreeFormatter):
         return _PlateCarreeFormatter._format_degrees(self, self._fix_lons(deg))
 
     def _hemisphere(self, value, value_source_crs):
+
+        if not self._direction_labels:
+            return ''
+
         value = self._fix_lons(value)
         # Perform basic hemisphere detection.
         if value < 0:
@@ -476,7 +500,7 @@ class LongitudeLocator(MaxNLocator):
             steps = np.array([1, 1.5, 2, 2.5, 3, 5, 10])
 
         else:
-            steps = np.array([1, 10/6., 15/6., 20/6., 30/6., 10])
+            steps = np.array([1, 10 / 6., 15 / 6., 20 / 6., 30 / 6., 10])
 
         self.set_params(steps=np.array(steps))
 
@@ -498,6 +522,7 @@ class LatitudeLocator(LongitudeLocator):
     dms: bool
         Allow the locator to stop on minutes and seconds (False by default)
     """
+
     def tick_values(self, vmin, vmax):
         vmin = max(vmin, -90.)
         vmax = min(vmax, 90.)

--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -77,11 +77,17 @@ class _PlateCarreeFormatter(Formatter):
     def _format_value(self, value, original_value):
 
         hemisphere = ''
+        sign = ''
+
         if self._direction_labels:
             hemisphere = self._hemisphere(value, original_value)
+        else:
+            if (value != 0 and
+                    self._hemisphere(value, original_value) in ['W', 'S']):
+                sign = '-'
 
         if not self._dms:
-            return (self._format_degrees(abs(value)) +
+            return (sign + self._format_degrees(abs(value)) +
                     hemisphere)
 
         value, deg, mn, sec = self._get_dms(abs(value))

--- a/lib/cartopy/tests/mpl/test_ticker.py
+++ b/lib/cartopy/tests/mpl/test_ticker.py
@@ -46,6 +46,17 @@ def test_LatitudeFormatter():
     assert result == expected
 
 
+def test_LatitudeFormatter_direction_label():
+    formatter = LatitudeFormatter(direction_label=False)
+    p = ccrs.PlateCarree()
+    formatter.axis = Mock(axes=Mock(GeoAxes, projection=p))
+    test_ticks = [-90, -60, -30, 0, 30, 60, 90]
+    result = [formatter(tick) for tick in test_ticks]
+    expected = ['90\u00B0', '60\u00B0', '30\u00B0', '0\u00B0',
+                '30\u00B0', '60\u00B0', '90\u00B0']
+    assert result == expected
+
+
 def test_LatitudeFormatter_degree_symbol():
     formatter = LatitudeFormatter(degree_symbol='')
     p = ccrs.PlateCarree()
@@ -90,6 +101,19 @@ def test_LatitudeFormatter_small_numbers():
     result = [formatter(tick) for tick in test_ticks]
     expected = ['40.1275150\u00B0N', '40.1275152\u00B0N',
                 '40.1275154\u00B0N']
+    assert result == expected
+
+
+def test_LongitudeFormatter_direction_label():
+    formatter = LongitudeFormatter(direction_label=False,
+                                   dateline_direction_label=True,
+                                   zero_direction_label=True)
+    p = ccrs.PlateCarree()
+    formatter.axis = Mock(axes=Mock(GeoAxes, projection=p))
+    test_ticks = [-180, -120, -60, 0, 60, 120, 180]
+    result = [formatter(tick) for tick in test_ticks]
+    expected = ['180\u00B0', '120\u00B0', '60\u00B0', '0\u00B0',
+                '60\u00B0', '120\u00B0', '180\u00B0']
     assert result == expected
 
 
@@ -247,7 +271,7 @@ def test_lonlatformatter_non_geoaxes(cls, letter):
                                        id='lon_medium'),
                           pytest.param(LongitudeLocator, -1, 0,
                                        np.array([-60., -50., -40., -30.,
-                                                 -20., -10.,   0.]) / 60,
+                                                 -20., -10., 0.]) / 60,
                                        id='lon_small'),
                           pytest.param(LongitudeLocator, 0, 2 * ONE_MIN,
                                        np.array([0., 18., 36., 54., 72., 90.,

--- a/lib/cartopy/tests/mpl/test_ticker.py
+++ b/lib/cartopy/tests/mpl/test_ticker.py
@@ -52,7 +52,7 @@ def test_LatitudeFormatter_direction_label():
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=p))
     test_ticks = [-90, -60, -30, 0, 30, 60, 90]
     result = [formatter(tick) for tick in test_ticks]
-    expected = ['90\u00B0', '60\u00B0', '30\u00B0', '0\u00B0',
+    expected = ['-90\u00B0', '-60\u00B0', '-30\u00B0', '0\u00B0',
                 '30\u00B0', '60\u00B0', '90\u00B0']
     assert result == expected
 
@@ -112,7 +112,7 @@ def test_LongitudeFormatter_direction_label():
     formatter.axis = Mock(axes=Mock(GeoAxes, projection=p))
     test_ticks = [-180, -120, -60, 0, 60, 120, 180]
     result = [formatter(tick) for tick in test_ticks]
-    expected = ['180\u00B0', '120\u00B0', '60\u00B0', '0\u00B0',
+    expected = ['-180\u00B0', '-120\u00B0', '-60\u00B0', '0\u00B0',
                 '60\u00B0', '120\u00B0', '180\u00B0']
     assert result == expected
 

--- a/lib/cartopy/tests/mpl/test_ticker.py
+++ b/lib/cartopy/tests/mpl/test_ticker.py
@@ -230,6 +230,26 @@ def test_LongitudeFormatter_minutes_seconds(test_ticks, expected):
 
 @pytest.mark.parametrize("test_ticks,expected",
                          [pytest.param([-3.75, -3.5],
+                                       ["-3\u00B045'", "-3\u00B030'"],
+                                       id='minutes_no_hide'),
+                          pytest.param([-3.5, -3.],
+                                       ["30'", "-3\u00B0"],
+                                       id='minutes_hide'),
+                          pytest.param([-3. - 2 * ONE_MIN - 30 * ONE_SEC],
+                                       ["-3\u00B02'30''"],
+                                       id='seconds'),
+                          ])
+def test_LongitudeFormatter_minutes_seconds_direction_label(test_ticks,
+                                                            expected):
+    formatter = LongitudeFormatter(
+        dms=True, auto_hide=True, direction_label=False)
+    formatter.set_locs(test_ticks)
+    result = [formatter(tick) for tick in test_ticks]
+    assert result == expected
+
+
+@pytest.mark.parametrize("test_ticks,expected",
+                         [pytest.param([-3.75, -3.5],
                                        ["3\u00B0S45'", "3\u00B0S30'"],
                                        id='minutes_no_hide'),
                           ])


### PR DESCRIPTION

## Rationale

This change fixes #1635 (Add option to remove 'E', 'W', 'N', 'S' from axis labels).

## Implications
 
Users will be able to to remove 'E', 'W', 'N', 'S' from axis labels.

## Checklist

 * I have signed the Contributor Licence Agreement (CLA).

 * The example I'd add is based on https://scitools.org.uk/cartopy/docs/v0.15/examples/tick_labels.html
I wonder if adding a subplot to this example would be a good idea.

 * A test should be added to lib/cartopy/tests/mpl/test_ticker.py. Should I add it to this pull request ? 
