### PR TITLE
MAINT: Coveralls needs to know about the service

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -76,7 +76,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:
-          coveralls
+          coveralls --service=github
 
       - name: Create image output
         if: ${{ steps.test.conclusion == 'failure' }}


### PR DESCRIPTION
A recent update to coveralls 3 requires the service to be explicitly set.
See: https://github.com/TheKevJames/coveralls-python/issues/252