### PR TITLE
Use packaging.version instead of distutils

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,9 +21,9 @@ import os
 import sys
 
 import cartopy
-from distutils.version import LooseVersion
 import matplotlib
 import owslib
+from packaging.version import parse as parse_version
 from sphinx_gallery.sorting import ExampleTitleSortKey, ExplicitOrder
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -84,7 +84,7 @@ release = cartopy.__version__
 
 
 if (hasattr(owslib, '__version__') and
-        LooseVersion(owslib.__version__) >= '0.19.2'):
+        parse_version(owslib.__version__) >= parse_version('0.19.2')):
     expected_failing_examples = []
 else:
     # OWSLib WMTS support is broken.

--- a/lib/cartopy/tests/mpl/__init__.py
+++ b/lib/cartopy/tests/mpl/__init__.py
@@ -5,7 +5,6 @@
 # licensing details.
 
 import base64
-from distutils.version import LooseVersion
 import os
 import glob
 import shutil
@@ -17,8 +16,10 @@ import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 from matplotlib.testing import setup as mpl_setup
 import matplotlib.testing.compare as mcompare
+import packaging.version
 
-MPL_VERSION = LooseVersion(mpl.__version__)
+
+MPL_VERSION = packaging.version.parse(mpl.__version__)
 
 
 class ImageTesting:
@@ -200,7 +201,7 @@ class ImageTesting:
                 plt.close('all')
 
             with mpl.style.context(self.style):
-                if MPL_VERSION >= '3.2.0':
+                if MPL_VERSION >= packaging.version.parse('3.2.0'):
                     mpl.rcParams['text.kerning_factor'] = 6
 
                 r = test_func(*args, **kwargs)

--- a/lib/cartopy/tests/mpl/test_examples.py
+++ b/lib/cartopy/tests/mpl/test_examples.py
@@ -5,6 +5,7 @@
 # licensing details.
 
 import matplotlib.pyplot as plt
+from packaging.version import parse as parse_version
 import pytest
 
 import cartopy.crs as ccrs
@@ -49,7 +50,9 @@ def test_global_map():
 
 @pytest.mark.natural_earth
 @ExampleImageTesting(['contour_label'],
-                     tolerance=9.9 if MPL_VERSION < "3.2" else 0.5)
+                     tolerance=(9.9
+                                if MPL_VERSION < parse_version("3.2")
+                                else 0.5))
 def test_contour_label():
     from cartopy.tests.mpl.test_caching import sample_data
     fig = plt.figure()

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -9,6 +9,7 @@ import warnings
 
 import numpy as np
 import matplotlib.pyplot as plt
+from packaging.version import parse as parse_version
 import pytest
 
 import cartopy.crs as ccrs
@@ -106,7 +107,7 @@ def test_global_scatter_wrap_no_transform():
 
 @pytest.mark.natural_earth
 @ImageTesting(['global_hexbin_wrap'],
-              tolerance=2 if MPL_VERSION < '3.2' else 0.5)
+              tolerance=2 if MPL_VERSION < parse_version('3.2') else 0.5)
 def test_global_hexbin_wrap():
     ax = plt.axes(projection=ccrs.PlateCarree())
     ax.coastlines(zorder=2)
@@ -123,7 +124,7 @@ def test_global_hexbin_wrap():
 
 @pytest.mark.natural_earth
 @ImageTesting(['global_hexbin_wrap'],
-              tolerance=2 if MPL_VERSION < '3.2' else 0.5)
+              tolerance=2 if MPL_VERSION < parse_version('3.2') else 0.5)
 def test_global_hexbin_wrap_transform():
     ax = plt.axes(projection=ccrs.PlateCarree())
     ax.coastlines(zorder=2)
@@ -827,7 +828,7 @@ def test_barbs_1d_transformed():
 
 @pytest.mark.natural_earth
 @ImageTesting(['streamplot'], style='mpl20',
-              tolerance=42 if MPL_VERSION < "3.2" else 0.54)
+              tolerance=42 if MPL_VERSION < parse_version('3.2') else 0.54)
 def test_streamplot():
     x = np.arange(-60, 42.5, 2.5)
     y = np.arange(30, 72.5, 2.5)

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,2 +1,3 @@
 flufl.lock
+packaging>=20
 pytest>=5.1.2


### PR DESCRIPTION
## Rationale

Makes us prepared for Python 3.12, which removes `distutils`.

Fixes #1836.

## Implications

New dependency.