### PR TITLE
Allow site-wide configuration via environment variables for data directory containing standard data.

### DIFF
--- a/lib/cartopy/__init__.py
+++ b/lib/cartopy/__init__.py
@@ -20,7 +20,7 @@ _data_dir = os.path.join(os.environ.get("XDG_DATA_HOME", _writable_dir),
                          'cartopy')
 _cache_dir = os.path.join(tempfile.gettempdir(), 'cartopy_cache_dir')
 
-config = {'pre_existing_data_dir': '',
+config = {'pre_existing_data_dir': os.environ.get('CARTOPY_DATA_DIR', ''),
           'data_dir': _data_dir,
           'cache_dir': _cache_dir,
           'repo_data_dir': os.path.join(os.path.dirname(__file__), 'data'),

--- a/lib/cartopy/__init__.py
+++ b/lib/cartopy/__init__.py
@@ -36,6 +36,9 @@ should contain a function called ``update_config`` which takes the config
 dictionary instance as its first and only argument (from where it is
 possible to update the dictionary howsoever desired).
 
+It is also possible to provide site wide customizations for pre-existing data
+via an environment variable `CARTOPY_DATA_DIR`.
+
 For users without write permission to the cartopy source directory, a package
 called ``cartopy_userconfig`` should be made importable (consider putting it
 in ``site.getusersitepackages()``) and should expose a


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

Allow easier site-wide use of standard data (such as that from NaturalEarth).  
Addresses Issue #1281

Cartopy allows for site-wide customizations via `cartopy.config` and `siteconfig.py`, but that requires system admins to place this file into the installation directory.  Cartopy also allows for users to configuration via `cartopy_userconfig`, but most users are not savvy about such things.


## Implications

This will allow site-wide use of system installed/provided standard data as well as users to provide their own path to this data via an environment variable `CARTOPY_DATA_DIR`.


## Checklist

 * CLA -- Signed

 * Example:  
```
export CARTOPY_DATA_DIR="absolute path to a directory where standard data can be found"
```

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing -- N/A
