### PR TITLE
Implement tiles for Azure Maps

### DIFF
--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -699,7 +699,7 @@ class AzureMapsTiles(GoogleWTS):
         username
             The username for the Mapbox user who defined the Mapbox style.
         tileset_id
-            A tileset ID for a map defined by a Mapbox style. See 
+            A tileset ID for a map defined by a Mapbox style. See
             https://docs.microsoft.com/en-us/rest/api/maps/renderv2/getmaptilepreview#tilesetid 
             for details
         api_version

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -684,8 +684,8 @@ def _merge_tiles(tiles):
 
 class AzureMapsTiles(GoogleWTS):
 
-    def __init__(self, subscription_key, tileset_id = "microsoft.imagery", api_version = "2.0",
-                 desired_tile_form='RGB'):
+    def __init__(self, subscription_key, tileset_id="microsoft.imagery", api_version="2.0",
+                 desired_tile_form='RGB', cache=False):
         """
         Set up a new instance to retrieve tiles from Azure Maps.
 
@@ -700,16 +700,20 @@ class AzureMapsTiles(GoogleWTS):
             The username for the Mapbox user who defined the Mapbox style.
         tileset_id
             A tileset ID for a map defined by a Mapbox style. See 
-            https://docs.microsoft.com/en-us/rest/api/maps/renderv2/getmaptilepreview#tilesetid for details
+            https://docs.microsoft.com/en-us/rest/api/maps/renderv2/getmaptilepreview#tilesetid 
+            for details
         api_version
             API version to use. Defaults to 2.0 as recommended by Microsoft.
 
         """
-        super().__init__(desired_tile_form=desired_tile_form)
+        super().__init__(desired_tile_form=desired_tile_form, cache=cache)
         self.subscription_key = subscription_key
         self.tileset_id = tileset_id
         self.api_version = api_version
 
     def _image_url(self, tile):
-        return ('https://atlas.microsoft.com/map/tile?api-version={self.api_version}&tilesetId={self.tileset_id}&x={x}&y={y}&zoom={z}&subscription-key={self.subscription_key}'
-                .format(self=self, x=tile[0], y=tile[1], z=tile[2]))
+        url = ('https://atlas.microsoft.com/map/tile?'
+               'api-version={self.api_version}&tilesetId={self.tileset_id}'
+               '&x={x}&y={y}&zoom={z}&'
+               'subscription-key={self.subscription_key}')
+        return url.format(self=self, x=tile[0], y=tile[1], z=tile[2])

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -680,3 +680,36 @@ def _merge_tiles(tiles):
         img[img_slice] = tile_img
 
     return img, [min(xs), max(xs), min(ys), max(ys)], 'lower'
+
+
+class AzureMapsTiles(GoogleWTS):
+
+    def __init__(self, subscription_key, tileset_id = "microsoft.imagery", api_version = "2.0",
+                 desired_tile_form='RGB'):
+        """
+        Set up a new instance to retrieve tiles from Azure Maps.
+
+        Access to Azure Maps REST API requires an subscription key.
+        See https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication#shared-key-authentication/ for details.
+
+        Parameters
+        ----------
+        subscription_key
+            A valid Azure Maps subscription key.
+        username
+            The username for the Mapbox user who defined the Mapbox style.
+        tileset_id
+            A tileset ID for a map defined by a Mapbox style. See 
+            https://docs.microsoft.com/en-us/rest/api/maps/renderv2/getmaptilepreview#tilesetid for details
+        api_version
+            API version to use. Defaults to 2.0 as recommended by Microsoft.
+
+        """
+        super().__init__(desired_tile_form=desired_tile_form)
+        self.subscription_key = subscription_key
+        self.tileset_id = tileset_id
+        self.api_version = api_version
+
+    def _image_url(self, tile):
+        return ('https://atlas.microsoft.com/map/tile?api-version={self.api_version}&tilesetId={self.tileset_id}&x={x}&y={y}&zoom={z}&subscription-key={self.subscription_key}'
+                .format(self=self, x=tile[0], y=tile[1], z=tile[2]))

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -684,8 +684,8 @@ def _merge_tiles(tiles):
 
 class AzureMapsTiles(GoogleWTS):
 
-    def __init__(self, subscription_key, tileset_id="microsoft.imagery", api_version="2.0",
-                 desired_tile_form='RGB', cache=False):
+    def __init__(self, subscription_key, tileset_id="microsoft.imagery",
+                 api_version="2.0", desired_tile_form='RGB', cache=False):
         """
         Set up a new instance to retrieve tiles from Azure Maps.
 
@@ -696,12 +696,9 @@ class AzureMapsTiles(GoogleWTS):
         ----------
         subscription_key
             A valid Azure Maps subscription key.
-        username
-            The username for the Mapbox user who defined the Mapbox style.
         tileset_id
-            A tileset ID for a map defined by a Mapbox style. See
-            https://docs.microsoft.com/en-us/rest/api/maps/renderv2/getmaptilepreview#tilesetid 
-            for details
+            A tileset ID for a map. See
+            https://docs.microsoft.com/en-us/rest/api/maps/renderv2/getmaptilepreview#tilesetid for details.
         api_version
             API version to use. Defaults to 2.0 as recommended by Microsoft.
 

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -690,7 +690,8 @@ class AzureMapsTiles(GoogleWTS):
         Set up a new instance to retrieve tiles from Azure Maps.
 
         Access to Azure Maps REST API requires an subscription key.
-        See https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication#shared-key-authentication/ for details.
+        See https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication#shared-key-authentication/  # noqa: E501
+        for details.
 
         Parameters
         ----------
@@ -698,7 +699,7 @@ class AzureMapsTiles(GoogleWTS):
             A valid Azure Maps subscription key.
         tileset_id
             A tileset ID for a map. See
-            https://docs.microsoft.com/en-us/rest/api/maps/renderv2/getmaptilepreview#tilesetid for details.
+            https://docs.microsoft.com/en-us/rest/api/maps/renderv2/getmaptilepreview#tilesetid for details. # noqa: E501
         api_version
             API version to use. Defaults to 2.0 as recommended by Microsoft.
 

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -689,7 +689,7 @@ class AzureMapsTiles(GoogleWTS):
         """
         Set up a new instance to retrieve tiles from Azure Maps.
 
-        Access to Azure Maps REST API requires an subscription key.
+        Access to Azure Maps REST API requires a subscription key.
         See https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication#shared-key-authentication/  # noqa: E501
         for details.
 
@@ -699,7 +699,8 @@ class AzureMapsTiles(GoogleWTS):
             A valid Azure Maps subscription key.
         tileset_id
             A tileset ID for a map. See
-            https://docs.microsoft.com/en-us/rest/api/maps/renderv2/getmaptilepreview#tilesetid for details. # noqa: E501
+            https://docs.microsoft.com/en-us/rest/api/maps/renderv2/getmaptilepreview#tilesetid  # noqa: E501
+            for details.
         api_version
             API version to use. Defaults to 2.0 as recommended by Microsoft.
 

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -305,7 +305,7 @@ def test_azuremaps_tiles_api_url():
 
 @pytest.mark.network
 def test_azuremaps_get_image():
-    # In order to test fetching map images from OS
+    # In order to test fetching map images from Azure Maps
     # an API key needs to be provided
     try:
         api_key = os.environ['AZURE_MAPS_SUBSCRIPTION_KEY']

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -290,6 +290,42 @@ def test_ordnance_survey_get_image():
     assert extent1 == extent2
 
 
+def test_azuremaps_tiles_api_url():
+    subscription_key = 'foo'
+    tileset_id = 'bar'
+    tile = [0, 1, 2]
+
+    exp_url = ('https://atlas.microsoft.com/map/tile?api-version=2.0&tilesetId=bar&x=0&y=1&zoom=2&subscription-key=foo')
+
+    az_maps_sample = cimgt.AzureMapsTiles(subscription_key, tileset_id)
+    url_str = az_maps_sample._image_url(tile)
+    assert url_str == exp_url
+
+
+@pytest.mark.network
+def test_azuremaps_get_image():
+    # In order to test fetching map images from OS
+    # an API key needs to be provided
+    try:
+        api_key = os.environ['AZURE_MAPS_SUBSCRIPTION_KEY']
+    except KeyError:
+        pytest.skip('AZURE_MAPS_SUBSCRIPTION_KEY environment variable is unset.')
+
+    am1 = cimgt.AzureMapsTiles(api_key, tileset_id="microsoft.imagery")
+    am2 = cimgt.AzureMapsTiles(api_key, tileset_id="microsoft.base.road")
+
+    tile = (500, 300, 10)
+
+    img1, extent1, _ = am1.get_image(tile)
+    img2, extent2, _ = am2.get_image(tile)
+
+    # Different images for different layers
+    assert img1 != img2
+
+    # The extent is the same though
+    assert extent1 == extent2
+
+
 @pytest.mark.network
 @pytest.mark.parametrize('cache_dir', ["tmpdir", True, False])
 def test_cache(cache_dir, tmpdir):

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -295,7 +295,8 @@ def test_azuremaps_tiles_api_url():
     tileset_id = 'bar'
     tile = [0, 1, 2]
 
-    exp_url = ('https://atlas.microsoft.com/map/tile?api-version=2.0&tilesetId=bar&x=0&y=1&zoom=2&subscription-key=foo')
+    exp_url = ('https://atlas.microsoft.com/map/tile?api-version=2.0'
+               '&tilesetId=bar&x=0&y=1&zoom=2&subscription-key=foo')
 
     az_maps_sample = cimgt.AzureMapsTiles(subscription_key, tileset_id)
     url_str = az_maps_sample._image_url(tile)
@@ -309,7 +310,8 @@ def test_azuremaps_get_image():
     try:
         api_key = os.environ['AZURE_MAPS_SUBSCRIPTION_KEY']
     except KeyError:
-        pytest.skip('AZURE_MAPS_SUBSCRIPTION_KEY environment variable is unset.')
+        pytest.skip('AZURE_MAPS_SUBSCRIPTION_KEY environment variable '
+                    'is unset.')
 
     am1 = cimgt.AzureMapsTiles(api_key, tileset_id="microsoft.imagery")
     am2 = cimgt.AzureMapsTiles(api_key, tileset_id="microsoft.base.road")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12762439/104132577-8bb7df00-537e-11eb-8369-d6e208c98de9.png)

Code:

```python
import matplotlib.pyplot as plt
import cartopy.crs as ccrs

from cartopy.io.img_tiles import AzureMapsTiles

tiler = AzureMapsTiles("your-key", tileset_id="microsoft.base.road")
mercator = tiler.crs

fig = plt.figure()
ax = fig.add_subplot(1, 1, 1, projection=mercator)
ax.set_extent([	9.206600, 9.240600, 49.135002, 49.1552], crs=ccrs.Geodetic())

ax.add_image(tiler, 15)

ax.plot([9.219108094488016], [49.141744935977776], "r+", label="Kilianskirche", transform=ccrs.Geodetic())

ax.set_title("Heilbronn, Germany\nwith microsoft.base.road tileset")
ax.legend()

plt.show()
```




## Rationale

Easy access to [Azure Maps](https://azure.microsoft.com/en-us/services/azure-maps/) tile images for plotting maps.


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

An additional CI-variable `AZURE_MAPS_SUBSCRIPTION_KEY` has to be set for tests.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
