### PR TITLE
CI: Fixing image uploads on failure

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -26,21 +26,21 @@ jobs:
       - name: Minimum packages
         # Only run on macos for now
         # Conda's linux packages don't grab the testing label of matplotlib causing failures due to freetype differences
-        if: ${{ matrix.python-version == '3.6' && matrix.os == 'macos-latest' }}
+        if: matrix.python-version == '3.6' && matrix.os == 'macos-latest'
         id: minimum-packages
         run: |
           echo "PACKAGES=cython=0.28.5 matplotlib=2.2.2 numpy=1.16 owslib=0.17 proj4=5.2.0 scipy=1.2.0" >> $GITHUB_ENV
           echo "CFLAGS=-stdlib=libc++" >> $GITHUB_ENV
 
       - name: Latest packages
-        if: ${{ steps.minimum-packages.conclusion == 'skipped' }}
+        if: steps.minimum-packages.conclusion == 'skipped'
         run: |
           echo "PACKAGES=cython fiona matplotlib-base numpy proj<8 pykdtree scipy" >> $GITHUB_ENV
 
       - name: Coverage packages
         id: coverage
         # only want the coverage to be run on the latest ubuntu
-        if: ${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' }}
+        if: matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
         run: |
           echo "PACKAGES=$PACKAGES pytest-cov coveralls" >> $GITHUB_ENV
           echo "CYTHON_COVERAGE=1" >> $GITHUB_ENV
@@ -56,6 +56,7 @@ jobs:
           conda list
 
       - name: Install Cartopy
+        id: install
         run: |
           MPL_CONFIG_DIR=~/.config/matplotlib
           mkdir -p $MPL_CONFIG_DIR
@@ -72,14 +73,14 @@ jobs:
           pytest -n 4 --doctest-modules --pyargs cartopy ${EXTRA_TEST_ARGS}
 
       - name: Coveralls
-        if: ${{ steps.coverage.conclusion == 'success' }}
+        if: steps.coverage.conclusion == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:
           coveralls --service=github
 
       - name: Create image output
-        if: ${{ steps.test.conclusion == 'failure' }}
+        if: failure() && steps.install.conclusion == 'success'
         id: image-output
         run:
           python -c "import cartopy.tests.mpl; print(cartopy.tests.mpl.failed_images_html())" >> image-failures-${{ matrix.os }}-${{ matrix.python-version }}.html
@@ -87,7 +88,7 @@ jobs:
       # Can't create image output and upload in the same step
       - name: Upload image results
         uses: actions/upload-artifact@v2
-        if: ${{ steps.image-output.conclusion == 'success' }}
+        if: failure() && steps.image-output.conclusion == 'success'
         with:
           name: image-failures-${{ matrix.os }}-${{ matrix.python-version }}.html
           path: image-failures-${{ matrix.os }}-${{ matrix.python-version }}.html


### PR DESCRIPTION
This should now upload the artifacts from all of the tests that had image failures.

I tested by creating a failing image test and the actions do have artifacts seen on my fork: https://github.com/greglucas/cartopy/actions/runs/826186355