### PR TITLE
ci: Don't allow proj 8 yet

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@ environment:
     matrix:
         - PYTHON_VERSION: "3.9"
           CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
-          PACKAGES: "cython numpy matplotlib-base proj pykdtree scipy"
+          PACKAGES: "cython numpy matplotlib-base proj=7 pykdtree scipy"
 
 install:
   # Install miniconda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ deps-run: &deps-install
         numpy \
         owslib \
         pillow \
-        proj \
+        'proj<8' \
         pyepsg \
         pykdtree \
         pyshp \

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Latest packages
         if: ${{ steps.minimum-packages.conclusion == 'skipped' }}
         run: |
-          echo "PACKAGES=cython fiona matplotlib-base numpy proj pykdtree scipy" >> $GITHUB_ENV
+          echo "PACKAGES=cython fiona matplotlib-base numpy proj<8 pykdtree scipy" >> $GITHUB_ENV
 
       - name: Coverage packages
         id: coverage

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -9,4 +9,4 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/docs/build/html/index.html
-          circleci-jobs: docs-python2,docs-python3
+          circleci-jobs: docs-python3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          PACKAGES="cython fiona matplotlib-base numpy proj pykdtree scipy"
+          PACKAGES="cython fiona matplotlib-base numpy proj<8 pykdtree scipy"
           PACKAGES="$PACKAGES flufl.lock owslib pep8 pillow pyepsg pyshp pytest"
           PACKAGES="$PACKAGES pytest-xdist requests setuptools_scm"
           PACKAGES="$PACKAGES setuptools_scm_git_archive shapely"


### PR DESCRIPTION
## Rationale

Since proj 8 removed the `proj_api.h` header and we still use it, we need to pin <8 temporarily.

Also, remove check for Python 2 doc artifacts, since that build is gone.

## Implications

CI will build again.