### PR TITLE
FIX: Don't reset datalims in contour, only update/expand

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1553,7 +1553,7 @@ class GeoAxes(matplotlib.axes.Axes):
                   if col.get_paths()]
         if bboxes:
             extent = mtransforms.Bbox.union(bboxes)
-            self.dataLim.update_from_data_xy(extent.get_points())
+            self.dataLim.update_from_data_xy(extent.get_points(), ignore=False)
 
         self.autoscale_view()
 
@@ -1591,7 +1591,7 @@ class GeoAxes(matplotlib.axes.Axes):
                   if col.get_paths()]
         if bboxes:
             extent = mtransforms.Bbox.union(bboxes)
-            self.dataLim.update_from_data_xy(extent.get_points())
+            self.dataLim.update_from_data_xy(extent.get_points(), ignore=False)
 
         self.autoscale_view()
 

--- a/lib/cartopy/tests/mpl/test_contour.py
+++ b/lib/cartopy/tests/mpl/test_contour.py
@@ -34,6 +34,27 @@ def test_contour_plot_bounds():
     ax.contourf(x, y, data, levels=np.max(data) + np.arange(1, 3))
 
 
+def test_contour_doesnt_shrink():
+    xglobal = np.linspace(-180, 180)
+    yglobal = np.linspace(-90, 90)
+    xsmall = np.linspace(-30, 30)
+    ysmall = np.linspace(-30, 30)
+    data = np.hypot(*np.meshgrid(xglobal, yglobal))
+
+    proj = ccrs.PlateCarree()
+
+    ax = plt.axes(projection=proj)
+    ax.contourf(xglobal, yglobal, data)
+    expected = np.array([xglobal[0], xglobal[-1], yglobal[0], yglobal[-1]])
+    assert_array_almost_equal(ax.get_extent(), expected)
+
+    # Make sure that a call to contour(f) doesn't shrink the already set bounds
+    ax.contour(xsmall, ysmall, data)
+    assert_array_almost_equal(ax.get_extent(), expected)
+    ax.contourf(xsmall, ysmall, data)
+    assert_array_almost_equal(ax.get_extent(), expected)
+
+
 @cleanup
 def test_contour_linear_ring():
     """Test contourf with a section that only has 3 points."""


### PR DESCRIPTION
Contour(f) previously updated the datalims with ignore=None, which
takes the last value (that must have been True to ignore the current
data limits). We only want to update what was previously there, not
override that box and potentially shrink the limits.

Closes #1780 