### PR TITLE
Bump minimum Matplotlib to 3.1

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -100,7 +100,7 @@ Optional Dependencies
 To make the most of Cartopy by enabling additional functionality, you may want
 to install these optional dependencies.
 
-**Matplotlib** 1.5.1 or later (https://matplotlib.org/)
+**Matplotlib** 3.1 or later (https://matplotlib.org/)
     Python package for 2D plotting. Python package required for any
     graphical capabilities.
 

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -43,8 +43,8 @@ from cartopy.mpl.slippy_image_artist import SlippyImageArtist
 from cartopy.vector_transform import vector_scalar_to_grid
 
 
-assert mpl.__version__ >= '1.5.1', ('Cartopy is only supported with '
-                                    'Matplotlib 1.5.1 or greater.')
+assert mpl.__version__ >= '3.1', \
+    'Cartopy is only supported with Matplotlib 3.1 or greater.'
 
 _PATH_TRANSFORM_CACHE = weakref.WeakKeyDictionary()
 """

--- a/lib/cartopy/mpl/patch.py
+++ b/lib/cartopy/mpl/patch.py
@@ -165,11 +165,6 @@ def path_to_geos(path, force_ccw=False):
             geom = sgeom.Point(path_verts[0, :])
         elif path_verts.shape[0] > 4 and path_codes[-1] == Path.CLOSEPOLY:
             geom = sgeom.Polygon(path_verts[:-1, :])
-        elif (matplotlib.__version__ < '2.2.0' and
-                # XXX A path can be given which does not end with close poly,
-                # in that situation, we have to guess?
-                path_verts.shape[0] > 3 and verts_same_as_first[-1]):
-            geom = sgeom.Polygon(path_verts)
         else:
             geom = sgeom.LineString(path_verts)
 

--- a/lib/cartopy/mpl/slippy_image_artist.py
+++ b/lib/cartopy/mpl/slippy_image_artist.py
@@ -26,9 +26,8 @@ class SlippyImageArtist(AxesImage):
     """
     def __init__(self, ax, raster_source, **kwargs):
         self.raster_source = raster_source
-        if matplotlib.__version__ >= '3':
-            # This artist fills the Axes, so should not influence layout.
-            kwargs.setdefault('in_layout', False)
+        # This artist fills the Axes, so should not influence layout.
+        kwargs.setdefault('in_layout', False)
         super().__init__(ax, **kwargs)
         self.cache = []
 

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -17,7 +17,7 @@ from cartopy.mpl.gridliner import (
     LATITUDE_FORMATTER, LONGITUDE_FORMATTER,
     classic_locator, classic_formatter)
 
-from cartopy.tests.mpl import MPL_VERSION, ImageTesting
+from cartopy.tests.mpl import ImageTesting
 
 TEST_PROJS = [
     ccrs.PlateCarree,
@@ -126,11 +126,7 @@ def test_gridliner_specified_lines():
 
 # The tolerance on these tests are particularly high because of the high number
 # of text objects. A new testing strategy is needed for this kind of test.
-if MPL_VERSION < "3":
-    TOL = 15
-else:
-    TOL = 3.1
-grid_label_tol = grid_label_inline_tol = grid_label_inline_usa_tol = TOL
+grid_label_tol = grid_label_inline_tol = grid_label_inline_usa_tol = 3.1
 grid_label_tol += 0.8
 grid_label_inline_tol += 1.6
 grid_label_image = 'gridliner_labels'
@@ -212,9 +208,6 @@ def test_grid_labels():
     plt.subplots_adjust(wspace=0.25, hspace=0.25)
 
 
-@pytest.mark.skipif(
-    MPL_VERSION < '3.0.0',
-    reason='Impossible to override tight layout algorithm in mpl < 3')
 @pytest.mark.skipif(geos_version == (3, 9, 0), reason="GEOS intersection bug")
 @pytest.mark.natural_earth
 @ImageTesting(['gridliner_labels_tight'],

--- a/lib/cartopy/tests/mpl/test_patch.py
+++ b/lib/cartopy/tests/mpl/test_patch.py
@@ -4,9 +4,7 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-import matplotlib
 from matplotlib.path import Path
-import pytest
 import shapely.geometry as sgeom
 
 import cartopy.mpl.patch as cpatch
@@ -29,8 +27,6 @@ class Test_path_to_geos:
         assert [type(geom) for geom in geoms] == [sgeom.Point] * 4
         assert len(geoms) == 4
 
-    @pytest.mark.skipif(matplotlib.__version__ < '2.2.0',
-                        reason='Paths may not be closed with old Matplotlib.')
     def test_non_polygon_loop(self):
         p = Path([[0, 10], [170, 20], [-170, 30], [0, 10]],
                  codes=[1, 2, 2, 2])

--- a/requirements/plotting.txt
+++ b/requirements/plotting.txt
@@ -1,4 +1,4 @@
-matplotlib>=1.5.1
+matplotlib>=3.1
 GDAL>=1.10.0
 pillow>=1.7.8
 scipy>=0.10


### PR DESCRIPTION
## Rationale

Another step towards #1518. We already only test with 3.1, and this will make it official.

## Implications

Older Matplotlib will not be supported.