### PR TITLE
Revert "DOC: Removing failing WMTS examples from doc build"

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -82,16 +82,16 @@ version = cartopy.__version__
 release = cartopy.__version__
 
 
-# if (hasattr(owslib, '__version__') and
-#         LooseVersion(owslib.__version__) >= '0.19.2'):
-#     expected_failing_examples = []
-# else:
-# OWSLib WMTS support is broken.
-expected_failing_examples = [
-    '../../examples/web_services/reprojected_wmts.py',
-    '../../examples/web_services/wmts.py',
-    '../../examples/web_services/wmts_time.py',
-]
+if (hasattr(owslib, '__version__') and
+        LooseVersion(owslib.__version__) >= '0.19.2'):
+    expected_failing_examples = []
+else:
+    # OWSLib WMTS support is broken.
+    expected_failing_examples = [
+        '../../examples/web_services/reprojected_wmts.py',
+        '../../examples/web_services/wmts.py',
+        '../../examples/web_services/wmts_time.py',
+    ]
 
 subsection_order = ExplicitOrder(['../../examples/lines_and_polygons',
                                   '../../examples/scalar_data',


### PR DESCRIPTION
Looks like the WMTS examples work again. It would be nice to be less dependent on WMTS tile examples failing when there isn't anything to do on our side of things. I'm not sure if there is a robust approach to this through the gallery or not?

This reverts commit dbecff2b584abc5c0fbbade7e30313ab10fb6686.

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
