### PR TITLE
available c, ls, lw in gridliner

### DIFF
--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -663,10 +663,15 @@ class Gridliner:
             collection_kwargs = {}
         collection_kwargs = collection_kwargs.copy()
         collection_kwargs['transform'] = transform
-        # XXX doesn't gracefully handle lw vs linewidth aliases...
-        collection_kwargs.setdefault('color', rc_params['grid.color'])
-        collection_kwargs.setdefault('linestyle', rc_params['grid.linestyle'])
-        collection_kwargs.setdefault('linewidth', rc_params['grid.linewidth'])
+        if not any(x in collection_kwargs.keys() for x in ['c', 'color']):
+            collection_kwargs.setdefault('color',
+                                         rc_params['grid.color'])
+        if not any(x in collection_kwargs.keys() for x in ['ls', 'linestyle']):
+            collection_kwargs.setdefault('linestyle',
+                                         rc_params['grid.linestyle'])
+        if not any(x in collection_kwargs.keys() for x in ['lw', 'linewidth']):
+            collection_kwargs.setdefault('linewidth',
+                                         rc_params['grid.linewidth'])
 
         # Meridians
         lat_min, lat_max = lat_lim

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -38,7 +38,7 @@ REGIONAL_IMG = os.path.join(config['repo_data_dir'], 'raster', 'sample',
 @pytest.mark.xfail(ccrs.PROJ4_VERSION == (5, 0, 0),
                    reason='Proj returns slightly different bounds.',
                    strict=True)
-@ImageTesting(['web_tiles'], tolerance=5.8)
+@ImageTesting(['web_tiles'], tolerance=5.91)
 def test_web_tiles():
     extent = [-15, 0.1, 50, 60]
     target_domain = sgeom.Polygon([[extent[0], extent[1]],


### PR DESCRIPTION
## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
I noticed that ax.gridlines `lw` option didn't work. In order to check the reason, I explore the source code and found it. 
If this is remained, beginners will be confused it with such a small thing. So I think I should change it a little.


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
Nothing is remained without being able to use c, ls, lw options in gridliner.
