### PR TITLE
MNT: Update Feature Artist default zorder

### DIFF
--- a/docs/source/reference/feature.rst
+++ b/docs/source/reference/feature.rst
@@ -6,7 +6,9 @@ Feature interface (cartopy.feature)
 .. currentmodule:: cartopy.feature
 
 The feature interface can be used and extended to add various "features"
-to geoaxes, such as Shapely objects and Natural Earth Imagery.
+to geoaxes, such as Shapely objects and Natural Earth Imagery. The default
+zorder for Cartopy features is 1.5, which puts them above images and patches,
+but below lines and text.
 
 Feature attributes
 ~~~~~~~~~~~~~~~~~~

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -112,21 +112,18 @@ class FeatureArtist(matplotlib.artist.Artist):
             color = self._kwargs.pop('color')
             self._kwargs['facecolor'] = self._kwargs['edgecolor'] = color
 
-        # Set default zorder so that features are drawn before
-        # lines e.g. contours but after images.
+        # Set default zorder so that features are drawn under
+        # lines e.g. contours but over images and filled patches.
         # Note that the zorder of Patch, PatchCollection and PathCollection
         # are all 1 by default. Assuming equal zorder drawing takes place in
-        # the following order: collections, patches, lines (default zorder=2),
-        # text (default zorder=3), then other artists e.g. FeatureArtist.
+        # the following order: collections, patches, FeatureArtist, lines,
+        # text.
         if self._kwargs.get('zorder') is not None:
             self.set_zorder(self._kwargs['zorder'])
         elif feature.kwargs.get('zorder') is not None:
             self.set_zorder(feature.kwargs['zorder'])
         else:
-            # The class attribute matplotlib.collections.PathCollection.zorder
-            # was removed after mpl v1.2.0, so the hard-coded value of 1 is
-            # used instead.
-            self.set_zorder(1)
+            self.set_zorder(1.5)
 
         self._feature = feature
 

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -115,7 +115,7 @@ class FeatureArtist(matplotlib.artist.Artist):
         # Set default zorder so that features are drawn under
         # lines e.g. contours but over images and filled patches.
         # Note that the zorder of Patch, PatchCollection and PathCollection
-        # are all 1 by default. Assuming equal zorder drawing takes place in
+        # are all 1 by default. Assuming default zorder, drawing takes place in
         # the following order: collections, patches, FeatureArtist, lines,
         # text.
         if self._kwargs.get('zorder') is not None:


### PR DESCRIPTION
This PR changes the default zorder to 1.5 for all features added to an axis. This places them above images and patches, but below lines and text.

## Rationale

Matplotlib 3.5 is changing the artist list draw order, which means patches will be drawn in the order they were added to the axis, and *not* last as we have been counting on inadvertently. Many users use `.coastlines()`, which would be drawn in a different order now and likely break a lot of workflows. This PR forces all "features" to have a default zorder of 1.5, which can be overridden when created or added to the axes.

ping @QuLogic, let me know if you have a better fix for this.