### PR TITLE
DOC: whats new v0.20

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,8 +22,11 @@ You will find cartopy especially useful for large area / small scale data, where
 assumptions of spherical data traditionally break down. If you've ever experienced a singularity
 at the pole or a cut-off at the dateline, it is likely you will appreciate cartopy's unique features!
 
-.. warning::
-  The 0.19 release, and later, no longer support Python 2.7.
+.. note::
+  The v0.20 release uses pyproj for transformations, which could be slower in some situations.
+  If you need to increase the speed of plots and don't need to worry about thread safety in
+  your application, you can set the environment variable
+  `PYPROJ_GLOBAL_CONTEXT=ON` to make the projection calculations faster.
 
 
 Getting involved
@@ -48,6 +51,3 @@ There are many ways to get involved in the development of cartopy:
  * Contribute bug fixes (:issues:`a list of outstanding bugs can be found on GitHub <Type%3A%20bug>`).
  * Contribute enhancements and new features on the issue tracker.
  * Chat with users and developers in the `Gitter chat room <https://gitter.im/SciTools/cartopy>`_.
-
-
-

--- a/docs/source/whatsnew/index.rst
+++ b/docs/source/whatsnew/index.rst
@@ -14,6 +14,7 @@ Versions
 .. toctree::
    :maxdepth: 2
 
+   v0.20
    v0.19
    v0.18
    v0.17

--- a/docs/source/whatsnew/v0.20.rst
+++ b/docs/source/whatsnew/v0.20.rst
@@ -1,0 +1,73 @@
+Version 0.20 (September 17, 2021)
+=================================
+
+For a full list of included Pull Requests and closed Issues, please see the
+`0.20 milestone <https://github.com/SciTools/cartopy/milestone/29>`_.
+
+Features
+--------
+
+* We have updated the minimum versions of dependencies following the
+  guidelines of NEP29. This includes the required dependencies, which are now
+  Python>=3.7, GEOS>=3.7.2, shapely>=1.6.4, pyshp>=2.1, numpy>=1.18,
+  matplotlib>=3.1, PROJ>=8.0, and pyproj>=3.0
+
+* Stephane Raynaud added the ``cartopy_feature_download.py`` script to the
+  installation bundle, making it accessible to everyone and Ruth Comer updated
+  the NaturalEarth url to download from the new AWS cloud host.
+  (:pull:`1602`, :pull:`1833`)
+
+* Louis Moresi updated the Mapbox API to download from their new endpoints.
+  (:pull:`1763`)
+
+* Stephane Raynaud updated the visibility handling for labels (:pull:`1537`)
+
+* @muchjp added the ability for the gridliner to handle shorthand keyword
+  arguments (e.g., c for color). (:pull:`1818`)
+
+* Greg Lucas reorganized the documentation and updated the theme to use the
+  pydata-sphinx-theme. (:pull:`1652`)
+
+* John Krasting extended the InterruptedGoodeHomolosine projection to add
+  an ocean emphasis option. (:pull:`1561`)
+
+    .. plot::
+       :width: 400pt
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import cartopy.crs as ccrs
+
+        fig = plt.figure(figsize=(10, 5))
+        proj = ccrs.InterruptedGoodeHomolosine(central_longitude=-160,
+                                               emphasis='ocean')
+        ax = plt.axes(projection=proj)
+        ax.stock_img()
+
+        plt.show()
+
+* Max H. Balsmeier updated the GSHHS coastlines that are used by Cartopy.
+  (:pull:`1823`)
+
+* Yihe Xu added the ability to adjust the threshold of the projections.
+  (:pull:`1815`)
+
+* Rahul Mahajan added an environment variable to point to site-wide data
+  installation directories. (:pull:`1827`)
+
+* Alan D. Snow updated Cartopy to use pyproj for coordinate transformations,
+  which enables the use of newer PROJ versions. (:pull:`1808`)
+
+* Thomas Grainger and Elliott Sales de Andrade bumped the minimum Python
+  dependency to 3.7. (:pull:`1844`)
+
+* Greg Lucas updated the default zorder for features to be 1.5, which is
+  above patches and below lines. This is in preparation for a change in
+  artist orders with Matplotlib 3.5. (:pull:`1840`)
+
+* Ryan May updated the Geostationary projection boundary to properly
+  calculate the boundary ellipse. (:pull:`1829`)
+
+.. figure:: ../gallery/miscellanea/images/sphx_glr_eccentric_ellipse_001.png
+   :target: ../gallery/miscellanea/eccentric_ellipse.html
+   :align: center

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -2420,7 +2420,7 @@ class InterruptedGoodeHomolosine(Projection):
     ocean features.
 
     Original Reference:
-    Goode, J. P., 1925: The Homolosine Projection: A new device for
+        Goode, J. P., 1925: The Homolosine Projection: A new device for
         portraying the Earth's surface entire. Annals of the
         Association of American Geographers, 15:3, 119-125,
         DOI: 10.1080/00045602509356949


### PR DESCRIPTION
This adds a what's new entry for v0.20.

Additionally, I added a commit that removes the Python 2 warning, and changes that to a note about how to get a speedup with PYPROJ_GLOBAL_CONTEXT, which I think is important to make people aware of.

Things to do before the v0.20 release still:
- [x] #1646
- [x] #1843
- [x] #1854 

Things to consider:
- [ ] Where should we put the new documentation? Keep the old location and just live without the version selector for now, or try to move hosting to RTD (#1765)
- [ ] Removing the PROJ dependency entirely. (#1832)