### PR TITLE
make threshold writable for RotatedPole

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1376,11 +1376,16 @@ class RotatedPole(_CylindricalProjection):
                         ('o_lat_p', pole_latitude),
                         ('lon_0', 180 + pole_longitude),
                         ('to_meter', math.radians(1))]
+        self._threshold = 0.5
         super().__init__(proj4_params, 180, 90, globe=globe)
 
     @property
     def threshold(self):
-        return 0.5
+        return self._threshold
+
+    @threshold.setter
+    def threshold(self, t):
+        self._threshold = t
 
 
 class Gnomonic(Projection):


### PR DESCRIPTION
## Rationale

Make `threshold` writable for the projection `RotatedPole`, which makes it easier to adjust the resolution of the great circle path. Related to Issue #8.


## Implications

`threshold` of projection `RotatedPole` can be changed after its initialisation using
```python
import cartopy.crs as ccrs
prj = ccrs.RotatedPole(180, 37)
# this line raises AttributeError: can't set attribute before this change
prj.threshold = 0.01 
```
Similar changes can be made to other projections as well if this one is approved.

