### PR TITLE
FIX: Adding build_ext call to setup.py on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           conda install $PACKAGES
 
       - name: Create sdist
-        run: python setup.py sdist
+        run: python setup.py build_ext sdist
 
       - name: Publish Package
         uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
We need to call build_ext before creating to the sdist so that we
can have the Cython built extensions available for inclusion in the release.

~~Additionally, cleaning up the MANIFEST.in file to exclude large
files (testing and images) that aren't needed if not installing from source. I'm not sure whether people want this or not? But it cuts the size down from over 10 MB to 1.6 MB on my local machine.~~

Closes #1767