### PR TITLE
Skipping bad GEOS version and updating Appveyor Python version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 environment:
     matrix:
-        - PYTHON_VERSION: "3.6"
+        - PYTHON_VERSION: "3.9"
           CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
           PACKAGES: "cython numpy matplotlib-base proj pykdtree scipy"
 
@@ -14,7 +14,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no --set show_channel_urls yes
   - conda config --add channels conda-forge
   - conda config --add channels conda-forge/label/testing
-  - if %PYTHON_VERSION%==3.6 conda update conda --yes
+  - if %PYTHON_VERSION%==3.9 conda update conda --yes
   - set ENV_NAME=test-environment
   - set PACKAGES=%PACKAGES% flufl.lock owslib pep8 pillow pyepsg pyshp pytest
   - set PACKAGES=%PACKAGES% requests setuptools_scm setuptools_scm_git_archive

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 import numpy as np
 import pytest
+from shapely.geos import geos_version
 
 import cartopy.crs as ccrs
 from cartopy.mpl.geoaxes import GeoAxes
@@ -136,6 +137,7 @@ grid_label_inline_image = 'gridliner_labels_inline'
 grid_label_inline_usa_image = 'gridliner_labels_inline_usa'
 
 
+@pytest.mark.skipif(geos_version == (3, 9, 0), reason="GEOS intersection bug")
 @pytest.mark.natural_earth
 @ImageTesting([grid_label_image], tolerance=grid_label_tol)
 def test_grid_labels():
@@ -209,6 +211,7 @@ def test_grid_labels():
 @pytest.mark.skipif(
     MPL_VERSION < '3.0.0',
     reason='Impossible to override tight layout algorithm in mpl < 3')
+@pytest.mark.skipif(geos_version == (3, 9, 0), reason="GEOS intersection bug")
 @pytest.mark.natural_earth
 @ImageTesting(['gridliner_labels_tight'],
               tolerance=grid_label_tol if ccrs.PROJ4_VERSION < (7, 1, 0)
@@ -251,6 +254,7 @@ def test_grid_labels_tight():
             assert hasattr(gl, '_plotted') and gl._plotted
 
 
+@pytest.mark.skipif(geos_version == (3, 9, 0), reason="GEOS intersection bug")
 @pytest.mark.natural_earth
 @ImageTesting([grid_label_inline_image], tolerance=grid_label_inline_tol)
 def test_grid_labels_inline():
@@ -274,6 +278,7 @@ def test_grid_labels_inline():
     plt.subplots_adjust(wspace=0.35, hspace=0.35)
 
 
+@pytest.mark.skipif(geos_version == (3, 9, 0), reason="GEOS intersection bug")
 @pytest.mark.natural_earth
 @ImageTesting([grid_label_inline_usa_image],
               tolerance=grid_label_inline_usa_tol)
@@ -308,6 +313,7 @@ def test_grid_labels_inline_usa():
     plt.subplots_adjust(wspace=0.35, hspace=0.35)
 
 
+@pytest.mark.skipif(geos_version == (3, 9, 0), reason="GEOS intersection bug")
 @ImageTesting(["gridliner_labels_bbox_style"], tolerance=grid_label_tol)
 def test_gridliner_labels_bbox_style():
     top = 49.3457868  # north lat


### PR DESCRIPTION
Pinning GEOS to 3.8.1, I'm not entirely clear why this is causing the gridliner to fail only on the lowest Python version.

Updating appveyor to use Python 3.9 to keep more current on all packages.

## Rationale

Passes tests

## Implications

The gridliner and GEOS 3.9 may have some bad interactions that are hidden by this pinning. But, it is likely only on 3.6/older package versions.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
