### PR TITLE
enforce stable aws endpoint for cartopy_feature_download.py

### DIFF
--- a/tools/cartopy_feature_download.py
+++ b/tools/cartopy_feature_download.py
@@ -10,19 +10,23 @@ the data used by various Feature instances.
 
 For detail on how to use this tool, execute it with the `-h` option:
 
-    python download.py -h
+    python cartopy_feature_download.py -h
 
 """
 
 import argparse
+import pathlib
 
 from cartopy import config
 from cartopy.feature import Feature, GSHHSFeature, NaturalEarthFeature
-from cartopy.io import Downloader
+from cartopy.io import Downloader, DownloadWarning
 
 
 ALL_SCALES = ('110m', '50m', '10m')
 
+# See https://github.com/SciTools/cartopy/pull/1833
+URL_TEMPLATE = "https://naturalearth.s3.amazonaws.com/{resolution}_{category}/ne_{resolution}_{name}.zip"
+SHP_NE_SPEC = ("shapefiles", "natural_earth")
 
 FEATURE_DEFN_GROUPS = {
     # Only need one GSHHS resolution because they *all* get downloaded
@@ -114,11 +118,27 @@ if __name__ == '__main__':
                         action='store_true')
     parser.add_argument('--ignore-repo-data', action='store_true',
                         help='ignore existing repo data when downloading')
+    parser.add_argument('--no-warn',
+                        action='store_true',
+                        help='ignore cartopy "DownloadWarning" warnings')
     args = parser.parse_args()
 
     if args.output:
-        config['pre_existing_data_dir'] = args.output
-        config['data_dir'] = args.output
+        target_dir = pathlib.Path(args.output).expanduser().resolve()
+        target_dir.mkdir(parents=True, exist_ok=True)
+        config['pre_existing_data_dir'] = target_dir
+        config['data_dir'] = target_dir
     if args.ignore_repo_data:
         config['repo_data_dir'] = config['data_dir']
+    if args.no_warn:
+        import warnings
+        warnings.filterwarnings("ignore", category=DownloadWarning)
+
+    # Enforce use of stable AWS endpoint, regardless of cartopy version.
+    # In doing so, this allows users to download this script and execute it with
+    # any version of cartopy, thus taking advantage of the stable AWS endpoint.
+    # This removes the need to backport the associated fix
+    # https://github.com/SciTools/cartopy/pull/1833.
+    config['downloaders'][SHP_NE_SPEC].url_template = URL_TEMPLATE
+
     download_features(args.group_names, dry_run=args.dry_run)

--- a/tools/cartopy_feature_download.py
+++ b/tools/cartopy_feature_download.py
@@ -25,8 +25,9 @@ from cartopy.io import Downloader, DownloadWarning
 ALL_SCALES = ('110m', '50m', '10m')
 
 # See https://github.com/SciTools/cartopy/pull/1833
-URL_TEMPLATE = "https://naturalearth.s3.amazonaws.com/{resolution}_{category}/ne_{resolution}_{name}.zip"
-SHP_NE_SPEC = ("shapefiles", "natural_earth")
+URL_TEMPLATE = ('https://naturalearth.s3.amazonaws.com/{resolution}_'
+                '{category}/ne_{resolution}_{name}.zip')
+SHP_NE_SPEC = ('shapefiles', 'natural_earth')
 
 FEATURE_DEFN_GROUPS = {
     # Only need one GSHHS resolution because they *all* get downloaded
@@ -132,11 +133,12 @@ if __name__ == '__main__':
         config['repo_data_dir'] = config['data_dir']
     if args.no_warn:
         import warnings
-        warnings.filterwarnings("ignore", category=DownloadWarning)
+        warnings.filterwarnings('ignore', category=DownloadWarning)
 
     # Enforce use of stable AWS endpoint, regardless of cartopy version.
-    # In doing so, this allows users to download this script and execute it with
-    # any version of cartopy, thus taking advantage of the stable AWS endpoint.
+    # In doing so, this allows users to download this script and execute it
+    # with any version of cartopy, thus taking advantage of the stable AWS
+    # endpoint.
     # This removes the need to backport the associated fix
     # https://github.com/SciTools/cartopy/pull/1833.
     config['downloaders'][SHP_NE_SPEC].url_template = URL_TEMPLATE


### PR DESCRIPTION
This PR is related to #1833 and the ability to download `cartopy` feature resources from the now preferred stable AWS endpoint.

The now renamed `tools/cartopy_feature_download.py` (#1602) on `master` only requires a one line change to ensure that this script works with almost all older versions of `cartopy`, see [line +142](https://github.com/SciTools/cartopy/compare/master...bjlittle:cartopy-feature-download?expand=1#diff-b744d38ca10296c79eaa50b103cd221fb7bfc388caa7faa1a49ff08f1b3357ddR142). Thus removing the need to backport this fix. Clearly there is community appetite for this to happen given #1834.

We have a live use case on SciTools/iris, see [here](https://github.com/SciTools/iris/pull/4304/files#diff-62587956f943bb2503db7bc6dd27d0d888074a1c0ecaab3f570ad611aff0f7bbR81), where we want the benefits of using #1833 to download and populate a `cartopy` cache for our CI. As it happens, the fix proposed here works with an installed `cartopy` v0.18. 

Initially, we worked around the issue by crafting the change solely within `iris`, but there is a bigger win for the `cartopy` community here rather than limiting the win within `iris` e.g., downloading this PR version of `cartopy_feature_download.py` will work for older immutable production versions of `cartopy` to populate the cache and avoid downloading resources on demand.

The benefits of this PR is also not dependant on https://github.com/conda-forge/cartopy-feedstock/pull/116, which only helps users of `cartopy_feature_download.py` with `cartopy` v0.19.0.post1 and onwards.

Closes #1834