### PR TITLE
Coastlines update

### DIFF
--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -324,7 +324,7 @@ class GSHHSFeature(Feature):
         The dataset scale. One of 'auto', 'coarse', 'low', 'intermediate',
         'high, or 'full' (default is 'auto').
     levels
-        A list of integers 1-4 corresponding to the desired GSHHS feature
+        A list of integers 1-6 corresponding to the desired GSHHS feature
         levels to draw (default is [1] which corresponds to coastlines).
 
     Other Parameters


### PR DESCRIPTION
## Rationale

The GSHHS coastlines that cartopy was automatically downloading were quite old, lots of newer versions came out. Several issues were raised about this (#1353, #1659). I updated the coastlines from 2.2.0 to 2.3.6.

## Implications

More up-to-date and better coastlines are used that include bugfixes and resolve some shape warnings that were frequently thrown.
