### PR TITLE
Bump minimum Python to 3.7

### DIFF
--- a/docs/make_projection.py
+++ b/docs/make_projection.py
@@ -115,14 +115,14 @@ def create_instance(prj_cls, instance_args):
 
     # Format instance arguments into strings
     instance_params = ',\n                            '.join(
-        '{}={}'.format(k, v)
+        f'{k}={v}'
         for k, v in sorted(instance_args.items()))
 
     if instance_params:
         instance_params = '\n                            ' \
                           + instance_params
 
-    instance_creation_code = '{}({})'.format(name, instance_params)
+    instance_creation_code = f'{name}({instance_params})'
 
     prj_inst = prj(**instance_args)
 
@@ -167,7 +167,7 @@ if __name__ == '__main__':
                       np.diff(prj_inst.y_limits))[0]
 
             width = 3 * aspect
-            width = '{:.4f}'.format(width).rstrip('0').rstrip('.')
+            width = f'{width:.4f}'.rstrip('0').rstrip('.')
 
             # Generate plotting code
             code = textwrap.dedent("""

--- a/examples/lines_and_polygons/nightshade.py
+++ b/examples/lines_and_polygons/nightshade.py
@@ -16,7 +16,7 @@ ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
 
 date = datetime.datetime(1999, 12, 31, 12)
 
-ax.set_title('Night time shading for {}'.format(date))
+ax.set_title(f'Night time shading for {date}')
 ax.stock_img()
 ax.add_feature(Nightshade(date, alpha=0.2))
 plt.show()

--- a/lib/cartopy/_epsg.py
+++ b/lib/cartopy/_epsg.py
@@ -23,4 +23,4 @@ class _EPSGProjection(ccrs.Projection):
         super().__init__(crs.to_wkt())
 
     def __repr__(self):
-        return '_EPSGProjection({})'.format(self.epsg_code)
+        return f'_EPSGProjection({self.epsg_code})'

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -198,8 +198,8 @@ class CRS(_CRS):
             a = globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS
             b = globe.semiminor_axis or a
             if a != b or globe.ellipse is not None:
-                warnings.warn('The "{}" projection does not handle elliptical '
-                              'globes.'.format(self.__class__.__name__))
+                warnings.warn(f'The {self.__class__.__name__!r} projection '
+                              'does not handle elliptical globes.')
         self.globe = globe
         if isinstance(proj4_params, str):
             self._proj4_params = {}
@@ -212,13 +212,13 @@ class CRS(_CRS):
             for k, v in self._proj4_params.items():
                 if v is not None:
                     if isinstance(v, float):
-                        init_items.append('+{}={:.16}'.format(k, v))
+                        init_items.append(f'+{k}={v:.16}')
                     elif isinstance(v, np.float32):
-                        init_items.append('+{}={:.8}'.format(k, v))
+                        init_items.append(f'+{k}={v:.8}')
                     else:
-                        init_items.append('+{}={}'.format(k, v))
+                        init_items.append(f'+{k}={v}')
                 else:
-                    init_items.append('+{}'.format(k))
+                    init_items.append(f'+{k}')
             self.proj4_init = ' '.join(init_items) + ' +no_defs'
         super().__init__(self.proj4_init)
 
@@ -833,8 +833,7 @@ class Projection(CRS, metaclass=ABCMeta):
         geom_type = geometry.geom_type
         method_name = self._method_map.get(geom_type)
         if not method_name:
-            raise ValueError('Unsupported geometry '
-                             'type {!r}'.format(geom_type))
+            raise ValueError(f'Unsupported geometry type {geom_type!r}')
         return getattr(self, method_name)(geometry, src_crs)
 
     def _project_point(self, point, src_crs):
@@ -1796,8 +1795,7 @@ class LambertConformal(Projection):
 
         if not 1 <= n_parallels <= 2:
             raise ValueError('1 or 2 standard parallels must be specified. '
-                             'Got {} ({})'.format(n_parallels,
-                                                  standard_parallels))
+                             f'Got {n_parallels} ({standard_parallels})')
 
         proj4_params.append(('lat_1', standard_parallels[0]))
         if n_parallels == 2:
@@ -2353,9 +2351,9 @@ class EqualEarth(_WarpedRectangularProjection):
 
         """
         if PROJ_VERSION < (5, 2, 0):
+            _proj_ver = '.'.join(str(v) for v in PROJ_VERSION)
             raise ValueError('The EqualEarth projection requires Proj version '
-                             '5.2.0, but you are using {}.'
-                             .format('.'.join(str(v) for v in PROJ_VERSION)))
+                             f'5.2.0, but you are using {_proj_ver}.')
 
         proj_params = [('proj', 'eqearth'), ('lon_0', central_longitude)]
         super().__init__(proj_params, central_longitude,
@@ -2549,7 +2547,7 @@ class InterruptedGoodeHomolosine(Projection):
                 _proj_ver = '.'.join(str(v) for v in PROJ_VERSION)
                 raise ValueError('The Interrupted Goode Homolosine ocean '
                                  'projection requires Proj version 7.1.0, '
-                                 'but you are using ' + _proj_ver)
+                                 f'but you are using {_proj_ver}')
             proj4_params = [('proj', 'igh_o'), ('lon_0', central_longitude)]
             super().__init__(proj4_params, globe=globe)
 
@@ -3120,9 +3118,7 @@ class _BoundaryPoint:
         self.data = data
 
     def __repr__(self):
-        return '_BoundaryPoint({!r}, {!r}, {})'.format(
-            self.distance, self.kind, self.data
-        )
+        return f'_BoundaryPoint({self.distance!r}, {self.kind!r}, {self.data})'
 
 
 def _find_first_ge(a, x):

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -799,7 +799,7 @@ class Projection(CRS, metaclass=ABCMeta):
         # "Rewind" the buffer to the start and return it as an svg string.
         buf.seek(0)
         svg = buf.read()
-        return '{}<pre>{}</pre>'.format(svg, escape(object.__repr__(self)))
+        return f'{svg}<pre>{escape(object.__repr__(self))}</pre>'
 
     def _as_mpl_axes(self):
         import cartopy.mpl.geoaxes as geoaxes
@@ -893,7 +893,7 @@ class Projection(CRS, metaclass=ABCMeta):
                                               line_strings[j].coords[-1],
                                               atol=threshold):
                         if debug:
-                            print('Joining together {} and {}.'.format(i, j))
+                            print(f'Joining together {i} and {j}.')
                         last_coords = list(line_strings[j].coords)
                         first_coords = list(line_strings[i].coords)[1:]
                         combo = sgeom.LineString(last_coords + first_coords)
@@ -1066,7 +1066,7 @@ class Projection(CRS, metaclass=ABCMeta):
                 mid_point = boundary.interpolate(mid_dist)
                 new_thing = _BoundaryPoint(mid_dist, True, mid_point)
                 if debug:
-                    print('Artificially insert boundary: {}'.format(new_thing))
+                    print(f'Artificially insert boundary: {new_thing}')
                 ind = edge_things.index(edge_thing)
                 edge_things.insert(ind, new_thing)
                 prev_thing = None
@@ -1089,7 +1089,7 @@ class Projection(CRS, metaclass=ABCMeta):
                     ax.plot(coords[:, 0], coords[:, 1])
                     ax.text(coords[0, 0], coords[0, 1], thing.data[0])
                     ax.text(coords[-1, 0], coords[-1, 1],
-                            '{}.'.format(thing.data[0]))
+                            f'{thing.data[0]}.')
 
         def filter_last(t):
             return t.kind or t.data[1] == 'first'
@@ -1106,7 +1106,7 @@ class Projection(CRS, metaclass=ABCMeta):
                 sys.stdout.write('+')
                 sys.stdout.flush()
                 print()
-                print('Processing: {}, {}'.format(i, current_ls))
+                print(f'Processing: {i}, {current_ls}')
 
             added_linestring = set()
             while True:
@@ -1115,7 +1115,7 @@ class Projection(CRS, metaclass=ABCMeta):
                 # the next point on the boundary.
                 d_last = boundary_distance(current_ls.coords[-1])
                 if debug:
-                    print('   d_last: {!r}'.format(d_last))
+                    print(f'   d_last: {d_last!r}')
                 next_thing = _find_first_ge(edge_things, d_last)
                 # Remove this boundary point from the edge.
                 edge_things.remove(next_thing)

--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -358,8 +358,7 @@ class GSHHSFeature(Feature):
         self._levels = set(levels)
         unknown_levels = self._levels.difference([1, 2, 3, 4])
         if unknown_levels:
-            raise ValueError("Unknown GSHHS levels "
-                             "'{}'.".format(unknown_levels))
+            raise ValueError(f"Unknown GSHHS levels {unknown_levels!r}.")
 
         # Default kwargs
         self._kwargs.setdefault('edgecolor', 'black')

--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -265,7 +265,7 @@ class NaturalEarthFeature(Feature):
     def _validate_scale(self):
         if self.scale not in ('110m', '50m', '10m'):
             raise ValueError(
-                '{} is not a valid Natural Earth scale. '.format(self.scale) +
+                f'{self.scale!r} is not a valid Natural Earth scale. '
                 'Valid scales are "110m", "50m", and "10m".'
             )
 
@@ -350,7 +350,7 @@ class GSHHSFeature(Feature):
 
         if scale not in ('auto', 'a', 'coarse', 'c', 'low', 'l',
                          'intermediate', 'i', 'high', 'h', 'full', 'f'):
-            raise ValueError("Unknown GSHHS scale '{}'.".format(scale))
+            raise ValueError(f"Unknown GSHHS scale {scale!r}.")
         self._scale = scale
 
         if levels is None:

--- a/lib/cartopy/feature/nightshade.py
+++ b/lib/cartopy/feature/nightshade.py
@@ -43,8 +43,8 @@ class Nightshade(ShapelyFeature):
 
         # make sure date is UTC, or naive with respect to time zones
         if date.utcoffset():
-            raise ValueError('datetime instance must be UTC, not {}'.format(
-                             date.tzname()))
+            raise ValueError(
+                f'datetime instance must be UTC, not {date.tzname()}')
 
         # Returns the Greenwich hour angle,
         # need longitude (opposite direction)

--- a/lib/cartopy/io/__init__.py
+++ b/lib/cartopy/io/__init__.py
@@ -238,7 +238,7 @@ class Downloader:
         Caller should close the file handle when finished with it.
 
         """
-        warnings.warn('Downloading: {}'.format(url), DownloadWarning)
+        warnings.warn(f'Downloading: {url}', DownloadWarning)
         return urlopen(url)
 
     @staticmethod

--- a/lib/cartopy/io/__init__.py
+++ b/lib/cartopy/io/__init__.py
@@ -294,7 +294,7 @@ class Downloader:
             # some strange things like not having any downloaders defined
             # in the config...
             raise ValueError('No generic downloadable item in the config '
-                             'dictionary for {}'.format(specification))
+                             f'dictionary for {specification}')
 
         return result_downloader
 

--- a/lib/cartopy/io/img_nest.py
+++ b/lib/cartopy/io/img_nest.py
@@ -116,15 +116,13 @@ class Img(collections.namedtuple('Img', _img_class_attrs)):
         froot, fext = os.path.splitext(fname)
         # If there was no extension to the filename.
         if froot == fname:
-            result = ['{}.{}'.format(fname, 'w'),
-                      '{}.{}'.format(fname, 'W')]
+            result = [f'{fname}.w', f'{fname}.W']
         else:
             fext = fext[1::].lower()
             if len(fext) < 3:
-                result = ['{}.{}'.format(fname, 'w'),
-                          '{}.{}'.format(fname, 'W')]
+                result = [f'{fname}.w', f'{fname}.W']
             else:
-                fext_types = [fext + 'w', fext[0] + fext[-1] + 'w']
+                fext_types = [f'{fext}w', f'{fext[0]}{fext[-1]}w']
                 fext_types.extend([ext.upper() for ext in fext_types])
                 result = [f'{froot}.{ext}' for ext in fext_types]
 
@@ -240,8 +238,8 @@ class ImageCollection:
                 if os.path.exists(fworld):
                     break
             else:
-                msg = 'Image file {!r} has no associated world file'
-                raise ValueError(msg.format(img))
+                raise ValueError(
+                    f'Image file {img!r} has no associated world file')
 
             self.images.append(img_class.from_world_file(img, fworld))
 
@@ -354,8 +352,8 @@ class NestedImageCollection:
         # XXX Copied from cartopy.io.img_tiles
         if target_z not in self._collections_by_name:
             # TODO: Handle integer depths also?
-            msg = '{!r} is not one of the possible collections.'
-            raise ValueError(msg.format(target_z))
+            raise ValueError(
+                f'{target_z!r} is not one of the possible collections.')
 
         tiles = []
         for tile in self.find_images(target_domain, target_z):
@@ -408,8 +406,8 @@ class NestedImageCollection:
         # XXX Copied from cartopy.io.img_tiles
         if target_z not in self._collections_by_name:
             # TODO: Handle integer depths also?
-            msg = '{!r} is not one of the possible collections.'
-            raise ValueError(msg.format(target_z))
+            raise ValueError(
+                f'{target_z!r} is not one of the possible collections.')
 
         if start_tiles is None:
             start_tiles = ((self._collections[0].name, img)

--- a/lib/cartopy/io/img_nest.py
+++ b/lib/cartopy/io/img_nest.py
@@ -126,7 +126,7 @@ class Img(collections.namedtuple('Img', _img_class_attrs)):
             else:
                 fext_types = [fext + 'w', fext[0] + fext[-1] + 'w']
                 fext_types.extend([ext.upper() for ext in fext_types])
-                result = ['{}.{}'.format(froot, ext) for ext in fext_types]
+                result = [f'{froot}.{ext}' for ext in fext_types]
 
         def _convert_basename(name):
             dirname, basename = os.path.split(name)

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -327,7 +327,7 @@ class OSM(GoogleWTS):
 
     def _image_url(self, tile):
         x, y, z = tile
-        url = 'https://a.tile.openstreetmap.org/{}/{}/{}.png'.format(z, x, y)
+        url = f'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'
         return url
 
 
@@ -617,7 +617,7 @@ class OrdnanceSurvey(GoogleWTS):
         self.apikey = apikey
 
         if layer not in ['Outdoor', 'Road', 'Light', 'Night', 'Leisure']:
-            raise ValueError('Invalid layer {}'.format(layer))
+            raise ValueError(f'Invalid layer {layer}')
 
         self.layer = layer
 

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -47,7 +47,7 @@ class GoogleWTS(metaclass=ABCMeta):
     _MAX_THREADS = 24
 
     def __init__(self, desired_tile_form='RGB',
-                 user_agent='CartoPy/' + cartopy.__version__, cache=False):
+                 user_agent=f'CartoPy/{cartopy.__version__}', cache=False):
         self.imgs = []
         self.crs = ccrs.Mercator.GOOGLE
         self.desired_tile_form = desired_tile_form
@@ -115,7 +115,7 @@ class GoogleWTS(metaclass=ABCMeta):
                 if self._default_cache:
                     warnings.warn(
                         'Cartopy created the following directory to cache '
-                        'GoogleWTS tiles: {}'.format(cache_dir))
+                        f'GoogleWTS tiles: {cache_dir}')
             self.cache = self.cache.union(set(os.listdir(cache_dir)))
 
     def _find_images(self, target_domain, target_z, start_tile=(0, 0, 0)):
@@ -170,10 +170,10 @@ class GoogleWTS(metaclass=ABCMeta):
 
         """
         n = 2 ** z
-        assert 0 <= x <= (n - 1), ("Tile's x index is out of range. Upper "
-                                   "limit %s. Got %s" % (n, x))
-        assert 0 <= y <= (n - 1), ("Tile's y index is out of range. Upper "
-                                   "limit %s. Got %s" % (n, y))
+        assert 0 <= x <= (n - 1), \
+            f"Tile's x index is out of range. Upper limit {n}. Got {x}"
+        assert 0 <= y <= (n - 1), \
+            f"Tile's y index is out of range. Upper limit {n}. Got {y}"
 
         x0, x1 = self.crs.x_limits
         y0, y1 = self.crs.y_limits
@@ -264,9 +264,8 @@ World_Shaded_Relief/MapServer/tile/{z}/{y}/{x}.jpg'``
         style = style.lower()
         self.url = url
         if style not in styles:
-            msg = "Invalid style '%s'. Valid styles: %s" % \
-                (style, ", ".join(styles))
-            raise ValueError(msg)
+            raise ValueError(
+                f"Invalid style {style!r}. Valid styles: {', '.join(styles)}")
         self.style = style
 
         # The 'satellite' and 'terrain' styles require pillow with a jpeg
@@ -274,8 +273,9 @@ World_Shaded_Relief/MapServer/tile/{z}/{y}/{x}.jpg'``
         if self.style in ["satellite", "terrain"] and \
                 not hasattr(Image.core, "jpeg_decoder") or \
                 not Image.core.jpeg_decoder:
-            msg = "The '%s' style requires pillow with jpeg decoding support."
-            raise ValueError(msg % self.style)
+            raise ValueError(
+                f"The {self.style!r} style requires pillow with jpeg decoding "
+                "support.")
         return super().__init__(desired_tile_form=desired_tile_form,
                                 cache=cache)
 
@@ -300,13 +300,12 @@ class MapQuestOSM(GoogleWTS):
     # this now requires a sign up to a plan
     def _image_url(self, tile):
         x, y, z = tile
-        url = 'https://otile1.mqcdn.com/tiles/1.0.0/osm/{}/{}/{}.jpg'.format(
-            z, x, y)
+        url = f'https://otile1.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.jpg'
         mqdevurl = ('https://devblog.mapquest.com/2016/06/15/'
                     'modernization-of-mapquest-results-in-changes'
                     '-to-open-tile-access/')
-        warnings.warn('{} will require a log in and and will likely'
-                      ' fail. see {} for more details.'.format(url, mqdevurl))
+        warnings.warn(f'{url} will require a log in and and will likely'
+                      f' fail. see {mqdevurl} for more details.')
         return url
 
 
@@ -317,9 +316,7 @@ class MapQuestOpenAerial(GoogleWTS):
     #  Farm Service Agency"
     def _image_url(self, tile):
         x, y, z = tile
-        url = 'https://oatile1.mqcdn.com/tiles/1.0.0/sat/{}/{}/{}.jpg'.format(
-            z, x, y)
-        return url
+        return f'https://oatile1.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.jpg'
 
 
 class OSM(GoogleWTS):
@@ -327,8 +324,7 @@ class OSM(GoogleWTS):
 
     def _image_url(self, tile):
         x, y, z = tile
-        url = f'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'
-        return url
+        return f'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'
 
 
 class Stamen(GoogleWTS):
@@ -358,8 +354,8 @@ class Stamen(GoogleWTS):
         self.style = style
 
     def _image_url(self, tile):
-        return ('http://tile.stamen.com/{self.style}/{z}/{x}/{y}.png'
-                .format(self=self, x=tile[0], y=tile[1], z=tile[2]))
+        x, y, z = tile
+        return f'http://tile.stamen.com/{self.style}/{z}/{x}/{y}.png'
 
 
 class StamenTerrain(Stamen):
@@ -438,11 +434,8 @@ class MapboxTiles(GoogleWTS):
     def _image_url(self, tile):
         x, y, z = tile
 
-        url = ('https://api.mapbox.com/styles/v1/mapbox/{id}/tiles/{z}/{x}/{y}'
-               '?access_token={token}'.format(z=z, y=y, x=x,
-                                              id=self.map_id,
-                                              token=self.access_token))
-        return url
+        return (f'https://api.mapbox.com/styles/v1/mapbox/{self.map_id}/tiles'
+                f'/{z}/{x}/{y}?access_token={self.access_token}')
 
 
 class MapboxStyleTiles(GoogleWTS):
@@ -481,13 +474,9 @@ class MapboxStyleTiles(GoogleWTS):
 
     def _image_url(self, tile):
         x, y, z = tile
-        url = ('https://api.mapbox.com/styles/v1/'
-               '{user}/{mapid}/tiles/256/{z}/{x}/{y}'
-               '?access_token={token}'.format(z=z, y=y, x=x,
-                                              user=self.username,
-                                              mapid=self.map_id,
-                                              token=self.access_token))
-        return url
+        return (f'https://api.mapbox.com/styles/v1/{self.username}'
+                f'/{self.map_id}/tiles/256/{z}/{x}/{y}'
+                f'?access_token={self.access_token}')
 
 
 class QuadtreeTiles(GoogleWTS):
@@ -500,10 +489,9 @@ class QuadtreeTiles(GoogleWTS):
 
     """
     def _image_url(self, tile):
-        url = ('http://ecn.dynamic.t1.tiles.virtualearth.net/comp/'
-               'CompositionHandler/{tile}?mkt=en-'
-               'gb&it=A,G,L&shading=hill&n=z'.format(tile=tile))
-        return url
+        return ('http://ecn.dynamic.t1.tiles.virtualearth.net/comp/'
+                f'CompositionHandler/{tile}?mkt=en-'
+                'gb&it=A,G,L&shading=hill&n=z')
 
     def tms_to_quadkey(self, tms, google=False):
         quadKey = ""
@@ -541,8 +529,7 @@ class QuadtreeTiles(GoogleWTS):
                 x |= mask
                 y |= mask
             else:
-                raise ValueError('Invalid QuadKey digit '
-                                 'sequence.' + str(quadkey))
+                raise ValueError(f'Invalid QuadKey digit sequence: {quadkey}')
         # the algorithm works to google tiles, so convert to tms
         if not google:
             y = (2 ** z - 1) - y
@@ -623,15 +610,12 @@ class OrdnanceSurvey(GoogleWTS):
 
     def _image_url(self, tile):
         x, y, z = tile
-        url = ('https://api2.ordnancesurvey.co.uk/'
-               'mapping_api/v1/service/wmts?'
-               'key={apikey}&height=256&width=256&tilematrixSet=EPSG%3A3857&'
-               'version=1.0.0&style=true&layer={layer}%203857&'
-               'SERVICE=WMTS&REQUEST=GetTile&format=image%2Fpng&'
-               'TileMatrix=EPSG%3A3857%3A{z}&TileRow={y}&TileCol={x}')
-        return url.format(z=z, y=y, x=x,
-                          apikey=self.apikey,
-                          layer=self.layer)
+        return (
+            f'https://api2.ordnancesurvey.co.uk/mapping_api/v1/service/wmts?'
+            f'key={self.apikey}&height=256&width=256&version=1.0.0&'
+            f'tilematrixSet=EPSG%3A3857&style=true&layer={self.layer}%203857&'
+            f'SERVICE=WMTS&REQUEST=GetTile&format=image%2Fpng&'
+            f'TileMatrix=EPSG%3A3857%3A{z}&TileRow={y}&TileCol={x}')
 
 
 def _merge_tiles(tiles):
@@ -719,8 +703,8 @@ class AzureMapsTiles(GoogleWTS):
         self.api_version = api_version
 
     def _image_url(self, tile):
-        url = ('https://atlas.microsoft.com/map/tile?'
-               'api-version={self.api_version}&tilesetId={self.tileset_id}'
-               '&x={x}&y={y}&zoom={z}&'
-               'subscription-key={self.subscription_key}')
-        return url.format(self=self, x=tile[0], y=tile[1], z=tile[2])
+        x, y, z = tile
+        return (
+            f'https://atlas.microsoft.com/map/tile?'
+            f'api-version={self.api_version}&tilesetId={self.tileset_id}&'
+            f'x={x}&y={y}&zoom={z}&subscription-key={self.subscription_key}')

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -232,8 +232,8 @@ class WMSRasterSource(RasterSource):
             raise ValueError('One or more layers must be defined.')
         for layer in layers:
             if layer not in service.contents:
-                raise ValueError('The {!r} layer does not exist in '
-                                 'this service.'.format(layer))
+                raise ValueError(f'The {layer!r} layer does not exist in '
+                                 'this service.')
 
         #: The OWSLib WebMapService instance.
         self.service = service
@@ -358,8 +358,8 @@ class WMTSRasterSource(RasterSource):
         try:
             layer = wmts.contents[layer_name]
         except KeyError:
-            raise ValueError('Invalid layer name {!r} for WMTS at {!r}'.format(
-                layer_name, wmts.url))
+            raise ValueError(
+                f'Invalid layer name {layer_name!r} for WMTS at {wmts.url!r}')
 
         #: The OWSLib WebMapTileService instance.
         self.wmts = wmts
@@ -410,7 +410,7 @@ class WMTSRasterSource(RasterSource):
                         self.wmts.tilematrixsets[name].crs
                         for name in matrix_set_names})
                     msg = 'Unable to find tile matrix for projection.'
-                    msg += '\n    Projection: ' + str(target_projection)
+                    msg += f'\n    Projection: {target_projection}'
                     msg += '\n    Available tile CRS URNs:'
                     msg += '\n        ' + '\n        '.join(available_urns)
                     raise ValueError(msg)
@@ -655,8 +655,8 @@ class WFSGeometrySource:
             raise ValueError('One or more features must be specified.')
         for feature in features:
             if feature not in service.contents:
-                raise ValueError('The {!r} feature does not exist in this '
-                                 'service.'.format(feature))
+                raise ValueError(
+                    f'The {feature!r} feature does not exist in this service.')
 
         self.service = service
         self.features = features
@@ -681,8 +681,9 @@ class WFSGeometrySource:
                 default_urn = default_urn.pop()
 
             if str(default_urn) not in _URN_TO_CRS:
-                raise ValueError('Unknown mapping from SRS/CRS_URN {!r} to '
-                                 'cartopy projection.'.format(default_urn))
+                raise ValueError(
+                    f'Unknown mapping from SRS/CRS_URN {default_urn!r} to '
+                    'cartopy projection.')
 
             self._default_urn = default_urn
 
@@ -711,7 +712,7 @@ class WFSGeometrySource:
         """
         if self.default_projection() != projection:
             raise ValueError('Geometries are only available in projection '
-                             '{!r}.'.format(self.default_projection()))
+                             f'{self.default_projection()!r}.')
 
         min_x, max_x, min_y, max_y = extent
         response = self.service.getfeature(typename=self.features,
@@ -732,15 +733,14 @@ class WFSGeometrySource:
                 if srs in _URN_TO_CRS:
                     geom_proj = _URN_TO_CRS[srs]
                     if geom_proj != projection:
-                        raise ValueError('The geometries are not in expected '
-                                         'projection. Expected {!r}, got '
-                                         '{!r}.'.format(projection, geom_proj))
+                        raise ValueError(
+                            'The geometries are not in expected projection. '
+                            f'Expected {projection!r}, got {geom_proj!r}.')
                 else:
-                    msg = 'Unable to verify matching projections due ' \
-                          'to incomplete mappings from SRS identifiers ' \
-                          'to cartopy projections. The geometries have ' \
-                          'an SRS of {!r}.'.format(srs)
-                    warnings.warn(msg)
+                    warnings.warn(
+                        'Unable to verify matching projections due to '
+                        'incomplete mappings from SRS identifiers to cartopy '
+                        f'projections. The geometries have an SRS of {srs!r}.')
         return geoms
 
     def _to_shapely_geoms(self, response):

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -765,21 +765,21 @@ class WFSGeometrySource:
         points_data = []
         tree = ElementTree.parse(response)
 
-        for node in tree.findall('.//{}msGeometry'.format(_MAP_SERVER_NS)):
+        for node in tree.findall(f'.//{_MAP_SERVER_NS}msGeometry'):
             # Find LinearRing geometries in our msGeometry node.
-            find_str = './/{gml}LinearRing'.format(gml=_GML_NS)
+            find_str = f'.//{_GML_NS}LinearRing'
             if self._node_has_child(node, find_str):
                 data = self._find_polygon_coords(node, find_str)
                 linear_rings_data.extend(data)
 
             # Find LineString geometries in our msGeometry node.
-            find_str = './/{gml}LineString'.format(gml=_GML_NS)
+            find_str = f'.//{_GML_NS}LineString'
             if self._node_has_child(node, find_str):
                 data = self._find_polygon_coords(node, find_str)
                 linestrings_data.extend(data)
 
             # Find Point geometries in our msGeometry node.
-            find_str = './/{gml}Point'.format(gml=_GML_NS)
+            find_str = f'.//{_GML_NS}Point'
             if self._node_has_child(node, find_str):
                 data = self._find_polygon_coords(node, find_str)
                 points_data.extend(data)
@@ -823,8 +823,8 @@ class WFSGeometrySource:
             x, y = [], []
 
             # We can have nodes called `coordinates` or `coord`.
-            coordinates_find_str = '{}coordinates'.format(_GML_NS)
-            coords_find_str = '{}coord'.format(_GML_NS)
+            coordinates_find_str = f'{_GML_NS}coordinates'
+            coords_find_str = f'{_GML_NS}coord'
 
             if self._node_has_child(polygon, coordinates_find_str):
                 points = polygon.findtext(coordinates_find_str)
@@ -835,8 +835,8 @@ class WFSGeometrySource:
                     y.append(float(y_val))
             elif self._node_has_child(polygon, coords_find_str):
                 for coord in polygon.findall(coords_find_str):
-                    x.append(float(coord.findtext('{}X'.format(_GML_NS))))
-                    y.append(float(coord.findtext('{}Y'.format(_GML_NS))))
+                    x.append(float(coord.findtext(f'{_GML_NS}X')))
+                    y.append(float(coord.findtext(f'{_GML_NS}Y')))
             else:
                 raise ValueError('Unable to find or parse coordinate values '
                                  'from the XML.')

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -72,14 +72,10 @@ class Record:
         self._fields = fields
 
     def __repr__(self):
-        return '<Record: {!r}, {!r}, <fields>>'.format(
-            self.geometry, self.attributes
-        )
+        return f'<Record: {self.geometry!r}, {self.attributes!r}, <fields>>'
 
     def __str__(self):
-        return 'Record({}, {}, <fields>)'.format(
-            self.geometry, self.attributes
-        )
+        return f'Record({self.geometry}, {self.attributes}, <fields>)'
 
     @property
     def bounds(self):
@@ -412,7 +408,7 @@ class GSHHSShpDownloader(Downloader):
 
     _GSHHS_URL_TEMPLATE = (
         'https://www.ngdc.noaa.gov/mgg/shorelines/data/'
-        'gshhs/latest/gshhg-shp-' + gshhs_version + '.zip'
+        f'gshhs/latest/gshhg-shp-{gshhs_version}.zip'
     )
 
     def __init__(self,
@@ -448,9 +444,9 @@ class GSHHSShpDownloader(Downloader):
                 without changing the naming convention
                 """
                 url = (
-                    'https://www.ngdc.noaa.gov/mgg/shorelines/data/'
-                    'gshhs/oldversions/version' + self.gshhs_version + '/'
-                    'gshhg-shp-' + self.gshhs_version + '.zip'
+                    f'https://www.ngdc.noaa.gov/mgg/shorelines/data/'
+                    f'gshhs/oldversions/version{self.gshhs_version}/'
+                    f'gshhg-shp-{self.gshhs_version}.zip'
                 )
                 shapefile_online = self._urlopen(url)
             except HTTPError:
@@ -513,7 +509,7 @@ class GSHHSShpDownloader(Downloader):
         self.acquire_all_resources(format_dict)
         if not os.path.exists(target_path):
             raise RuntimeError('Failed to download and extract GSHHS '
-                               'shapefile to {!r}.'.format(target_path))
+                               f'shapefile to {target_path!r}.')
         return target_path
 
     @staticmethod

--- a/lib/cartopy/io/srtm.py
+++ b/lib/cartopy/io/srtm.py
@@ -57,7 +57,7 @@ class _SRTMSource(RasterSource):
             self._shape = (3601, 3601)
         else:
             raise ValueError(
-                'Resolution is an unexpected value ({}).'.format(resolution))
+                f'Resolution is an unexpected value ({resolution}).')
         self._resolution = resolution
 
         #: The CRS of the underlying SRTM data.
@@ -348,7 +348,7 @@ def read_SRTM(fh):
         elev.shape = (1201, 1201)
     else:
         raise ValueError(
-            'Shape of SRTM data ({}) is unexpected.'.format(elev.size))
+            f'Shape of SRTM data ({elev.size}) is unexpected.')
 
     fname = os.path.basename(fname)
     y_dir, y, x_dir, x = fname[0], int(fname[1:3]), fname[3], int(fname[4:7])

--- a/lib/cartopy/io/srtm.py
+++ b/lib/cartopy/io/srtm.py
@@ -69,7 +69,7 @@ class _SRTMSource(RasterSource):
 
         if self.downloader is None:
             self.downloader = Downloader.from_config(
-                ('SRTM', 'SRTM' + str(resolution)))
+                ('SRTM', f'SRTM{resolution}'))
 
         #: A tuple of (max_x_tiles, max_y_tiles).
         self._max_tiles = (max_nx, max_ny)
@@ -83,9 +83,8 @@ class _SRTMSource(RasterSource):
 
         """
         if not self.validate_projection(projection):
-            raise ValueError(
-                'Unsupported projection for the SRTM{} source.'.format(
-                    self._resolution))
+            raise ValueError(f'Unsupported projection for the '
+                             f'SRTM{self._resolution} source.')
 
         min_x, max_x, min_y, max_y = extent
         min_x, min_y = np.floor([min_x, min_y])
@@ -94,15 +93,13 @@ class _SRTMSource(RasterSource):
         skip = False
         if nx > self._max_tiles[0]:
             warnings.warn(
-                'Required SRTM{} tile count ({}) exceeds maximum ({}). '
-                'Increase max_nx limit.'.format(self._resolution, nx,
-                                                self._max_tiles[0]))
+                f'Required SRTM{self._resolution} tile count ({nx}) exceeds '
+                f'maximum ({self._max_tiles[0]}). Increase max_nx limit.')
             skip = True
         if ny > self._max_tiles[1]:
             warnings.warn(
-                'Required SRTM{} tile count ({}) exceeds maximum ({}). '
-                'Increase max_ny limit.'.format(self._resolution, ny,
-                                                self._max_tiles[1]))
+                f'Required SRTM{self._resolution} tile count ({ny}) exceeds '
+                f'maximum ({self._max_tiles[1]}). Increase max_ny limit.')
             skip = True
         if skip:
             return []
@@ -124,7 +121,7 @@ class _SRTMSource(RasterSource):
         y = '%s%02d' % ('N' if lat >= 0 else 'S', abs(int(lat)))
 
         srtm_downloader = Downloader.from_config(
-            ('SRTM', 'SRTM' + str(self._resolution)))
+            ('SRTM', f'SRTM{self._resolution}'))
         params = {'config': config, 'resolution': self._resolution,
                   'x': x, 'y': y}
 

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -588,8 +588,10 @@ class GeoAxes(matplotlib.axes.Axes):
         ns = 'N' if lat >= 0.0 else 'S'
         ew = 'E' if lon >= 0.0 else 'W'
 
-        return u'%.4g, %.4g (%f\u00b0%s, %f\u00b0%s)' % (x, y, abs(lat),
-                                                         ns, abs(lon), ew)
+        return (
+            f'{x:.4g}, {y:.4g} '
+            f'({abs(lat):f}\u00b0{ns}, {abs(lon):f}\u00b0{ew})'
+        )
 
     def coastlines(self, resolution='auto', color='black', **kwargs):
         """

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -102,9 +102,8 @@ class InterProjectionTransform(mtransforms.Transform):
         mtransforms.Transform.__init__(self)
 
     def __repr__(self):
-        return ('< {!s} {!s} -> {!s} >'.format(self.__class__.__name__,
-                                               self.source_projection,
-                                               self.target_projection))
+        return (f'< {self.__class__.__name__!s} {self.source_projection!s} '
+                f'-> {self.target_projection!s} >')
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
@@ -313,9 +312,9 @@ def _add_transform(func):
         if (func.__name__ in non_spherical_funcs and
                 isinstance(transform, ccrs.CRS) and
                 not isinstance(transform, ccrs.Projection)):
-            raise ValueError('Invalid transform: Spherical {} '
+            raise ValueError(f'Invalid transform: Spherical {func.__name__} '
                              'is not supported - consider using '
-                             'PlateCarree/RotatedPole.'.format(func.__name__))
+                             'PlateCarree/RotatedPole.')
 
         kwargs['transform'] = transform
         return func(self, *args, **kwargs)
@@ -797,15 +796,15 @@ class GeoAxes(matplotlib.axes.Axes):
             if isinstance(crs, ccrs.RotatedGeodetic):
                 proj = ccrs.RotatedPole(crs.proj4_params['lon_0'] - 180,
                                         crs.proj4_params['o_lat_p'])
-                warnings.warn('Approximating coordinate system {!r} with a '
-                              'RotatedPole projection.'.format(crs))
+                warnings.warn(f'Approximating coordinate system {crs!r} with '
+                              'a RotatedPole projection.')
             elif hasattr(crs, 'is_geodetic') and crs.is_geodetic():
                 proj = ccrs.PlateCarree(globe=crs.globe)
-                warnings.warn('Approximating coordinate system {!r} with the '
-                              'PlateCarree projection.'.format(crs))
+                warnings.warn(f'Approximating coordinate system {crs!r} with '
+                              'the PlateCarree projection.')
             else:
                 raise ValueError('Cannot determine extent in'
-                                 ' coordinate system {!r}'.format(crs))
+                                 f' coordinate system {crs!r}')
 
         # Calculate intersection with boundary and project if necessary.
         boundary_poly = sgeom.Polygon(self.projection.boundary)
@@ -867,12 +866,11 @@ class GeoAxes(matplotlib.axes.Axes):
             # the projection extents, so try and give a better error message.
             x1, y1, x2, y2 = projected.bounds
         except ValueError:
-            msg = ('Failed to determine the required bounds in projection '
-                   'coordinates. Check that the values provided are within '
-                   'the valid range (x_limits=[{xlim[0]}, {xlim[1]}], '
-                   'y_limits=[{ylim[0]}, {ylim[1]}]).')
-            raise ValueError(msg.format(xlim=self.projection.x_limits,
-                                        ylim=self.projection.y_limits))
+            raise ValueError(
+                'Failed to determine the required bounds in projection '
+                'coordinates. Check that the values provided are within the '
+                f'valid range (x_limits={self.projection.x_limits}, '
+                f'y_limits={self.projection.y_limits}).')
 
         self.set_xlim([x1, x2])
         self.set_ylim([y1, y2])
@@ -1078,9 +1076,10 @@ class GeoAxes(matplotlib.axes.Axes):
         try:
             fname = _USER_BG_IMGS[name][resolution]
         except KeyError:
-            msg = ('Image "{}" and resolution "{}" are not present in '
-                   'the user background image metadata in directory "{}"')
-            raise ValueError(msg.format(name, resolution, bgdir))
+            raise ValueError(
+                f'Image {name!r} and resolution {resolution!r} are not '
+                f'present in the user background image metadata in directory '
+                f'{bgdir!r}')
         # Now obtain the image data from file or cache:
         fpath = os.path.join(bgdir, fname)
         if cache:
@@ -1192,19 +1191,18 @@ class GeoAxes(matplotlib.axes.Axes):
                     # check that this image type has the required info:
                     for required in required_info:
                         if required not in _USER_BG_IMGS[img_type]:
-                            msg = ('User background metadata file "{}", '
-                                   'image type "{}", does not specify '
-                                   'metadata item "{}"')
-                            raise ValueError(msg.format(json_file, img_type,
-                                                        required))
+                            raise ValueError(
+                                f'User background metadata file {json_file!r},'
+                                f' image type {img_type!r}, does not specify'
+                                f' metadata item {required!r}')
                     for resln in _USER_BG_IMGS[img_type]:
                         # the required_info items are not resolutions:
                         if resln not in required_info:
                             img_it_r = _USER_BG_IMGS[img_type][resln]
                             test_file = os.path.join(bgdir, img_it_r)
                             if not os.path.isfile(test_file):
-                                msg = 'File "{}" not found'
-                                raise ValueError(msg.format(test_file))
+                                raise ValueError(
+                                    f'File "{test_file}" not found')
 
     def add_raster(self, raster_source, **slippy_image_kwargs):
         """

--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -25,7 +25,6 @@ degree_locator = mticker.MaxNLocator(nbins=9, steps=[1, 1.5, 1.8, 2, 3, 6, 10])
 classic_locator = mticker.MaxNLocator(nbins=9)
 classic_formatter = mticker.ScalarFormatter
 
-_DEGREE_SYMBOL = '\u00B0'
 _X_INLINE_PROJS = (
     cartopy.crs.InterruptedGoodeHomolosine,
     cartopy.crs.LambertConformal,
@@ -84,17 +83,13 @@ def _lat_hemisphere(latitude):
 
 
 def _east_west_formatted(longitude, num_format='g'):
-    fmt_string = '{longitude:{num_format}}{degree}{hemisphere}'
-    return fmt_string.format(longitude=abs(longitude), num_format=num_format,
-                             hemisphere=_lon_hemisphere(longitude),
-                             degree=_DEGREE_SYMBOL)
+    hemisphere = _lon_hemisphere(longitude)
+    return f'{abs(longitude):{num_format}}\N{Degree Sign}{hemisphere}'
 
 
 def _north_south_formatted(latitude, num_format='g'):
-    fmt_string = '{latitude:{num_format}}{degree}{hemisphere}'
-    return fmt_string.format(latitude=abs(latitude), num_format=num_format,
-                             hemisphere=_lat_hemisphere(latitude),
-                             degree=_DEGREE_SYMBOL)
+    hemisphere = _lat_hemisphere(latitude)
+    return f'{abs(latitude):{num_format}}\N{Degree Sign}{hemisphere}'
 
 
 #: A formatter which turns longitude values into nice longitudes such as 110W
@@ -319,7 +314,7 @@ class Gridliner:
             self.geo_labels = draw_labels
 
         for loc in 'top', 'bottom', 'left', 'right', 'geo':
-            value = getattr(self, loc + '_labels')
+            value = getattr(self, f'{loc}_labels')
             if isinstance(value, str):
                 value = value.lower()
             if (not isinstance(value, (list, bool)) and
@@ -802,7 +797,7 @@ class Gridliner:
 
             x_inline = self.x_inline and xylabel == 'x'
             y_inline = self.y_inline and xylabel == 'y'
-            padding = getattr(self, xylabel + "padding")
+            padding = getattr(self, f'{xylabel}padding')
             bbox_style = self.labels_bbox_style.copy()
             if "bbox" in label_style:
                 bbox_style.update(label_style["bbox"])
@@ -885,7 +880,7 @@ class Gridliner:
                     else:
                         warnings.warn(
                             'Unsupported intersection geometry for gridline '
-                            'labels: ' + intersection.__class__.__name__)
+                            f'labels: {intersection.__class__.__name__}')
                         continue
                     del intersection
 
@@ -1190,9 +1185,9 @@ class Gridliner:
         """
         # Check labelling is supported, currently a limited set of options.
         if not isinstance(self.crs, PlateCarree):
-            raise TypeError('Cannot label {crs.__class__.__name__} gridlines.'
-                            ' Only PlateCarree gridlines are currently '
-                            'supported.'.format(crs=self.crs))
+            raise TypeError(f'Cannot label {self.crs.__class__.__name__} '
+                            'gridlines. Only PlateCarree gridlines are '
+                            'currently supported.')
         return True
 
     def _axes_domain(self, nx=None, ny=None):

--- a/lib/cartopy/mpl/patch.py
+++ b/lib/cartopy/mpl/patch.py
@@ -79,7 +79,7 @@ def geos_to_path(shape):
         vertices, codes = shape._as_mpl_path()
         return [Path(vertices, codes)]
     else:
-        raise ValueError('Unsupported shape type {}.'.format(type(shape)))
+        raise ValueError(f'Unsupported shape type {type(shape)}.')
 
 
 def path_segments(path, **kwargs):

--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -158,23 +158,15 @@ class _PlateCarreeFormatter(Formatter):
             number_format = 'd'
         else:
             number_format = self._degrees_number_format
-        return '{value:{number_format}}{symbol}'.format(
-            value=abs(deg),
-            number_format=number_format,
-            symbol=self._degree_symbol)
+        return f'{abs(deg):{number_format}}{self._degree_symbol}'
 
     def _format_minutes(self, mn):
         """Format minutes as an integer"""
-        return '{value:d}{symbol}'.format(
-            value=int(mn),
-            symbol=self._minute_symbol)
+        return f'{int(mn):d}{self._minute_symbol}'
 
     def _format_seconds(self, sec):
         """Format seconds as an float"""
-        return '{value:{fmt}}{symbol}'.format(
-            value=sec,
-            fmt=self._seconds_num_format,
-            symbol=self._second_symbol)
+        return f'{sec:{self._seconds_num_format}}{self._second_symbol}'
 
     def _apply_transform(self, value, target_proj, source_crs):
         """

--- a/lib/cartopy/tests/crs/helpers.py
+++ b/lib/cartopy/tests/crs/helpers.py
@@ -10,6 +10,6 @@ Helpers for Cartopy CRS subclass tests.
 
 
 def check_proj_params(name, crs, other_args):
-    expected = other_args | {'proj=' + name, 'no_defs'}
+    expected = other_args | {f'proj={name}', 'no_defs'}
     proj_params = set(crs.proj4_init.lstrip('+').split(' +'))
     assert expected == proj_params

--- a/lib/cartopy/tests/crs/test_albers_equal_area.py
+++ b/lib/cartopy/tests/crs/test_albers_equal_area.py
@@ -57,7 +57,7 @@ class TestAlbersEqualArea:
     def test_central_longitude(self, lon):
         aea = ccrs.AlbersEqualArea()
         aea_offset = ccrs.AlbersEqualArea(central_longitude=lon)
-        other_args = {'ellps=WGS84', 'lon_0={}'.format(lon), 'lat_0=0.0',
+        other_args = {'ellps=WGS84', f'lon_0={lon}', 'lat_0=0.0',
                       'x_0=0.0', 'y_0=0.0', 'lat_1=20.0', 'lat_2=50.0'}
         check_proj_params('aea', aea_offset, other_args)
 

--- a/lib/cartopy/tests/crs/test_eckert.py
+++ b/lib/cartopy/tests/crs/test_eckert.py
@@ -126,7 +126,7 @@ def test_offset(name, proj):
 @pytest.mark.parametrize('lon', [-10.0, 10.0])
 def test_central_longitude(name, proj, lim, lon):
     eck = proj(central_longitude=lon)
-    other_args = {'a=6378137.0', 'lon_0={}'.format(lon)}
+    other_args = {'a=6378137.0', f'lon_0={lon}'}
     check_proj_params(name, eck, other_args)
 
     assert_almost_equal(eck.x_limits, [-lim, lim], decimal=5)
@@ -160,7 +160,7 @@ def test_eckert_grid(name, proj, radius, expected_x, expected_y):
     eck = proj(globe=globe)
     geodetic = eck.as_geodetic()
 
-    other_args = {'a={}'.format(radius), 'lon_0=0'}
+    other_args = {f'a={radius}', 'lon_0=0'}
     check_proj_params(name, eck, other_args)
 
     assert_almost_equal(eck.x_limits, [-2, 2], decimal=5)

--- a/lib/cartopy/tests/crs/test_equal_earth.py
+++ b/lib/cartopy/tests/crs/test_equal_earth.py
@@ -62,7 +62,7 @@ def test_eccentric_globe():
 @pytest.mark.parametrize('lon', [-10.0, 10.0])
 def test_central_longitude(lon):
     eqearth = ccrs.EqualEarth(central_longitude=lon)
-    other_args = {'ellps=WGS84', 'lon_0={}'.format(lon)}
+    other_args = {'ellps=WGS84', f'lon_0={lon}'}
     check_proj_params('eqearth', eqearth, other_args)
 
     assert_almost_equal(eqearth.x_limits,

--- a/lib/cartopy/tests/crs/test_equidistant_conic.py
+++ b/lib/cartopy/tests/crs/test_equidistant_conic.py
@@ -57,7 +57,7 @@ class TestEquidistantConic:
     def test_central_longitude(self, lon):
         eqdc = ccrs.EquidistantConic()
         eqdc_offset = ccrs.EquidistantConic(central_longitude=lon)
-        other_args = {'ellps=WGS84', 'lon_0={}'.format(lon), 'lat_0=0.0',
+        other_args = {'ellps=WGS84', f'lon_0={lon}', 'lat_0=0.0',
                       'x_0=0.0', 'y_0=0.0', 'lat_1=20.0', 'lat_2=50.0'}
         check_proj_params('eqdc', eqdc_offset, other_args)
 

--- a/lib/cartopy/tests/crs/test_gnomonic.py
+++ b/lib/cartopy/tests/crs/test_gnomonic.py
@@ -72,7 +72,7 @@ def test_eccentric_globe():
 @pytest.mark.parametrize('lon', [-10, 0, 10])
 def test_central_params(lat, lon):
     gnom = ccrs.Gnomonic(central_latitude=lat, central_longitude=lon)
-    other_args = {'lat_0={}'.format(lat), 'lon_0={}'.format(lon),
+    other_args = {f'lat_0={lat}', f'lon_0={lon}',
                   'a=6378137.0'}
     check_proj_params('gnom', gnom, other_args)
 

--- a/lib/cartopy/tests/crs/test_interrupted_goode_homolosine.py
+++ b/lib/cartopy/tests/crs/test_interrupted_goode_homolosine.py
@@ -60,7 +60,7 @@ def test_central_longitude(emphasis, lon):
     igh = ccrs.InterruptedGoodeHomolosine(
         central_longitude=lon, emphasis=emphasis
     )
-    other_args = {"ellps=WGS84", "lon_0={}".format(lon)}
+    other_args = {"ellps=WGS84", f"lon_0={lon}"}
     if emphasis == "land":
         check_proj_params("igh", igh, other_args)
     elif emphasis == "ocean":

--- a/lib/cartopy/tests/crs/test_lambert_azimuthal_equal_area.py
+++ b/lib/cartopy/tests/crs/test_lambert_azimuthal_equal_area.py
@@ -52,6 +52,6 @@ class TestLambertAzimuthalEqualArea:
     @pytest.mark.parametrize("latitude", [-90, 90])
     def test_extrema(self, latitude):
         crs = ccrs.LambertAzimuthalEqualArea(central_latitude=latitude)
-        other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0={}'.format(latitude),
+        other_args = {'ellps=WGS84', 'lon_0=0.0', f'lat_0={latitude}',
                       'x_0=0.0', 'y_0=0.0'}
         check_proj_params('laea', crs, other_args)

--- a/lib/cartopy/tests/crs/test_mercator.py
+++ b/lib/cartopy/tests/crs/test_mercator.py
@@ -50,7 +50,7 @@ def test_equality():
 @pytest.mark.parametrize('lon', [-10.0, 10.0])
 def test_central_longitude(lon):
     crs = ccrs.Mercator(central_longitude=lon)
-    other_args = {'ellps=WGS84', 'lon_0={}'.format(lon), 'x_0=0.0', 'y_0=0.0',
+    other_args = {'ellps=WGS84', f'lon_0={lon}', 'x_0=0.0', 'y_0=0.0',
                   'units=m'}
     check_proj_params('merc', crs, other_args)
 
@@ -62,7 +62,7 @@ def test_latitude_true_scale():
     lat_ts = 20.0
     crs = ccrs.Mercator(latitude_true_scale=lat_ts)
     other_args = {'ellps=WGS84', 'lon_0=0.0', 'x_0=0.0', 'y_0=0.0', 'units=m',
-                  'lat_ts={}'.format(lat_ts)}
+                  f'lat_ts={lat_ts}'}
     check_proj_params('merc', crs, other_args)
 
     assert_almost_equal(crs.boundary.bounds,
@@ -74,8 +74,8 @@ def test_easting_northing():
     false_northing = -2000000
     crs = ccrs.Mercator(false_easting=false_easting,
                         false_northing=false_northing)
-    other_args = {'ellps=WGS84', 'lon_0=0.0', 'x_0={}'.format(false_easting),
-                  'y_0={}'.format(false_northing), 'units=m'}
+    other_args = {'ellps=WGS84', 'lon_0=0.0', f'x_0={false_easting}',
+                  f'y_0={false_northing}', 'units=m'}
     check_proj_params('merc', crs, other_args)
 
     assert_almost_equal(crs.boundary.bounds,
@@ -88,7 +88,7 @@ def test_scale_factor():
     crs = ccrs.Mercator(scale_factor=scale_factor,
                         globe=ccrs.Globe(ellipse='sphere'))
     other_args = {'ellps=sphere', 'lon_0=0.0', 'x_0=0.0', 'y_0=0.0', 'units=m',
-                  'k_0={:.12f}'.format(scale_factor)}
+                  f'k_0={scale_factor:.12f}'}
     check_proj_params('merc', crs, other_args)
 
     assert_almost_equal(crs.boundary.bounds,

--- a/lib/cartopy/tests/crs/test_miller.py
+++ b/lib/cartopy/tests/crs/test_miller.py
@@ -75,7 +75,7 @@ def test_eccentric_globe():
 @pytest.mark.parametrize('lon', [-10.0, 10.0])
 def test_central_longitude(lon):
     mill = ccrs.Miller(central_longitude=lon)
-    other_args = {'a=6378137.0', 'lon_0={}'.format(lon)}
+    other_args = {'a=6378137.0', f'lon_0={lon}'}
     check_proj_params('mill', mill, other_args)
 
     assert_almost_equal(np.array(mill.x_limits),

--- a/lib/cartopy/tests/crs/test_mollweide.py
+++ b/lib/cartopy/tests/crs/test_mollweide.py
@@ -80,7 +80,7 @@ def test_offset():
 @pytest.mark.parametrize('lon', [-10.0, 10.0])
 def test_central_longitude(lon):
     moll = ccrs.Mollweide(central_longitude=lon)
-    other_args = {'a=6378137.0', 'lon_0={}'.format(lon)}
+    other_args = {'a=6378137.0', f'lon_0={lon}'}
     check_proj_params('moll', moll, other_args)
 
     assert_almost_equal(np.array(moll.x_limits),

--- a/lib/cartopy/tests/crs/test_orthographic.py
+++ b/lib/cartopy/tests/crs/test_orthographic.py
@@ -77,7 +77,7 @@ def test_eccentric_globe():
 @pytest.mark.parametrize('lon', [-10, 0, 10])
 def test_central_params(lat, lon):
     ortho = ccrs.Orthographic(central_latitude=lat, central_longitude=lon)
-    other_args = {'lat_0={}'.format(lat), 'lon_0={}'.format(lon),
+    other_args = {f'lat_0={lat}', f'lon_0={lon}',
                   'a=6378137.0'}
     check_proj_params('ortho', ortho, other_args)
 

--- a/lib/cartopy/tests/crs/test_robinson.py
+++ b/lib/cartopy/tests/crs/test_robinson.py
@@ -96,7 +96,7 @@ def test_offset():
 @pytest.mark.parametrize('lon', [-10.0, 10.0])
 def test_central_longitude(lon):
     robin = ccrs.Robinson(central_longitude=lon)
-    other_args = {'a=6378137.0', 'lon_0={}'.format(lon)}
+    other_args = {'a=6378137.0', f'lon_0={lon}'}
     check_proj_params('robin', robin, other_args)
 
     assert_almost_equal(robin.x_limits,

--- a/lib/cartopy/tests/crs/test_sinusoidal.py
+++ b/lib/cartopy/tests/crs/test_sinusoidal.py
@@ -49,7 +49,7 @@ class TestSinusoidal:
     @pytest.mark.parametrize('lon', [-10.0, 10.0])
     def test_central_longitude(self, lon):
         crs = ccrs.Sinusoidal(central_longitude=lon)
-        other_args = {'ellps=WGS84', 'lon_0={}'.format(lon),
+        other_args = {'ellps=WGS84', f'lon_0={lon}',
                       'x_0=0.0', 'y_0=0.0'}
         check_proj_params('sinu', crs, other_args)
 

--- a/lib/cartopy/tests/crs/test_utm.py
+++ b/lib/cartopy/tests/crs/test_utm.py
@@ -20,7 +20,7 @@ from .helpers import check_proj_params
 def test_default(south):
     zone = 1  # Limits are fixed, so don't bother checking other zones.
     utm = ccrs.UTM(zone, southern_hemisphere=south)
-    other_args = {'ellps=WGS84', 'units=m', 'zone={}'.format(zone)}
+    other_args = {'ellps=WGS84', 'units=m', f'zone={zone}'}
     if south:
         other_args |= {'south'}
     check_proj_params('utm', utm, other_args)

--- a/lib/cartopy/tests/io/test_downloaders.py
+++ b/lib/cartopy/tests/io/test_downloaders.py
@@ -113,8 +113,8 @@ def test_downloading_simple_ascii(download_to_temp):
     with warnings.catch_warnings(record=True) as w:
         assert dnld_item.path(format_dict) == tmp_fname
 
-        assert len(w) == 1, ('Expected a single download warning to be '
-                             'raised. Got {}.'.format(len(w)))
+        assert len(w) == 1, \
+            f'Expected a single download warning to be raised. Got {len(w)}.'
         assert issubclass(w[0].category, cio.DownloadWarning)
 
     with open(tmp_fname) as fh:
@@ -163,9 +163,8 @@ def test_natural_earth_downloader(tmpdir):
     exts = ['.shp', '.shx']
     for ext in exts:
         stem = os.path.splitext(shp_path)[0]
-        msg = "Shapefile's {0} file doesn't exist in {1}{0}".format(ext,
-                                                                    stem)
-        assert os.path.exists(stem + ext), msg
+        assert os.path.exists(stem + ext), \
+            f"Shapefile's {ext} file doesn't exist in {stem}{ext}"
 
     # check that providing a pre downloaded path actually works
     pre_dnld = NEShpDownloader(target_path_template='/not/a/real/file.txt',

--- a/lib/cartopy/tests/mpl/__init__.py
+++ b/lib/cartopy/tests/mpl/__init__.py
@@ -121,15 +121,13 @@ class ImageTesting:
             version of ImageTesting, they will be closed for you.
 
         """
-        n_figures_msg = ('Expected %s figures (based  on the number of '
-                         'image result filenames), but there are %s figures '
-                         'available. The most likely reason for this is that '
-                         'this test is producing too many figures, '
-                         '(alternatively if not using ImageCompare as a '
-                         'decorator, it is possible that a test run prior to '
-                         'this one has not closed its figures).'
-                         '' % (len(self.img_names), len(figures))
-                         )
+        n_figures_msg = (
+            f'Expected {len(self.img_names)} figures (based  on the number of '
+            f'image result filenames), but there are {len(figures)} figures '
+            f'available. The most likely reason for this is that this test is '
+            f'producing too many figures, (alternatively if not using '
+            f'ImageCompare as a decorator, it is possible that a test run '
+            f'prior to this one has not closed its figures).')
         assert len(figures) == len(self.img_names), n_figures_msg
 
         for img_name, figure in zip(self.img_names, figures):
@@ -174,11 +172,10 @@ class ImageTesting:
                                       tol=tol, in_decorator=True)
 
         if err:
-            msg = ('Images were different (RMS: %s).\n%s %s %s\nConsider '
-                   'running idiff to inspect these differences.'
-                   '' % (err['rms'], err['actual'],
-                         err['expected'], err['diff']))
-            assert False, msg
+            assert False, (
+                f"Images were different (RMS: {err['rms']}).\n"
+                f"{err['actual']} {err['expected']} {err['diff']}\n"
+                f"Consider running idiff to inspect these differences.")
 
     def __call__(self, test_func):
         """Called when the decorator is applied to a function."""

--- a/lib/cartopy/tests/mpl/test_caching.py
+++ b/lib/cartopy/tests/mpl/test_caching.py
@@ -95,9 +95,9 @@ def test_coastline_loading_cache():
         ax2.coastlines()
         plt.draw()
 
-    assert counter.count == 0, ('The shapereader Reader class was created {} '
-                                'times, indicating that the caching is not '
-                                'working.'.format(counter.count))
+    assert counter.count == 0, (
+        f'The shapereader Reader class was created {counter.count} times, '
+        f'indicating that the caching is not working.')
 
     plt.close()
 
@@ -135,10 +135,9 @@ def test_shapefile_transform_cache():
 
     # Without caching the count would have been
     # n_calls * n_geom, but should now be just n_geom.
-    assert counter.count == n_geom, ('The given geometry was transformed too '
-                                     'many times (expected: {}; got {}) - the'
-                                     ' caching is not working.'
-                                     ''.format(n_geom, counter.count))
+    assert counter.count == n_geom, (
+        f'The given geometry was transformed too many times (expected: '
+        f'{n_geom}; got {counter.count}) - the caching is not working.')
 
     # Check the cache has an entry for each geometry.
     assert len(FeatureArtist._geom_key_to_geometry_cache) == n_geom
@@ -174,10 +173,10 @@ def test_contourf_transform_path_counting():
 
     # Before the performance enhancement, the count would have been 2 * n_geom,
     # but should now be just n_geom.
-    msg = ('The given geometry was transformed too many times (expected: {}; '
-           'got {}) - the caching is not working.'
-           '').format(n_geom, path_to_geos_counter.count)
-    assert path_to_geos_counter.count == n_geom, msg
+    assert path_to_geos_counter.count == n_geom, (
+        f'The given geometry was transformed too many times (expected: '
+        f'{n_geom}; got {path_to_geos_counter.count}) - the caching is not '
+        f'working.')
 
     # Check the cache has an entry for each geometry.
     assert len(cgeoaxes._PATH_TRANSFORM_CACHE) == initial_cache_size + n_geom
@@ -213,11 +212,9 @@ def test_wmts_tile_caching():
     with gettile_counter:
         source.fetch_raster(crs, extent, resolution)
     n_tiles = 2
-    assert gettile_counter.count == n_tiles, ('Too many tile requests - '
-                                              'expected {}, got {}.'.format(
-                                                  n_tiles,
-                                                  gettile_counter.count)
-                                              )
+    assert gettile_counter.count == n_tiles, (
+        f'Too many tile requests - expected {n_tiles}, got '
+        f'{gettile_counter.count}.')
     gc.collect()
     assert len(image_cache) == 1
     assert len(image_cache[wmts]) == 1
@@ -228,11 +225,9 @@ def test_wmts_tile_caching():
     # call count will stay the same.
     with gettile_counter:
         source.fetch_raster(crs, extent, resolution)
-    assert gettile_counter.count == n_tiles, ('Too many tile requests - '
-                                              'expected {}, got {}.'.format(
-                                                  n_tiles,
-                                                  gettile_counter.count)
-                                              )
+    assert gettile_counter.count == n_tiles, (
+        f'Too many tile requests - expected {n_tiles}, got '
+        f'{gettile_counter.count}.')
     gc.collect()
     assert len(image_cache) == 1
     assert len(image_cache[wmts]) == 1

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -231,19 +231,19 @@ def test_multiple_projections_520():
 
 def test_cursor_values():
     ax = plt.axes(projection=ccrs.NorthPolarStereo())
-    x, y = np.array([-969100.]), np.array([-4457000.])
+    x, y = np.array([-969100., -4457000.])
     r = ax.format_coord(x, y)
     assert (r.encode('ascii', 'ignore') ==
             b'-9.691e+05, -4.457e+06 (50.716617N, 12.267069W)')
 
     ax = plt.axes(projection=ccrs.PlateCarree())
-    x, y = np.array([-181.5]), np.array([50.])
+    x, y = np.array([-181.5, 50.])
     r = ax.format_coord(x, y)
     assert (r.encode('ascii', 'ignore') ==
             b'-181.5, 50 (50.000000N, 178.500000E)')
 
     ax = plt.axes(projection=ccrs.Robinson())
-    x, y = np.array([16060595.2]), np.array([2363093.4])
+    x, y = np.array([16060595.2, 2363093.4])
     r = ax.format_coord(x, y)
     assert re.search(b'1.606e\\+07, 2.363e\\+06 '
                      b'\\(22.09[0-9]{4}N, 173.70[0-9]{4}E\\)',

--- a/lib/cartopy/tests/mpl/test_ticker.py
+++ b/lib/cartopy/tests/mpl/test_ticker.py
@@ -272,7 +272,7 @@ def test_lonlatformatter_non_geoaxes(cls, letter):
     ax.xaxis.set_major_formatter(cls(degree_symbol='', dms=False))
     fig.canvas.draw()
     ticklabels = [t.get_text() for t in ax.get_xticklabels()]
-    assert ticklabels == ['{:g}{}'.format(v, letter) for v in ticks]
+    assert ticklabels == [f'{v:g}{letter}' for v in ticks]
     plt.close()
 
 

--- a/lib/cartopy/tests/test_coding_standards.py
+++ b/lib/cartopy/tests/test_coding_standards.py
@@ -75,7 +75,7 @@ class TestLicenseHeaders:
         except ValueError as e:
             # Caught the case where this is not a git repo.
             return pytest.skip('cartopy installation did not look like a git '
-                               'repo: ' + str(e))
+                               f'repo: {e}')
 
         failed = []
         for fname in sorted(tracked_files):

--- a/lib/cartopy/tests/test_coding_standards.py
+++ b/lib/cartopy/tests/test_coding_standards.py
@@ -51,7 +51,7 @@ class TestLicenseHeaders:
         """
         # Check the ".git" folder exists at the repo dir.
         if not os.path.isdir(os.path.join(REPO_DIR, '.git')):
-            raise ValueError('{} is not a git repository.'.format(REPO_DIR))
+            raise ValueError(f'{REPO_DIR} is not a git repository.')
 
         output = subprocess.check_output(['git', 'ls-tree', '-z', '-r',
                                           '--name-only', 'HEAD'],

--- a/lib/cartopy/tests/test_img_nest.py
+++ b/lib/cartopy/tests/test_img_nest.py
@@ -223,11 +223,11 @@ def test_nest(nest_from_config):
     # floating point values badly
     for img in z1.images:
         if not z0.images[0].bbox().contains(img.bbox()):
-            raise OSError('The test images aren\'t all "contained" by the '
-                          'z0 images, the nest cannot possibly work.\n '
-                          'img {!s} not contained by {!s}\nExtents: {!s}; '
-                          '{!s}'.format(img, z0.images[0], img.extent,
-                                        z0.images[0].extent))
+            raise OSError(
+                'The test images aren\'t all "contained" by the z0 images, '
+                'the nest cannot possibly work.\n'
+                f'img {img!s} not contained by {z0.images[0]!s}\n'
+                f'Extents: {img.extent!s}; {z0.images[0].extent!s}')
     nest_z0_z1 = cimg_nest.NestedImageCollection('aerial test',
                                                  crs,
                                                  [z0, z1])
@@ -312,7 +312,7 @@ def wmts_data():
     finally:
         if test_data_version != _TEST_DATA_VERSION:
             warnings.warn('WMTS test data is out of date, regenerating at '
-                          '{}.'.format(_TEST_DATA_DIR))
+                          f'{_TEST_DATA_DIR}.')
             shutil.rmtree(_TEST_DATA_DIR)
             os.makedirs(_TEST_DATA_DIR)
             with open(data_version_fname, 'w') as fh:

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -47,12 +47,11 @@ if ccrs.PROJ_VERSION == (5, 0, 0):
 
 
 def GOOGLE_IMAGE_URL_REPLACEMENT(self, tile):
-    url = ('https://chart.googleapis.com/chart?chst=d_text_outline&'
-           'chs=256x256&chf=bg,s,00000055&chld=FFFFFF|16|h|000000|b||||'
-           'Google:%20%20(' + str(tile[0]) + ',' + str(tile[1]) + ')'
-           '|Zoom%20' + str(tile[2]) + '||||||______________________'
-           '______')
-    return url
+    x, y, z = tile
+    return (f'https://chart.googleapis.com/chart?chst=d_text_outline&'
+            f'chs=256x256&chf=bg,s,00000055&chld=FFFFFF|16|h|000000|b||||'
+            f'Google:%20%20({x},{y})|Zoom%20{z}||||||'
+            f'____________________________')
 
 
 def test_google_tile_styles():
@@ -243,8 +242,8 @@ def test_ordnance_survey_tile_styles():
 
     ref_url = ('https://api2.ordnancesurvey.co.uk/'
                'mapping_api/v1/service/wmts?'
-               'key=None&height=256&width=256&tilematrixSet=EPSG%3A3857&'
-               'version=1.0.0&style=true&layer={layer}%203857&'
+               'key=None&height=256&width=256&version=1.0.0&'
+               'tilematrixSet=EPSG%3A3857&style=true&layer={layer}%203857&'
                'SERVICE=WMTS&REQUEST=GetTile&format=image%2Fpng&'
                'TileMatrix=EPSG%3A3857%3A{z}&TileRow={y}&TileCol={x}')
     tile = ["1", "2", "3"]

--- a/lib/cartopy/tests/test_line_string.py
+++ b/lib/cartopy/tests/test_line_string.py
@@ -34,7 +34,7 @@ class TestLineString:
             else:
                 expected = 1
             assert len(multi_line_string) == expected, \
-                'Unexpected line when working from {} to {}'.format(start, end)
+                f'Unexpected line when working from {start} to {end}'
 
     def test_simple_fragment_count(self):
         projection = ccrs.PlateCarree()

--- a/lib/cartopy/tests/test_polygon.py
+++ b/lib/cartopy/tests/test_polygon.py
@@ -196,7 +196,7 @@ class TestMisc:
         # approximately 13262233761329.
         area = projected.area
         assert 2.2e9 < area < 2.3e9, \
-            'Got area {}, expecting ~2.2e9'.format(area)
+            f'Got area {area}, expecting ~2.2e9'
 
     def test_self_intersecting_2(self):
         # Geometry comes from a matplotlib contourf (see #509)
@@ -224,7 +224,7 @@ class TestMisc:
         # Before fixing, this geometry used to fill the whole disk. Approx
         # 1.2e14.
         assert 81330 < area < 81340, \
-            'Got area {}, expecting ~81336'.format(area)
+            f'Got area {area}, expecting ~81336'
 
     def test_same_points_on_boundary_1(self):
         source = ccrs.PlateCarree()

--- a/lib/cartopy/util.py
+++ b/lib/cartopy/util.py
@@ -78,11 +78,10 @@ def add_cyclic_point(data, coord=None, axis=-1):
         if coord.ndim != 1:
             raise ValueError('The coordinate must be 1-dimensional.')
         if len(coord) != data.shape[axis]:
-            raise ValueError('The length of the coordinate does not match '
-                             'the size of the corresponding dimension of '
-                             'the data array: len(coord) = {}, '
-                             'data.shape[{}] = {}.'.format(
-                                 len(coord), axis, data.shape[axis]))
+            raise ValueError(f'The length of the coordinate does not match '
+                             f'the size of the corresponding dimension of '
+                             f'the data array: len(coord) = {len(coord)}, '
+                             f'data.shape[{axis}] = {data.shape[axis]}.')
         delta_coord = np.diff(coord)
         if not np.allclose(delta_coord, delta_coord[0]):
             raise ValueError('The coordinate must be equally spaced.')

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@
 # and/or pip.
 import sys
 
-PYTHON_MIN_VERSION = (3, 5)
+PYTHON_MIN_VERSION = (3, 7)
 
 if sys.version_info < PYTHON_MIN_VERSION:
     error = """
@@ -399,8 +399,6 @@ setup(
             'Programming Language :: C++',
             'Programming Language :: Python',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.5',
-            'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',

--- a/tools/cartopy_feature_download.py
+++ b/tools/cartopy_feature_download.py
@@ -79,11 +79,11 @@ def download_features(group_names, dry_run=True):
             format_dict = {'config': config, 'scale': feature._scale,
                            'level': level}
             if dry_run:
-                print('URL: {}'.format(downloader.url(format_dict)))
+                print(f'URL: {downloader.url(format_dict)}')
             else:
                 downloader.path(format_dict)
                 geoms = list(feature.geometries())
-                print('Feature {} length: {}'.format(feature, len(geoms)))
+                print(f'Feature {feature} length: {len(geoms)}')
         else:
             for category, name, scales in feature_defns:
                 if not isinstance(scales, tuple):
@@ -97,7 +97,7 @@ def download_features(group_names, dry_run=True):
                     format_dict = {'config': config, 'category': category,
                                    'name': name, 'resolution': scale}
                     if dry_run:
-                        print('URL: {}'.format(downloader.url(format_dict)))
+                        print(f'URL: {downloader.url(format_dict)}')
                     else:
                         downloader.path(format_dict)
                         geoms = list(feature.geometries())


### PR DESCRIPTION
## Rationale

This is a rebase of #1700, fixing conflicts, dropping unrelated changes, and expanding the f-string change everywhere.

## Implications

Python 3.5 and 3.6 will no longer be supported.