### PR TITLE
Bump minimum Pytest to 5.1.2

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -134,7 +134,7 @@ These packages are required for the full Cartopy test suite to run.
 **flufl.lock** (https://flufllock.readthedocs.io/)
     A platform independent file lock for Python.
 
-**pytest** 3.1.0 or later (https://docs.pytest.org/en/latest/)
+**pytest** 5.1.2 or later (https://docs.pytest.org/en/latest/)
     Python package for software testing.
 
 **pep8** 1.3.3 or later (https://pypi.python.org/pypi/pep8)

--- a/lib/cartopy/tests/io/test_downloaders.py
+++ b/lib/cartopy/tests/io/test_downloaders.py
@@ -49,7 +49,7 @@ def config_replace(replacement_dict):
 
 
 @pytest.fixture
-def download_to_temp(tmpdir_factory):
+def download_to_temp(tmp_path_factory):
     """
     Context manager which defaults the "data_dir" to a temporary directory
     which is automatically cleaned up on exit.
@@ -58,7 +58,7 @@ def download_to_temp(tmpdir_factory):
     old_downloads_dict = cartopy.config['downloaders'].copy()
     old_dir = cartopy.config['data_dir']
 
-    tmp_dir = tmpdir_factory.mktemp('cartopy_data')
+    tmp_dir = tmp_path_factory.mktemp('cartopy_data')
     cartopy.config['data_dir'] = str(tmp_dir)
     try:
         yield tmp_dir
@@ -103,7 +103,7 @@ def test_downloading_simple_ascii(download_to_temp):
 
     format_dict = {'name': 'jquery'}
 
-    target_template = str(download_to_temp.join('{name}.txt'))
+    target_template = str(download_to_temp / '{name}.txt')
     tmp_fname = target_template.format(**format_dict)
 
     dnld_item = cio.Downloader(file_url, target_template)
@@ -128,7 +128,7 @@ def test_downloading_simple_ascii(download_to_temp):
 
 
 @pytest.mark.network
-def test_natural_earth_downloader(tmpdir):
+def test_natural_earth_downloader(tmp_path):
     # downloads a file to a temporary location, and uses that temporary
     # location, then:
     #   * Checks that the file is only downloaded once even when calling
@@ -136,7 +136,7 @@ def test_natural_earth_downloader(tmpdir):
     #   * Checks that shapefiles have all the necessary files when downloaded
     #   * Checks that providing a path in a download item gets used rather
     #     than triggering another download
-    shp_path_template = str(tmpdir.join('{category}_{resolution}_{name}.shp'))
+    shp_path_template = str(tmp_path / '{category}_{resolution}_{name}.shp')
 
     # picking a small-ish file to speed up download times, the file itself
     # isn't important - it is the download mechanism that is.

--- a/lib/cartopy/tests/mpl/test_set_extent.py
+++ b/lib/cartopy/tests/mpl/test_set_extent.py
@@ -157,12 +157,12 @@ def test_view_lim_autoscaling():
     plt.close()
 
 
-def test_view_lim_default_global(tmpdir):
+def test_view_lim_default_global(tmp_path):
     ax = plt.axes(projection=ccrs.PlateCarree())
     # The view lim should be the default unit bbox until it is drawn.
     assert_array_almost_equal(ax.viewLim.frozen().get_points(),
                               [[0, 0], [1, 1]])
-    plt.savefig(str(tmpdir.join('view_lim_default_global.png')))
+    plt.savefig(tmp_path / 'view_lim_default_global.png')
     expected = np.array([[-180, -90], [180, 90]])
     assert_array_almost_equal(ax.viewLim.frozen().get_points(),
                               expected)

--- a/lib/cartopy/tests/test_img_nest.py
+++ b/lib/cartopy/tests/test_img_nest.py
@@ -67,72 +67,61 @@ def _save_world(fname, args):
         fh.write(_world.format(**args))
 
 
-def test_intersect(tmpdir):
+def test_intersect(tmp_path):
     # Zoom level zero.
     # File 1: Parent space of all images.
-    z_0_dir = tmpdir.mkdir('z_0')
+    z_0_dir = tmp_path / 'z_0'
+    z_0_dir.mkdir()
     world = dict(x_pix_size=2, y_rotation=0, x_rotation=0,
                  y_pix_size=2, x_center=1, y_center=1)
     im = Image.new('RGB', (50, 50))
-    fname = z_0_dir.join('p0.tfw')
-    _save_world(str(fname), world)
-    fname = z_0_dir.join('p0.tif')
-    im.save(str(fname))
+    _save_world(z_0_dir / 'p0.tfw', world)
+    im.save(z_0_dir / 'p0.tif')
 
     # Zoom level one.
     # File 1: complete containment within p0.
-    z_1_dir = tmpdir.mkdir('z_1')
+    z_1_dir = tmp_path / 'z_1'
+    z_1_dir.mkdir()
     world = dict(x_pix_size=2, y_rotation=0, x_rotation=0,
                  y_pix_size=2, x_center=21, y_center=21)
     im = Image.new('RGB', (30, 30))
-    fname = z_1_dir.join('p1.tfw')
-    _save_world(str(fname), world)
-    fname = z_1_dir.join('p1.tif')
-    im.save(str(fname))
+    _save_world(z_1_dir / 'p1.tfw', world)
+    im.save(z_1_dir / 'p1.tif')
 
     # Zoom level two.
     # File 1: intersect right edge with p1 left edge.
-    z_2_dir = tmpdir.mkdir('z_2')
+    z_2_dir = tmp_path / 'z_2'
+    z_2_dir.mkdir()
     world = dict(x_pix_size=2, y_rotation=0, x_rotation=0,
                  y_pix_size=2, x_center=6, y_center=21)
     im = Image.new('RGB', (5, 5))
-    fname = z_2_dir.join('p2-1.tfw')
-    _save_world(str(fname), world)
-    fname = z_2_dir.join('p2-1.tif')
-    im.save(str(fname))
+    _save_world(z_2_dir / 'p2-1.tfw', world)
+    im.save(z_2_dir / 'p2-1.tif')
     # File 2: intersect upper right corner with p1
     #         lower left corner.
     world = dict(x_pix_size=2, y_rotation=0, x_rotation=0,
                  y_pix_size=2, x_center=6, y_center=6)
     im = Image.new('RGB', (5, 5))
-    fname = z_2_dir.join('p2-2.tfw')
-    _save_world(str(fname), world)
-    fname = z_2_dir.join('p2-2.tif')
-    im.save(str(fname))
+    _save_world(z_2_dir / 'p2-2.tfw', world)
+    im.save(z_2_dir / 'p2-2.tif')
     # File 3: complete containment within p1.
     world = dict(x_pix_size=2, y_rotation=0, x_rotation=0,
                  y_pix_size=2, x_center=41, y_center=41)
     im = Image.new('RGB', (5, 5))
-    fname = z_2_dir.join('p2-3.tfw')
-    _save_world(str(fname), world)
-    fname = z_2_dir.join('p2-3.tif')
-    im.save(str(fname))
+    _save_world(z_2_dir / 'p2-3.tfw', world)
+    im.save(z_2_dir / 'p2-3.tif')
     # File 4: overlap with p1 right edge.
     world = dict(x_pix_size=2, y_rotation=0, x_rotation=0,
                  y_pix_size=2, x_center=76, y_center=61)
     im = Image.new('RGB', (5, 5))
-    fname = z_2_dir.join('p2-4.tfw')
-    _save_world(str(fname), world)
-    fname = z_2_dir.join('p2-4.tif')
-    im.save(str(fname))
+    _save_world(z_2_dir / 'p2-4.tfw', world)
+    im.save(z_2_dir / 'p2-4.tif')
     # File 5: overlap with p1 bottom right corner.
     world = dict(x_pix_size=2, y_rotation=0, x_rotation=0,
                  y_pix_size=2, x_center=76, y_center=76)
     im = Image.new('RGB', (5, 5))
-    fname = z_2_dir.join('p2-5.tfw')
-    _save_world(str(fname), world)
-    fname = z_2_dir.join('p2-5.tif')
-    im.save(str(fname))
+    _save_world(z_2_dir / 'p2-5.tfw', world)
+    im.save(z_2_dir / 'p2-5.tif')
 
     # Provided in reverse order in order to test the area sorting.
     items = [('dummy-z-2', str(z_2_dir)),

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -329,14 +329,14 @@ def test_azuremaps_get_image():
 
 @pytest.mark.network
 @pytest.mark.parametrize('cache_dir', ["tmpdir", True, False])
-def test_cache(cache_dir, tmpdir):
+def test_cache(cache_dir, tmp_path):
     if cache_dir == "tmpdir":
-        tmpdir_str = tmpdir.strpath
+        tmpdir_str = str(tmp_path)
     else:
         tmpdir_str = cache_dir
 
     if cache_dir is True:
-        config["cache_dir"] = tmpdir.strpath
+        config["cache_dir"] = str(tmp_path)
 
     # Fetch tiles and save them in the cache
     with warnings.catch_warnings(record=True) as w:

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,2 +1,2 @@
 flufl.lock
-pytest>=3.0.0
+pytest>=5.1.2


### PR DESCRIPTION
## Rationale

More of #1518. Also switch `tmpdir` to `tmp_path` fixture, which is newly added in 3.9.

## Implications

