### PR TITLE
Improve benchmarking

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -47,13 +47,21 @@
     //
     "matrix": {
         "numpy": [""],
-        "cython": [""],
         "matplotlib": [""],
-        "proj4": [""],
+        "pyproj": [],
         "pykdtree": [""],
         "scipy": [""],
         "fiona": [""]
     },
+
+    // Change the build command to pre-install build-time dependencies. We
+    // don't put this in matrix, because these are not things we will ever want
+    // to compare versions.
+    "build_command": [
+        "python -mpip install cython setuptools-scm",
+        "python setup.py build",
+        "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    ],
 
     // The directory (relative to the current directory) that benchmarks are
     // stored in.  If not provided, defaults to "benchmarks"

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -7,7 +7,7 @@
     "project": "cartopy",
 
     // The project's homepage
-    "project_url": "https://github.com/scitools/cartopy",
+    "project_url": "https://github.com/SciTools/cartopy",
 
     // The URL or local path of the source code repository for the
     // project being benchmarked
@@ -25,7 +25,7 @@
     "environment_type": "conda",
 
     // the base URL to show a commit for the project.
-    // "show_commit_url": "http://github.com/owner/project/commit/",
+    "show_commit_url": "http://github.com/SciTools/cartopy/commit/",
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.

--- a/benchmarks/cases/geodesic.py
+++ b/benchmarks/cases/geodesic.py
@@ -1,0 +1,71 @@
+# Copyright Cartopy Contributors
+#
+# This file is part of Cartopy and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+
+import numpy as np
+
+from cartopy.geodesic import Geodesic
+
+
+class DirectSuite:
+    params = [
+        ('scalar', 'array'),
+        ('scalar', 'array'),
+        ('zero', 'scalar', 'array'),
+    ]
+    param_names = ['points', 'azimuths', 'distances']
+
+    def setup(self, points, azimuths, distances):
+        self.geod = Geodesic()
+
+        self.points = {
+            'scalar': (0, 0),
+            'array': np.arange(200).reshape(-1, 2),
+        }[points]
+
+        self.azimuths = {
+            'scalar': 0,
+            'array': np.arange(100) * 2,
+        }[azimuths]
+
+        self.distances = {
+            'zero': 0,
+            'scalar': 100,
+            'array': np.logspace(2, 5, 100),
+        }[distances]
+
+    def time_direct(self, points, azimuths, distances):
+        self.geod.direct(self.points, self.azimuths, self.distances)
+
+
+class InverseSuite:
+    params = [
+        ('scalar', 'array'),
+        ('scalar', 'array'),
+    ]
+    param_names = ['points', 'endpoints']
+
+    def setup(self, points, endpoints):
+        self.geod = Geodesic()
+
+        possible_points = {
+            'scalar': (0, 0),
+            'array': np.arange(200).reshape(-1, 2),
+        }
+
+        self.points = possible_points[points]
+        self.endpoints = possible_points[endpoints]
+
+    def time_inverse(self, points, endpoints):
+        self.geod.inverse(self.points, self.endpoints)
+
+
+class CircleSuite:
+    params = [100, 1000, 10000, 100e3, 1000e3, 10000e3]  # in metres
+    param_names = ['radius']
+
+    def time_circle(self, radius):
+        geod = Geodesic()
+        geod.circle(0, 0, radius)

--- a/benchmarks/cases/gridliner.py
+++ b/benchmarks/cases/gridliner.py
@@ -1,0 +1,27 @@
+# Copyright Cartopy Contributors
+#
+# This file is part of Cartopy and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+
+import matplotlib.pyplot as plt
+
+import cartopy.crs as ccrs
+
+
+class Gridliner:
+    params = [
+        (False, True),
+        (False, True),
+    ]
+    param_names = ['draw_labels', 'inline']
+
+    def setup(self, draw_labels, inline):
+        self.proj = ccrs.PlateCarree()
+        fig, ax = plt.subplots(subplot_kw=dict(projection=self.proj))
+        ax.gridlines(draw_labels=draw_labels, x_inline=inline, y_inline=inline,
+                     auto_inline=False)
+        self.figure = fig
+
+    def time_gridlines(self, draw_labels, inline):
+        self.figure.canvas.draw()

--- a/benchmarks/cases/project_linear.py
+++ b/benchmarks/cases/project_linear.py
@@ -8,42 +8,22 @@ import cartopy.io.shapereader as shpreader
 import cartopy.crs as ccrs
 
 
-class Oceans:
-    def prepare(self):
+class Suite:
+    params = [
+        ('PlateCarree', 'NorthPolarStereo', 'Robinson',
+         'InterruptedGoodeHomolosine'),
+        ('110m', '50m'),
+    ]
+    param_names = ['projection', 'resolution']
+
+    def setup(self, projection, resolution):
         shpfilename = shpreader.natural_earth(
-            resolution='50m', category='physical', name='ocean')
+            resolution=resolution, category='physical', name='ocean')
         reader = shpreader.Reader(shpfilename)
         oceans = list(reader.geometries())
         self.geoms = oceans[0]
 
+        self.projection = getattr(ccrs, projection)()
 
-OCEAN = Oceans()
-
-
-def use_setup(setup_fn):
-    # A decorator to create a decorator...
-    def decorator(test_func):
-        # This decorator attaches the setup function to the test.
-        test_func.setup = setup_fn
-        return test_func
-    return decorator
-
-
-@use_setup(OCEAN.prepare)
-def time_ocean_pc():
-    ccrs.PlateCarree().project_geometry(OCEAN.geoms)
-
-
-@use_setup(OCEAN.prepare)
-def time_ocean_np():
-    ccrs.NorthPolarStereo().project_geometry(OCEAN.geoms)
-
-
-@use_setup(OCEAN.prepare)
-def time_ocean_rob():
-    ccrs.Robinson().project_geometry(OCEAN.geoms)
-
-
-@use_setup(OCEAN.prepare)
-def time_ocean_igh():
-    ccrs.InterruptedGoodeHomolosine().project_geometry(OCEAN.geoms)
+    def time_project_linear(self, projection, resolution):
+        self.projection.project_geometry(self.geoms)

--- a/benchmarks/cases/project_linear.py
+++ b/benchmarks/cases/project_linear.py
@@ -6,7 +6,6 @@
 
 import cartopy.io.shapereader as shpreader
 import cartopy.crs as ccrs
-import shapely.geometry as sgeom
 
 
 class Oceans:
@@ -14,9 +13,8 @@ class Oceans:
         shpfilename = shpreader.natural_earth(
             resolution='50m', category='physical', name='ocean')
         reader = shpreader.Reader(shpfilename)
-        oceans = reader.geometries()
-        oceans = sgeom.MultiPolygon(oceans)
-        self.geoms = oceans
+        oceans = list(reader.geometries())
+        self.geoms = oceans[0]
 
 
 OCEAN = Oceans()


### PR DESCRIPTION
## Rationale

Benchmarking stopped working because we've added `pyproj` and `setuptools-scm` as dependencies. 

I added more benchmarks for geodesics and grid lines. Additionally, I've folded the projection benchmarks into one parameterized test and also tested multiple resolutions (though 10m was too slow and timed out, so I've had to leave it out).

## Implications

You can see an example of the results for the last "100" commits here: https://qulogic.github.io/cartopy-bench/ (it's not actually 100 commits because Cartopy does not build with proj 8, so it's not actually any further than the pyproj merge.)