### PR TITLE
ENH: Adding a contour fast-path to speed up contouring

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1630,19 +1630,18 @@ class GeoAxes(matplotlib.axes.Axes):
         transform
             A :class:`~cartopy.crs.Projection`.
 
-        fast_transform: bool, optional
+        transform_first : bool, optional
             If True, this will transform the input arguments into
             projection-space before computing the contours, which is much
             faster than computing the contours in data-space and projecting
             the filled polygons. To use the projection-space method the input
             arguments X and Y must be provided and be 2-dimensional.
             The default is False, to compute the contours in data-space.
-
         """
         # Handle a fast-path optimization that projects the points before
         # calculating the contour polygons. This means that the contour
         # lines will be calculated in projected-space, not data-space.
-        if kwargs.pop('fast_transform', False):
+        if kwargs.pop('transform_first', False):
             if len(args) < 3:
                 # For the fast-path we need X and Y input points
                 raise ValueError("The X and Y arguments must be provided to "

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -321,6 +321,50 @@ def _add_transform(func):
     return wrapper
 
 
+def _add_transform_first(func):
+    """
+    A decorator that adds and validates the transform_first keyword argument.
+
+    This handles a fast-path optimization that projects the points before
+    creating any patches or lines. This means that the lines/patches will be
+    calculated in projected-space, not data-space. It requires the first
+    three arguments to be x, y, and z and all must be two-dimensional to use
+    the fast-path option.
+
+    This should be added after the _add_transform wrapper so that a transform
+    is guaranteed to be present.
+    """
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        if kwargs.pop('transform_first', False):
+            if len(args) < 3:
+                # For the fast-path we need X and Y input points
+                raise ValueError("The X and Y arguments must be provided to "
+                                 "use the transform_first=True fast-path.")
+            x, y, z = (np.array(i) for i in args[:3])
+            if not (x.ndim == y.ndim == 2):
+                raise ValueError("The X and Y arguments must be gridded "
+                                 "2-dimensional arrays")
+
+            # Remove the transform from the keyword arguments
+            t = kwargs.pop('transform')
+            # Transform all of the x and y points
+            pts = self.projection.transform_points(t, x, y)
+            x = pts[..., 0].reshape(x.shape)
+            y = pts[..., 1].reshape(y.shape)
+            # The x coordinates could be wrapped, but matplotlib expects
+            # them to be sorted, so we will reorganize the arrays based on x
+            ind = np.argsort(x, axis=1)
+            x = np.take_along_axis(x, ind, axis=1)
+            y = np.take_along_axis(y, ind, axis=1)
+            z = np.take_along_axis(z, ind, axis=1)
+
+            # Use the new points as the input arguments
+            args = (x, y, z) + args[3:]
+        return func(self, *args, **kwargs)
+    return wrapper
+
+
 class GeoAxes(matplotlib.axes.Axes):
     """
     A subclass of :class:`matplotlib.axes.Axes` which represents a
@@ -1593,6 +1637,7 @@ class GeoAxes(matplotlib.axes.Axes):
         self.spines['geo'].set_boundary(path, transform)
 
     @_add_transform
+    @_add_transform_first
     def contour(self, *args, **kwargs):
         """
         Add the "transform" keyword to :func:`~matplotlib.pyplot.contour`.
@@ -1601,6 +1646,16 @@ class GeoAxes(matplotlib.axes.Axes):
         ----------------
         transform
             A :class:`~cartopy.crs.Projection`.
+
+        transform_first : bool, optional
+            If True, this will transform the input arguments into
+            projection-space before computing the contours, which is much
+            faster than computing the contours in data-space and projecting
+            the filled polygons. Using this method does not handle wrapped
+            coordinates as well and can produce misleading contours in the
+            middle of the domain. To use the projection-space method the input
+            arguments X and Y must be provided and be 2-dimensional.
+            The default is False, to compute the contours in data-space.
 
         """
         result = matplotlib.axes.Axes.contour(self, *args, **kwargs)
@@ -1621,6 +1676,7 @@ class GeoAxes(matplotlib.axes.Axes):
         return result
 
     @_add_transform
+    @_add_transform_first
     def contourf(self, *args, **kwargs):
         """
         Add the "transform" keyword to :func:`~matplotlib.pyplot.contourf`.
@@ -1634,49 +1690,21 @@ class GeoAxes(matplotlib.axes.Axes):
             If True, this will transform the input arguments into
             projection-space before computing the contours, which is much
             faster than computing the contours in data-space and projecting
-            the filled polygons. To use the projection-space method the input
+            the filled polygons. Using this method does not handle wrapped
+            coordinates as well and can produce misleading contours in the
+            middle of the domain. To use the projection-space method the input
             arguments X and Y must be provided and be 2-dimensional.
             The default is False, to compute the contours in data-space.
         """
-        # Handle a fast-path optimization that projects the points before
-        # calculating the contour polygons. This means that the contour
-        # lines will be calculated in projected-space, not data-space.
-        if kwargs.pop('transform_first', False):
-            if len(args) < 3:
-                # For the fast-path we need X and Y input points
-                raise ValueError("The X and Y arguments must be provided to "
-                                 "use the fast-path.")
-            x, y, z = (np.array(i) for i in args[:3])
-            if not (x.ndim == y.ndim == 2):
-                raise ValueError("The X and Y arguments must be gridded "
-                                 "2-dimensional arrays")
-
-            # Remove the transform from the keyword arguments
-            t = kwargs.pop('transform')
-            pts = self.projection.transform_points(t, x, y)
-            x = pts[..., 0].reshape(x.shape)
-            y = pts[..., 1].reshape(y.shape)
-            # The x coordinates could be wrapped, but contourf expects
-            # them to be sorted, so we will reorganize the arrays based on x
-            ind = np.argsort(x, axis=1)
-            x = np.take_along_axis(x, ind, axis=1)
-            y = np.take_along_axis(y, ind, axis=1)
-            z = np.take_along_axis(z, ind, axis=1)
-
-            # Use the new points as the input arguments
-            args = (x, y, z) + args[3:]
-        else:
-            # Calculate the contours in data-space, then apply the standard
-            # Cartopy non-affine transforms to those contours
-            t = kwargs.get('transform')
-            if isinstance(t, ccrs.Projection):
-                kwargs['transform'] = t = t._as_mpl_transform(self)
-            # Set flag to indicate correcting orientation of paths if not ccw
-            if isinstance(t, mtransforms.Transform):
-                for sub_trans, _ in t._iter_break_from_left_to_right():
-                    if isinstance(sub_trans, InterProjectionTransform):
-                        if not hasattr(sub_trans, 'force_path_ccw'):
-                            sub_trans.force_path_ccw = True
+        t = kwargs.get('transform')
+        if isinstance(t, ccrs.Projection):
+            kwargs['transform'] = t = t._as_mpl_transform(self)
+        # Set flag to indicate correcting orientation of paths if not ccw
+        if isinstance(t, mtransforms.Transform):
+            for sub_trans, _ in t._iter_break_from_left_to_right():
+                if isinstance(sub_trans, InterProjectionTransform):
+                    if not hasattr(sub_trans, 'force_path_ccw'):
+                        sub_trans.force_path_ccw = True
 
         result = matplotlib.axes.Axes.contourf(self, *args, **kwargs)
 

--- a/lib/cartopy/tests/mpl/test_contour.py
+++ b/lib/cartopy/tests/mpl/test_contour.py
@@ -97,8 +97,9 @@ def test_contour_update_bounds():
     plt.draw()
 
 
+@pytest.mark.parametrize('func', ['contour', 'contourf'])
 @cleanup
-def test_contourf_transform_first():
+def test_contourf_transform_first(func):
     """Test the fast-path option for filled contours."""
     # Gridded data that needs to be wrapped
     x = np.arange(360)
@@ -107,24 +108,25 @@ def test_contourf_transform_first():
     z = xx + yy**2
 
     ax = plt.axes(projection=ccrs.PlateCarree())
+    test_func = getattr(ax, func)
     # Can't handle just Z input with the transform_first
     with pytest.raises(ValueError,
                        match="The X and Y arguments must be provided"):
-        ax.contourf(z, transform=ccrs.PlateCarree(),
-                    transform_first=True)
+        test_func(z, transform=ccrs.PlateCarree(),
+                  transform_first=True)
     # X and Y must also be 2-dimensional
     with pytest.raises(ValueError,
                        match="The X and Y arguments must be gridded"):
-        ax.contourf(x, y, z, transform=ccrs.PlateCarree(),
-                    transform_first=True)
+        test_func(x, y, z, transform=ccrs.PlateCarree(),
+                  transform_first=True)
 
     # When calculating the contour in projection-space the extent
     # will now be the extent of the transformed points (-179, 180, -25, 25)
-    ax.contourf(xx, yy, z, transform=ccrs.PlateCarree(),
-                transform_first=True)
+    test_func(xx, yy, z, transform=ccrs.PlateCarree(),
+              transform_first=True)
     assert_array_almost_equal(ax.get_extent(), (-179, 180, -25, 25))
 
     # The extent without the transform_first should be all the way out to -180
-    ax.contourf(xx, yy, z, transform=ccrs.PlateCarree(),
-                transform_first=False)
+    test_func(xx, yy, z, transform=ccrs.PlateCarree(),
+              transform_first=False)
     assert_array_almost_equal(ax.get_extent(), (-180, 180, -25, 25))

--- a/lib/cartopy/tests/mpl/test_contour.py
+++ b/lib/cartopy/tests/mpl/test_contour.py
@@ -98,7 +98,7 @@ def test_contour_update_bounds():
 
 
 @cleanup
-def test_contourf_fast_transform():
+def test_contourf_transform_first():
     """Test the fast-path option for filled contours."""
     # Gridded data that needs to be wrapped
     x = np.arange(360)
@@ -107,24 +107,24 @@ def test_contourf_fast_transform():
     z = xx + yy**2
 
     ax = plt.axes(projection=ccrs.PlateCarree())
-    # Can't handle just Z input with the fast_transform
+    # Can't handle just Z input with the transform_first
     with pytest.raises(ValueError,
                        match="The X and Y arguments must be provided"):
         ax.contourf(z, transform=ccrs.PlateCarree(),
-                    fast_transform=True)
+                    transform_first=True)
     # X and Y must also be 2-dimensional
     with pytest.raises(ValueError,
                        match="The X and Y arguments must be gridded"):
         ax.contourf(x, y, z, transform=ccrs.PlateCarree(),
-                    fast_transform=True)
+                    transform_first=True)
 
     # When calculating the contour in projection-space the extent
     # will now be the extent of the transformed points (-179, 180, -25, 25)
     ax.contourf(xx, yy, z, transform=ccrs.PlateCarree(),
-                fast_transform=True)
+                transform_first=True)
     assert_array_almost_equal(ax.get_extent(), (-179, 180, -25, 25))
 
-    # The extent without the fast_transform should be all the way out to -180
+    # The extent without the transform_first should be all the way out to -180
     ax.contourf(xx, yy, z, transform=ccrs.PlateCarree(),
-                fast_transform=False)
+                transform_first=False)
     assert_array_almost_equal(ax.get_extent(), (-180, 180, -25, 25))


### PR DESCRIPTION
This adds an option to change the contouring method to use the coordinates in projection-space rather than data-space. It is much faster to project the points beforehand, rather than projecting the contours themselves.

Before adding tests, I'd like to get a feel for whether people even think this is a good idea to have in Cartopy or not? This update basically removes the "transform" keyword from `matplotlib.axes.Axes.contourf` after already transforming the points to projection-space.

## Rationale

#1291 shows how slow filled contours can be in Cartopy because it is projecting the contour regions, not the points. This ends up slowing down the transformation pipeline because of the non-affine transforms of potentially many contour regions.

## Implications

A new keyword argument to contourf, but no changes to the defaults.
Closes #1291

## Timing example
Similar to standard MPL now, ~100x faster than the standard Cartopy for this example.
```
MPL: 0.4196739196777344
Cartopy-fast: 0.44753384590148926
Cartopy-standard: 35.90342998504639
```

```python
import time
import numpy as np
import cartopy.crs as ccrs
import matplotlib.pyplot as plt

lat = np.arange(-10, 90, .5)
lon = np.arange(0, 100, .5)
lons, lats = np.meshgrid(lon, lat)
data = np.random.rand(len(lat), len(lon))

# MPL
fig1 = plt.figure(figsize=(12, 9))
ax = fig1.add_subplot(111)
t0 = time.time()
ax.contourf(lons, lats, data)
fig1.savefig('contourf-mpl.png')
print("MPL:", time.time() - t0)

# Cartopy fast path
fig2 = plt.figure(figsize=(12, 9))
ax = fig2.add_subplot(111, projection=ccrs.Robinson())
t0 = time.time()
ax.contourf(lons, lats, data, transform=ccrs.PlateCarree(), fast=True)
ax.coastlines()
fig2.savefig('contourf-cartopy-fast.png')
print("Cartopy-fast:", time.time() - t0)

# Cartopy standard path
fig3 = plt.figure(figsize=(12, 9))
ax = fig3.add_subplot(111, projection=ccrs.Robinson())
t0 = time.time()
ax.contourf(lons, lats, data, transform=ccrs.PlateCarree())
ax.coastlines()
fig3.savefig('contourf-cartopy.png')
print("Cartopy-standard:", time.time() - t0)

```