### PR TITLE
Add cardinal_labels and decimal_point options to lon/lat formatters

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1423,7 +1423,8 @@ class GeoAxes(matplotlib.axes.Axes):
                   xformatter=None, yformatter=None, xlim=None, ylim=None,
                   rotate_labels=None, xlabel_style=None, ylabel_style=None,
                   labels_bbox_style=None, xpadding=5, ypadding=5,
-                  offset_angle=25, auto_update=False, **kwargs):
+                  offset_angle=25, auto_update=False, formatter_kwargs=None,
+                  **kwargs):
         """
         Automatically add gridlines to the axes, in the given coordinate
         system, at draw time.
@@ -1530,6 +1531,10 @@ class GeoAxes(matplotlib.axes.Axes):
         auto_update: bool
             Whether to update the grilines and labels when the plot is
             refreshed.
+        formatter_kwargs: dict, optional
+            Options passed to the default formatters.
+            See :class:`~cartopy.mpl.ticker.LongitudeFormatter` and
+            :class:`~cartopy.mpl.ticker.LatitudeFormatter`
 
         Keyword Parameters
         ------------------
@@ -1563,7 +1568,7 @@ class GeoAxes(matplotlib.axes.Axes):
             xlabel_style=xlabel_style, ylabel_style=ylabel_style,
             labels_bbox_style=labels_bbox_style,
             xpadding=xpadding, ypadding=ypadding, offset_angle=offset_angle,
-            auto_update=auto_update)
+            auto_update=auto_update, formatter_kwargs=formatter_kwargs)
         self._gridliners.append(gl)
         return gl
 

--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -113,7 +113,7 @@ class Gridliner:
                  xlim=None, ylim=None, rotate_labels=None,
                  xlabel_style=None, ylabel_style=None, labels_bbox_style=None,
                  xpadding=5, ypadding=5, offset_angle=25,
-                 auto_update=False):
+                 auto_update=False, formatter_kwargs=None):
         """
         Object used by :meth:`cartopy.mpl.geoaxes.GeoAxes.gridlines`
         to add gridlines and tick labels to a map.
@@ -220,6 +220,10 @@ class Gridliner:
         auto_update: bool
             Whether to redraw the gridlines and labels when the figure is
             updated.
+        formatter_kwargs: dict, optional
+            Options passed to the default formatters.
+            See :class:`~cartopy.mpl.ticker.LongitudeFormatter` and
+            :class:`~cartopy.mpl.ticker.LatitudeFormatter`
 
         Notes
         -----
@@ -254,9 +258,14 @@ class Gridliner:
         else:
             self.ylocator = classic_locator
 
+        formatter_kwargs = {
+            **(formatter_kwargs or {}),
+            "dms": dms,
+        }
+
         if xformatter is None:
             if isinstance(crs, PlateCarree):
-                xformatter = LongitudeFormatter(dms=dms)
+                xformatter = LongitudeFormatter(**formatter_kwargs)
             else:
                 xformatter = classic_formatter()
         #: The :class:`~matplotlib.ticker.Formatter` to use for the lon labels.
@@ -264,7 +273,7 @@ class Gridliner:
 
         if yformatter is None:
             if isinstance(crs, PlateCarree):
-                yformatter = LatitudeFormatter(dms=dms)
+                yformatter = LatitudeFormatter(**formatter_kwargs)
             else:
                 yformatter = classic_formatter()
         #: The :class:`~matplotlib.ticker.Formatter` to use for the lat labels.

--- a/lib/cartopy/tests/mpl/test_ticker.py
+++ b/lib/cartopy/tests/mpl/test_ticker.py
@@ -302,3 +302,17 @@ def test_LongitudeLocator(cls, vmin, vmax, expected):
     locator = cls(dms=True)
     result = locator.tick_values(vmin, vmax)
     np.testing.assert_allclose(result, expected)
+
+
+def test_lonlatformatter_decimal_point():
+    xticker = LongitudeFormatter(decimal_point=',', number_format='0.2f')
+    yticker = LatitudeFormatter(decimal_point=',', number_format='0.2f')
+    assert xticker(-10) == "10,00°W"
+    assert yticker(-10) == "10,00°S"
+
+
+def test_lonlatformatter_cardinal_labels():
+    xticker = LongitudeFormatter(cardinal_labels={'west': 'O'})
+    yticker = LatitudeFormatter(cardinal_labels={'south': 'South'})
+    assert xticker(-10) == "10°O"
+    assert yticker(-10) == "10°South"


### PR DESCRIPTION
## Rationale

This PR is a ligther version of PR #1726 and its excellent ideas.
It provides a way to change the decimal separator character and the cardinal labels.

## Implications

* The ``cardinal_labels`` and ``decimal_point`` options are made available to ``LongitudeFormatter`` and ``LatitudeFormatter``.
* The ``formatter_kwargs`` option is added to ``Gridliner`` and ``GeoAxes.gridlines`` to be able to easily change the default lon/lat formatter options.
<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


## Checklist

Three tests are added (and another one is fixed).

Here is an example closed the the one proposed in #1726:

````python
import matplotlib.pyplot as plt
import cartopy.crs as ccrs

ax = plt.subplot(1, 1, 1, projection=ccrs.PlateCarree())
ax.stock_img()
ax.set_extent([-80, -40.0, 10.0, -30.0])
gl = ax.gridlines(
    draw_labels=True, 
    dms=False, 
    formatter_kwargs=dict(
        decimal_point=',', 
        number_format='0.2f' ,
        cardinal_labels={'west': 'O'}
    )
)
plt.show()
````
![gridliner_decimal_point](https://user-images.githubusercontent.com/1941408/133432386-b7afbf3d-e13c-481e-aaf5-943da122624c.png)
