### PR TITLE
DOC: Remove Iris and NetCDF dependencies from docs

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,7 +1,3 @@
 sphinx
-netCDF4
-iris
-iris-sample-data
-cf_units
 sphinx-gallery
 beautifulsoup4

--- a/docs/source/matplotlib/advanced_plotting.rst
+++ b/docs/source/matplotlib/advanced_plotting.rst
@@ -2,13 +2,7 @@ More advanced mapping with cartopy and matplotlib
 =================================================
 
 From the outset, cartopy's purpose has been to simplify and improve the quality of
-mapping visualisations available for scientific data. Thanks to the simplicity of the cartopy
-interface, in many cases the hardest part of producing such visualisations is getting
-hold of the data in the first place. To address this, a Python package,
-`Iris <https://scitools.org.uk/iris/>`_, has been created to make loading and saving data from a
-variety of gridded datasets easier. Some of the following examples make use of the Iris
-loading capabilities, while others use the netCDF4 Python package so as to show a range
-of different approaches to data loading.
+mapping visualisations available for scientific data.
 
 
 Contour plots
@@ -20,8 +14,7 @@ Contour plots
 
     import os
     import matplotlib.pyplot as plt
-    from netCDF4 import Dataset as netcdf_dataset
-    import numpy as np
+    from scipy.io import netcdf
 
     from cartopy import config
     import cartopy.crs as ccrs
@@ -32,7 +25,7 @@ Contour plots
                          'netcdf', 'HadISST1_SST_update.nc'
                          )
 
-    dataset = netcdf_dataset(fname)
+    dataset = netcdf.netcdf_file(fname, maskandscale=True, mmap=False)
     sst = dataset.variables['sst'][0, :, :]
     lats = dataset.variables['lat'][:]
     lons = dataset.variables['lon'][:]
@@ -41,45 +34,6 @@ Contour plots
 
     plt.contourf(lons, lats, sst, 60,
                  transform=ccrs.PlateCarree())
-
-    ax.coastlines()
-
-    plt.show()
-
-
-Block plots
------------
-
-.. plot::
-    :include-source:
-
-    import iris
-    import iris_sample_data
-    import matplotlib.pyplot as plt
-
-    import cartopy.crs as ccrs
-
-
-    # load some sample iris data
-    fname = iris.sample_data_path('rotated_pole.nc')
-    temperature = iris.load_cube(fname)
-
-    # iris comes complete with a method to put bounds on a simple point
-    # coordinate. This is very useful...
-    temperature.coord('grid_latitude').guess_bounds()
-    temperature.coord('grid_longitude').guess_bounds()
-
-    # turn the iris Cube data structure into numpy arrays
-    gridlons = temperature.coord('grid_longitude').contiguous_bounds()
-    gridlats = temperature.coord('grid_latitude').contiguous_bounds()
-    temperature = temperature.data
-
-    # set up a map
-    ax = plt.axes(projection=ccrs.PlateCarree())
-
-    # define the coordinate system that the grid lons and grid lats are on
-    rotated_pole = ccrs.RotatedPole(pole_longitude=177.5, pole_latitude=37.5)
-    plt.pcolormesh(gridlons, gridlats, temperature, transform=rotated_pole)
 
     ax.coastlines()
 


### PR DESCRIPTION
Closes #1813

This removes the Iris and NetCDF dependencies from the doc builds. The Iris example is removed and the NetCDF example is changed to use Scipy instead.

This page is already hard to find on the normal docs and these dependencies don't add useful information to our docs.
https://scitools.org.uk/cartopy/docs/v0.19/matplotlib/advanced_plotting.html