### PR TITLE
LambertConformal projection maximal longitude extent

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1124,7 +1124,7 @@ class LambertConformal(Projection):
     def __init__(self, central_longitude=-96.0, central_latitude=39.0,
                  false_easting=0.0, false_northing=0.0,
                  secant_latitudes=None, standard_parallels=None,
-                 globe=None, cutoff=-30):
+                 globe=None, cutoff=-30, longitude_extent=180):
         """
         Parameters
         ----------
@@ -1149,6 +1149,10 @@ class LambertConformal(Projection):
             The map extends to infinity opposite the central pole
             so we must cut off the map drawing before then.
             A value of 0 will draw half the globe. Defaults to -30.
+        longitude_extent: optional
+            Maximal longitude extent of the map.
+            Limits the axes boundary from central longitude minus and plus
+            the longitude extent.
 
         """
         proj4_params = [('proj', 'lcc'),
@@ -1205,11 +1209,17 @@ class LambertConformal(Projection):
         lats[0] = lats[-1] = plat
         if plat == 90:
             # Ensure clockwise
-            lons[1:-1] = np.linspace(central_longitude + 180 - 0.001,
-                                     central_longitude - 180 + 0.001, n)
+            lons[1:-1] = np.linspace(
+                central_longitude + longitude_extent - 0.001,
+                central_longitude - longitude_extent + 0.001,
+                n
+            )
         else:
-            lons[1:-1] = np.linspace(central_longitude - 180 + 0.001,
-                                     central_longitude + 180 - 0.001, n)
+            lons[1:-1] = np.linspace(
+                central_longitude - longitude_extent + 0.001,
+                central_longitude + longitude_extent - 0.001,
+                n
+            )
 
         points = self.transform_points(PlateCarree(), lons, lats)
 


### PR DESCRIPTION
## Rationale

The previous version of LambertConformal projection does not allow to control the longitudinal extent of the map (it was hardcoded at 180º). It was only possible to use the `set_extent` method of a GeoAxes instance, resulting in vertical (or horizontal) axes boundaries. Yet, a Lambert conformal projection can have arbitrary longitude extent. This version implements a control on this extent.

## Implications

Being able to control the longitude extent of a GeoAxes instance with a single keyword argument added to LambertConformal. 

## Checklist

 * I have read and signed the Contributor Licence Agreement (CLA) just before proposing this pull request.

 * New feature: keyword argument `longitude_extent` added to the LambertConformal CRS. By default, the behavior of he projection is unchanged (i.e. `longitude_extent=180`). When specified, the extent of the GeoAxes with LambertConformal projection with have axes boundaries drawn within the range `(central_longitude - longitude_extent, central_longitude + longitude_extent)`.

 * The docstring was updated accordingly. 

## Example use (compare with and without controlling the longitude extent)

```py
from cartopy import crs, feature
from matplotlib import pyplot as plt

# create figure
fig = plt.figure()

# original behaviour
proj = crs.LambertConformal(central_longitude=-100)
ax = fig.add_subplot(121, projection=proj)
ax.add_feature(feature.LAND, facecolor="0.9")
ax.gridlines()
ax.set_title("Default extent")

# new possibility
proj = crs.LambertConformal(central_longitude=-100, longitude_extent=60)
ax = fig.add_subplot(122, projection=proj)
ax.add_feature(feature.LAND, facecolor="0.9")
ax.gridlines()
ax.set_title("Controled extent")

# show maps
plt.show()
```
![map_example](https://user-images.githubusercontent.com/16102060/95313774-ce09e580-0890-11eb-9541-0627fa9abc03.png)


