### PR TITLE
FIX: Adding sdist into the release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           conda install $PACKAGES
 
       - name: Create sdist
-        run: python setup.py
+        run: python setup.py sdist
 
       - name: Publish Package
         uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
Looked at the current release CI and noticed it wouldn't actually build the sdist, so I'm adding that in.