### PR TITLE
SciPy dependency missing

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,4 @@
 numpy>=1.13.3
 shapely>=1.5.6
 pyshp>=2
+scipy


### PR DESCRIPTION
See here: https://github.com/SciTools/cartopy/blob/545832ebfe18f7173559e2403fbd35e0ee900233/lib/cartopy/img_transform.py#L17

