### PR TITLE
Transform points

### DIFF
--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -353,26 +353,11 @@ cdef class CRS:
 
         """
         cdef:
-            np.ndarray[np.double_t, ndim=1] cx, cy
-            int status
-        cx = np.array([x])
-        cy = np.array([y])
-        if src_crs.is_geodetic():
-            cx *= DEG_TO_RAD
-            cy *= DEG_TO_RAD
-        status = _safe_pj_transform(src_crs, self, 1, 1, cx, cy, None)
+            np.ndarray[np.double_t, ndim=2] result
 
-        if trap and status == -14 or status == -20:
-            # -14 => "latitude or longitude exceeded limits"
-            # -20 => "tolerance condition error"
-            cx[0] = cy[0] = np.nan
-        elif trap and status != 0:
-            raise Proj4Error()
+        result = self.transform_points(src_crs, np.array([x]), np.array([y]))
+        return result[0, 0], result[0, 1]
 
-        if self.is_geodetic():
-            cx *= RAD_TO_DEG
-            cy *= RAD_TO_DEG
-        return (cx[0], cy[0])
 
     def transform_points(self, CRS src_crs not None,
                                 np.ndarray x not None,

--- a/lib/cartopy/_crs.pyx
+++ b/lib/cartopy/_crs.pyx
@@ -442,7 +442,7 @@ cdef class CRS:
                                     result[:, 0], result[:, 1],
                                     result[:, 2])
 
-        if trap and status == -14 or status == -20:
+        if trap and status in (-14, -20):
             # -14 => "latitude or longitude exceeded limits"
             # -20 => "tolerance condition error"
             result[:] = np.nan


### PR DESCRIPTION
Closes #1705 

## Rationale

When a single point was passed to `transform_points()` PROJ returns a bad status that is not caught and therefore we didn't update the result array properly.

1st commit: Fixes this to return nan's in the length-1 case
2nd commit: Combines the logic from transform_point and transform_points to remove duplicate code
3rd commit: Adds a test for these cases


## Further considerations

PROJ returns 'inf' when the length of the array is greater than 2, but we fill in nan's when it is length-1 and PROJ returned a bad status code. This is inconsistent in the fact that repeating the same coordinates gives two different values depending on the situation. Should we consider changing the nan-fill into an inf-fill instead so we are consistent? Converting all inf's to nan's didn't directly work:  `result[~np.isfinite(result)] = np.nan` causes failures for two gridliner_inline tests (shapely bad GEOS geometries)