### PR TITLE
Restore PEP-517 compliance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ cp-run: &cp-install
   name: Install Cartopy
   command: |
     source activate test-environment
-    pip install -ve .
+    python setup.py develop
 
 doc-run: &doc-build
   name: Build documentation

--- a/INSTALL
+++ b/INSTALL
@@ -56,7 +56,7 @@ for these packages can be found at https://github.com/conda-forge/feedstocks.
 For macOS, the required dependencies can be installed in the following way::
 
     brew install proj geos
-    pip3 install --upgrade cython numpy pyshp
+    pip3 install --upgrade pyshp
     # shapely needs to be built from source to link to geos. If it is already
     # installed, uninstall it by: pip3 uninstall shapely
     pip3 install shapely --no-binary shapely
@@ -78,12 +78,6 @@ to the core packages.
 Further information about the required dependencies can be found here:
 
 **Python** 3.5 or later (https://www.python.org/)
-
-**Cython** 0.28 or later (https://pypi.python.org/pypi/Cython/)
-
-**NumPy** 1.10 or later (https://numpy.org/)
-    Python package for scientific computing including a powerful N-dimensional
-    array object.
 
 **GEOS** 3.3.3 or later (https://trac.osgeo.org/geos/)
     GEOS is an API of spatial predicates and functions for processing geometry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 40.6.0", "numpy>=1.10" "cython>=0.28"]
+requires = ["setuptools >= 40.6.0", "numpy>=1.10", "cython>=0.28"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,17 @@
 [build-system]
-requires = ["setuptools >= 40.6.0", "numpy>=1.10", "cython>=0.28"]
+requires = [
+    "wheel",
+    "setuptools >= 40.6.0",
+    "Cython>=0.29.2",
+    "numpy==1.13.3; python_version=='3.5' and platform_system!='AIX'",
+    "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
+    "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",
+    "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",
+    "numpy==1.16.0; python_version=='3.5' and platform_system=='AIX'",
+    "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
+    "numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'",
+    "numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'",
+    # do not pin numpy on future versions of python to avoid incompatible numpy and python versions
+    "numpy; python_version>='3.9'",
+]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 40.6.0", "numpy>=1.10" "cython>=0.28"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,10 @@ from distutils.spawn import find_executable
 from distutils.sysconfig import get_config_var
 
 from setuptools import Command, Extension, convert_path, setup
+import numpy
+
+print("MY NUMPY VERSION IS", numpy.__version__)
+sys.exit(1)
 
 """
 Distribution definition for Cartopy.


### PR DESCRIPTION
## Rationale

pip installs are not currently compliant with PEP-517. This PEP is relied upon by external tooling. This behavior was reverted in 454a9118f711d111b36026b126724cdb8dd705e7 because it made it harder to test cartopy against a set particular version of numpy. IMO it is not necessary to remove PEP-517 compliance to enable this testing pattern. Using `python setup.py develop` versus `pip install` is enough. See this example:

```
bash-5.0$ python -m venv .env
bash-5.0$ source .env/bin/activate
(.env) bash-5.0$ pip install numpy==1.18
Collecting numpy==1.18
  Using cached https://files.pythonhosted.org/packages/f0/14/f71a89e03578084111e352f464d9f3b7f701ebbecbd1a60e89c96983ef77/numpy-1.18.0-cp37-cp37m-macosx_10_9_x86_64.whl
Installing collected packages: numpy
Successfully installed numpy-1.18.0
(.env) bash-5.0$ pip install .
Processing /Users/noah/workspace/cartopy
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  Complete output from command /Users/noah/workspace/cartopy/.env/bin/python /Users/noah/workspace/cartopy/.env/lib/python3.7/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /var/folders/l1/hgxljmwd51vdlxhnnd272mqm0000gn/T/tmpd1r2bc61:
  MY NUMPY VERSION IS 1.19.4

  ----------------------------------------
Command "/Users/noah/workspace/cartopy/.env/bin/python /Users/noah/workspace/cartopy/.env/lib/python3.7/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /var/folders/l1/hgxljmwd51vdlxhnnd272mqm0000gn/T/tmpd1r2bc61" failed with error code 1 in /private/var/folders/l1/hgxljmwd51vdlxhnnd272mqm0000gn/T/pip-req-build-i17lx8mw
(.env) bash-5.0$ python setup.py  develop
MY NUMPY VERSION IS 1.18.0
```

## Implications

Cannot pip install cartopy with one `pip` command.

## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->

Resolves #1552.