### PR TITLE
BUG: Fix pcolormesh with nan inputs and wrapping

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1880,10 +1880,8 @@ class GeoAxes(matplotlib.axes.Axes):
                     C_mask = getattr(C, 'mask', None)
 
                     # create the masked array to be used with this pcolormesh
-                    if C_mask is not None:
-                        pcolormesh_data = np.ma.array(C, mask=mask | C_mask)
-                    else:
-                        pcolormesh_data = np.ma.array(C, mask=mask)
+                    full_mask = mask if C_mask is None else mask | C_mask
+                    pcolormesh_data = np.ma.array(C, mask=full_mask)
 
                     collection.set_array(pcolormesh_data.ravel())
 
@@ -1912,10 +1910,8 @@ class GeoAxes(matplotlib.axes.Axes):
                                                  pcolor_data, zorder=zorder,
                                                  **kwargs)
                         # Now add back in the masked data if there was any
-                        if C_mask is not None:
-                            pcolor_data = np.ma.array(C, mask=~mask | C_mask)
-                        else:
-                            pcolor_data = np.ma.array(C, mask=~mask)
+                        full_mask = ~mask if C_mask is None else ~mask | C_mask
+                        pcolor_data = np.ma.array(C, mask=full_mask)
                         # The pcolor_col is now possibly shorter than the
                         # actual collection, so grab the masked cells
                         pcolor_col.set_array(pcolor_data[mask].ravel())

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1901,16 +1901,24 @@ class GeoAxes(matplotlib.axes.Axes):
                         # We will add the original data mask in later to
                         # make sure that set_array can work in future
                         # calls on the proper sized array inputs.
-                        pcolor_data = np.ma.array(C.data, mask=~mask)
+                        # NOTE: we don't use C.data here because C.data could
+                        #       contain nan's which would be masked in the
+                        #       pcolor routines, which we don't want. We will
+                        #       fill in the proper data later with set_array()
+                        #       calls.
+                        pcolor_data = np.ma.array(np.zeros(C.shape),
+                                                  mask=~mask)
                         pcolor_col = self.pcolor(pts[..., 0], pts[..., 1],
                                                  pcolor_data, zorder=zorder,
                                                  **kwargs)
                         # Now add back in the masked data if there was any
                         if C_mask is not None:
                             pcolor_data = np.ma.array(C, mask=~mask | C_mask)
-                            # The pcolor_col is now possibly shorter than the
-                            # actual collection, so grab the masked cells
-                            pcolor_col.set_array(pcolor_data[mask].ravel())
+                        else:
+                            pcolor_data = np.ma.array(C, mask=~mask)
+                        # The pcolor_col is now possibly shorter than the
+                        # actual collection, so grab the masked cells
+                        pcolor_col.set_array(pcolor_data[mask].ravel())
                         pcolor_col.set_cmap(cmap)
                         pcolor_col.set_norm(norm)
                         pcolor_col.set_clim(vmin, vmax)

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -605,6 +605,19 @@ def test_pcolormesh_diagonal_wrap():
     assert hasattr(mesh, "_wrapped_collection_fix")
 
 
+def test_pcolormesh_nan_wrap():
+    # Check that data with nan's as input still creates
+    # the proper number of pcolor cells and those aren't
+    # masked in the process.
+    xs, ys = np.meshgrid([120, 160, 200], [-30, 0, 30])
+    data = np.ones((2, 2)) * np.nan
+
+    ax = plt.axes(projection=ccrs.PlateCarree())
+    mesh = ax.pcolormesh(xs, ys, data)
+    pcolor = getattr(mesh, "_wrapped_collection_fix")
+    assert len(pcolor.get_paths()) == 2
+
+
 @pytest.mark.natural_earth
 @ImageTesting(['pcolormesh_goode_wrap'])
 def test_pcolormesh_goode_wrap():


### PR DESCRIPTION
nan inputs to pcolormesh combined with a wrap would mask out the
data before getting to pcolor, and therefore the paths would not
be created. This creates the pcolor paths with generic data and then
calls set_array() with the proper data after the pcolor has been
created to make sure all paths are made first.

Closes #1845