### PR TITLE
restore PEP-517 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,11 @@ install:
   # Customise the testing environment
   # ---------------------------------
   - PACKAGES="$PACKAGES flufl.lock owslib pep8 pillow pyepsg pyshp pytest"
-  - PACKAGES="$PACKAGES pytest-xdist requests setuptools_scm"
-  - PACKAGES="$PACKAGES setuptools_scm_git_archive shapely"
+  - PACKAGES="$PACKAGES pytest-xdist requests"
+  - PACKAGES="$PACKAGES shapely"
   - |
     if [[ "$NAME" == "Latest everything"* ]]; then
-        PACKAGES="$PACKAGES pytest-cov coveralls";
+        PACKAGES="$PACKAGES cython>=0.29.2 pytest-cov coveralls";
         export CYTHON_COVERAGE=1;
     fi
   - conda create -n $ENV_NAME python=$PYTHON_VERSION $PACKAGES

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ env:
     matrix:
         - NAME="Minimum dependencies."
           PYTHON_VERSION=3.6
-          PACKAGES="cython=0.28.5 matplotlib=2.2.2 numpy=1.16 owslib=0.17 proj4=5.2.0 scipy=1.2.0"
+          PACKAGES="matplotlib=2.2.2 numpy=1.16 owslib=0.17 proj4=5.2.0 scipy=1.2.0"
         - NAME="Latest everything."
           PYTHON_VERSION=3.8
-          PACKAGES="cython fiona matplotlib-base numpy proj pykdtree scipy"
+          PACKAGES="fiona matplotlib-base proj pykdtree scipy"
 
 
 sudo: false

--- a/INSTALL
+++ b/INSTALL
@@ -47,7 +47,7 @@ using the `setup.py` file::
 Required dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 In order to install Cartopy, or to access its basic functionality, it will be
-necessary to first install **GEOS**, **NumPy**, **Cython**, **Shapely**, and
+necessary to first install **GEOS**, **Shapely**, and
 **pyshp**. Many of these packages can be installed using pip or
 other package managers such as apt-get (Linux) and brew (macOS). Many of these
 dependencies are built as part of Cartopy's conda distribution, and the recipes
@@ -56,7 +56,7 @@ for these packages can be found at https://github.com/conda-forge/feedstocks.
 For macOS, the required dependencies can be installed in the following way::
 
     brew install proj geos
-    pip3 install --upgrade cython numpy pyshp
+    pip3 install --upgrade pyshp
     # shapely needs to be built from source to link to geos. If it is already
     # installed, uninstall it by: pip3 uninstall shapely
     pip3 install shapely --no-binary shapely
@@ -78,12 +78,6 @@ to the core packages.
 Further information about the required dependencies can be found here:
 
 **Python** 3.5 or later (https://www.python.org/)
-
-**Cython** 0.28 or later (https://pypi.python.org/pypi/Cython/)
-
-**NumPy** 1.10 or later (https://numpy.org/)
-    Python package for scientific computing including a powerful N-dimensional
-    array object.
 
 **GEOS** 3.3.3 or later (https://trac.osgeo.org/geos/)
     GEOS is an API of spatial predicates and functions for processing geometry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = [
+    "wheel",
+    "setuptools >= 40.6.0",
+    "Cython >= 0.29.2",
+    "oldest-supported-numpy",
+    "setuptools_scm",
+    "setuptools_scm_git_archive",
+]
+build-backend = "setuptools.build_meta"

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,3 @@
-numpy>=1.10
+numpy>=1.13
 shapely>=1.5.6
 pyshp>=2
-setuptools>=0.7.2

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,3 @@
-numpy>=1.13
+numpy>=1.13.3
 shapely>=1.5.6
 pyshp>=2

--- a/setup.py
+++ b/setup.py
@@ -371,7 +371,6 @@ setup(
     extras_require=extras_require,
     tests_require=tests_require,
 
-    setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
     use_scm_version={
         'write_to': 'lib/cartopy/_version.py',
     },


### PR DESCRIPTION
## Rationale

pip installs are not currently compliant with PEP-517. This PEP is relied upon by external tooling. This behavior was reverted in 454a911 because it made it harder to test cartopy against a set particular version of numpy. IMO it is not necessary to remove PEP-517 compliance to enable this testing pattern. Using python setup.py develop versus pip install is enough. See this example:
```
bash-5.0$ python -m venv .env
bash-5.0$ source .env/bin/activate
(.env) bash-5.0$ pip install numpy==1.18
Collecting numpy==1.18
  Using cached https://files.pythonhosted.org/packages/f0/14/f71a89e03578084111e352f464d9f3b7f701ebbecbd1a60e89c96983ef77/numpy-1.18.0-cp37-cp37m-macosx_10_9_x86_64.whl
Installing collected packages: numpy
Successfully installed numpy-1.18.0
(.env) bash-5.0$ pip install .
Processing /Users/noah/workspace/cartopy
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  Complete output from command /Users/noah/workspace/cartopy/.env/bin/python /Users/noah/workspace/cartopy/.env/lib/python3.7/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /var/folders/l1/hgxljmwd51vdlxhnnd272mqm0000gn/T/tmpd1r2bc61:
  MY NUMPY VERSION IS 1.19.4

  ----------------------------------------
Command "/Users/noah/workspace/cartopy/.env/bin/python /Users/noah/workspace/cartopy/.env/lib/python3.7/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /var/folders/l1/hgxljmwd51vdlxhnnd272mqm0000gn/T/tmpd1r2bc61" failed with error code 1 in /private/var/folders/l1/hgxljmwd51vdlxhnnd272mqm0000gn/T/pip-req-build-i17lx8mw
(.env) bash-5.0$ python setup.py  develop
MY NUMPY VERSION IS 1.18.0
```
## Implications

Cannot pip install cartopy with one pip command.
Checklist

    If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
    (See the governance page for the CLA and what to do with it).

    If this is a new feature, please provide an example of its use in the description. We may want to make a
    follow-on pull request to put the example in the gallery!

    Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

Fixes #1552.

based on https://github.com/SciTools/cartopy/pull/1680