### PR TITLE
Don't use default_params in LongitudeLocator.

### DIFF
--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -479,8 +479,8 @@ class LongitudeLocator(MaxNLocator):
         Allow the locator to stop on minutes and seconds (False by default)
     """
 
-    default_params = MaxNLocator.default_params.copy()
-    default_params.update(nbins=8, dms=False)
+    def __init__(self, nbins=8, *, dms=False, **kwargs):
+        super().__init__(nbins=nbins, dms=dms, **kwargs)
 
     def set_params(self, **kwargs):
         """Set parameters within this locator."""


### PR DESCRIPTION
There's a rather simpler way to override the defaults in
LongitudeLocator.  This change is in preparation of Matplotlib
deprecating default_params (https://github.com/matplotlib/matplotlib/pull/12998,
reverted in https://github.com/matplotlib/matplotlib/pull/13992 due to cartopy,
but I plan to revive that).

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
