### PR TITLE
IO - Add .prj and .cpg to NaturalEarth unzipped files

### DIFF
--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -316,7 +316,7 @@ class NEShpDownloader(Downloader):
         natural earth zip file.
 
         """
-        for ext in ['.shp', '.dbf', '.shx']:
+        for ext in ['.shp', '.dbf', '.shx', '.prj', '.cpg']:
             yield ('ne_{resolution}_{name}'
                    '{extension}'.format(extension=ext, **format_dict))
 


### PR DESCRIPTION
Fixes #1744 

## Rationale

Adding .prj files is necessary to have the CRS data attached.
Adding the .cpg file may be useful (unknown) and the files are super lightweight anyways.


## Implications

Now loading data has CRS data attached (e.g. via the ``crs`` attribute in GeoPandas).
Since data is only added, this should not affect any existing code (unless they specifically rely on the absence of CRS information but that would be really weird).

I checked on the [NaturalEarth repo](https://github.com/nvkelso/natural-earth-vector) that all zip files should contain .prj and .cpg files.

Since the zip files downloaded contained the .prj and .cpg files already, this does not lead to any additional data load except for a (tiny) additional use of space on the local drive.