### PR TITLE
Mapbox api changes

### DIFF
--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -450,8 +450,6 @@ class MapboxTiles(GoogleWTS):
         return url
 
 
-
-
 class MapboxStyleTiles(GoogleWTS):
     """
     Implement web tile retrieval from a user-defined Mapbox style. For more

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -421,8 +421,12 @@ class MapboxTiles(GoogleWTS):
             A valid Mapbox API access token.
         map_id
             An ID for a publicly accessible map (provided by Mapbox).
-            This is the map whose tiles will be retrieved through this process.
-
+            This is the map whose tiles will be retrieved through this process and is specified
+            through the Mapbox Styles API (https://docs.mapbox.com/api/maps/styles/)
+            Examples:
+              map_id='mapbox/streets-v11' 
+              map_id='mapbox/outdoors-v11' 
+              map_id='mapbox/satellite-v9'
         """
         self.access_token = access_token
         self.map_id = map_id
@@ -430,11 +434,20 @@ class MapboxTiles(GoogleWTS):
 
     def _image_url(self, tile):
         x, y, z = tile
-        url = ('https://api.mapbox.com/v4/mapbox.{id}/{z}/{x}/{y}.png'
+
+        # Previous version of the API (particularly note mapbox.{id} is replaced by mapbox/id)
+        # url = ('https://api.mapbox.com/v4/mapbox.{id}/{z}/{x}/{y}.png'
+        #        '?access_token={token}'.format(z=z, y=y, x=x,
+        #                                       id=self.map_id,
+        #                                       token=self.access_token))
+
+        url = ('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}'
                '?access_token={token}'.format(z=z, y=y, x=x,
                                               id=self.map_id,
                                               token=self.access_token))
         return url
+
+
 
 
 class MapboxStyleTiles(GoogleWTS):

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -421,11 +421,12 @@ class MapboxTiles(GoogleWTS):
             A valid Mapbox API access token.
         map_id
             An ID for a publicly accessible map (provided by Mapbox).
-            This is the map whose tiles will be retrieved through this process and is specified
-            through the Mapbox Styles API (https://docs.mapbox.com/api/maps/styles/)
+            This is the map whose tiles will be retrieved through this process
+            and is specified through the Mapbox Styles API
+            (https://docs.mapbox.com/api/maps/styles/)
             Examples:
-              map_id='mapbox/streets-v11' 
-              map_id='mapbox/outdoors-v11' 
+              map_id='mapbox/streets-v11'
+              map_id='mapbox/outdoors-v11'
               map_id='mapbox/satellite-v9'
         """
         self.access_token = access_token
@@ -435,7 +436,8 @@ class MapboxTiles(GoogleWTS):
     def _image_url(self, tile):
         x, y, z = tile
 
-        # Previous version of the API (particularly note mapbox.{id} is replaced by mapbox/id)
+        # Previous version of the API 
+        # (particularly note mapbox.{id} is replaced by mapbox/id)
         # url = ('https://api.mapbox.com/v4/mapbox.{id}/{z}/{x}/{y}.png'
         #        '?access_token={token}'.format(z=z, y=y, x=x,
         #                                       id=self.map_id,

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -425,9 +425,9 @@ class MapboxTiles(GoogleWTS):
             and is specified through the Mapbox Styles API
             (https://docs.mapbox.com/api/maps/styles/)
             Examples:
-              map_id='mapbox/streets-v11'
-              map_id='mapbox/outdoors-v11'
-              map_id='mapbox/satellite-v9'
+              map_id='streets-v11'
+              map_id='outdoors-v11'
+              map_id='satellite-v9'
         """
         self.access_token = access_token
         self.map_id = map_id
@@ -436,14 +436,7 @@ class MapboxTiles(GoogleWTS):
     def _image_url(self, tile):
         x, y, z = tile
 
-        # Previous version of the API 
-        # (particularly note mapbox.{id} is replaced by mapbox/id)
-        # url = ('https://api.mapbox.com/v4/mapbox.{id}/{z}/{x}/{y}.png'
-        #        '?access_token={token}'.format(z=z, y=y, x=x,
-        #                                       id=self.map_id,
-        #                                       token=self.access_token))
-
-        url = ('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}'
+        url = ('https://api.mapbox.com/styles/v1/mapbox/{id}/tiles/{z}/{x}/{y}'
                '?access_token={token}'.format(z=z, y=y, x=x,
                                               id=self.map_id,
                                               token=self.access_token))

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -213,7 +213,6 @@ def test_mapbox_tiles_api_url():
     exp_url = ('https://api.mapbox.com/styles/v1/bar/tiles'
                '/2/0/1?access_token=foo')
 
-
     mapbox_sample = cimgt.MapboxTiles(token, map_name)
     url_str = mapbox_sample._image_url(tile)
     assert url_str == exp_url

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -210,7 +210,7 @@ def test_mapbox_tiles_api_url():
     token = 'foo'
     map_name = 'bar'
     tile = [0, 1, 2]
-    exp_url = ('https://api.mapbox.com/styles/v1/bar/tiles'
+    exp_url = ('https://api.mapbox.com/styles/v1/mapbox/bar/tiles'
                '/2/0/1?access_token=foo')
 
     mapbox_sample = cimgt.MapboxTiles(token, map_name)

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -210,8 +210,9 @@ def test_mapbox_tiles_api_url():
     token = 'foo'
     map_name = 'bar'
     tile = [0, 1, 2]
-    exp_url = ('https://api.mapbox.com/v4/mapbox.bar'
-               '/2/0/1.png?access_token=foo')
+    exp_url = ('https://api.mapbox.com/styles/v1/bar/tiles'
+               '/2/0/1?access_token=foo')
+
 
     mapbox_sample = cimgt.MapboxTiles(token, map_name)
     url_str = mapbox_sample._image_url(tile)


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->


## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

See the discussion on issue #1761. 

The mapbox API has changed and breaks the current MapboxTiles class. The old interface remains active for the mapbox satellite map style but not for the others. The current Mapbox API documentation guides users to adopt the new approach for all the different styles.

The fix is relatively straightforward - update the url - but note that the previous assumption that all maps were described by `mapbox.map_id` is no longer valid. The styles are now `mapbox/name-version` but I am not sure if that prefix change is robust or long lasting and you may want to specify a pattern more like the original one (i.e. add the mapbox/ to the map id automagically)

## Implications

This is not backward compatible because the API is (selectively) deprecated and returns a 410 error for old-style urls. 


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
