### PR TITLE
Various test improvements

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -70,7 +70,7 @@ jobs:
           # Check that the downloader tool at least knows where to get the data from (but don't actually download it)
           python tools/cartopy_feature_download.py gshhs physical --dry-run
           CARTOPY_GIT_DIR=$PWD
-          PYPROJ_GLOBAL_CONTEXT=ON pytest -n 4 --doctest-modules --pyargs cartopy ${EXTRA_TEST_ARGS}
+          PYPROJ_GLOBAL_CONTEXT=ON pytest -ra -n 4 --doctest-modules --pyargs cartopy ${EXTRA_TEST_ARGS}
 
       - name: Coveralls
         if: steps.coverage.conclusion == 'success'

--- a/lib/cartopy/tests/io/test_downloaders.py
+++ b/lib/cartopy/tests/io/test_downloaders.py
@@ -6,7 +6,6 @@
 
 import contextlib
 import os
-import warnings
 
 import pytest
 
@@ -110,12 +109,8 @@ def test_downloading_simple_ascii(download_to_temp):
 
     assert dnld_item.target_path(format_dict) == tmp_fname
 
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(cio.DownloadWarning):
         assert dnld_item.path(format_dict) == tmp_fname
-
-        assert len(w) == 1, \
-            f'Expected a single download warning to be raised. Got {len(w)}.'
-        assert issubclass(w[0].category, cio.DownloadWarning)
 
     with open(tmp_fname) as fh:
         fh.readline()

--- a/lib/cartopy/tests/io/test_srtm.py
+++ b/lib/cartopy/tests/io/test_srtm.py
@@ -4,8 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-import warnings
-
 import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
@@ -65,10 +63,8 @@ class TestRetrieve:
     def test_srtm_retrieve(self, Source, read_SRTM, max_, min_, pt,
                            download_to_temp):  # noqa: F811
         # test that the download mechanism for SRTM works
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.warns(cartopy.io.DownloadWarning):
             r = Source().srtm_fname(-4, 50)
-            assert len(w) == 1
-            assert issubclass(w[0].category, cartopy.io.DownloadWarning)
 
         assert r.startswith(str(download_to_temp)), \
             'File not downloaded to tmp dir'

--- a/lib/cartopy/tests/mpl/test_axes.py
+++ b/lib/cartopy/tests/mpl/test_axes.py
@@ -15,7 +15,6 @@ import pytest
 import cartopy.crs as ccrs
 from cartopy.mpl.geoaxes import InterProjectionTransform, GeoAxes
 from cartopy.tests.mpl import ImageTesting
-from cartopy.tests.mpl.test_caching import CallCounter
 
 
 class TestNoSpherical:
@@ -51,20 +50,21 @@ def test_transform_PlateCarree_shortcut():
 
     trans = InterProjectionTransform(src, target)
 
-    counter = CallCounter(target, 'project_geometry')
-
-    with counter:
+    with mock.patch.object(target, 'project_geometry',
+                           wraps=target.project_geometry) as counter:
         trans.transform_path(pth1)
         # pth1 should allow a short-cut.
-        assert counter.count == 0
+        counter.assert_not_called()
 
-    with counter:
+    with mock.patch.object(target, 'project_geometry',
+                           wraps=target.project_geometry) as counter:
         trans.transform_path(pth2)
-        assert counter.count == 1
+        counter.assert_called_once()
 
-    with counter:
+    with mock.patch.object(target, 'project_geometry',
+                           wraps=target.project_geometry) as counter:
         trans.transform_path(pth3)
-        assert counter.count == 2
+        counter.assert_called_once()
 
 
 class Test_InterProjectionTransform:

--- a/lib/cartopy/tests/mpl/test_axes.py
+++ b/lib/cartopy/tests/mpl/test_axes.py
@@ -23,10 +23,6 @@ class TestNoSpherical:
         self.ax = plt.axes(projection=ccrs.PlateCarree())
         self.data = np.arange(12).reshape((3, 4))
 
-    def teardown_method(self):
-        plt.clf()
-        plt.close()
-
     def test_contour(self):
         with pytest.raises(ValueError):
             self.ax.contour(self.data, transform=ccrs.Geodetic())
@@ -98,8 +94,6 @@ class Test_InterProjectionTransform:
 
 
 class Test_Axes_add_geometries:
-    def teardown_method(self):
-        plt.close()
 
     @mock.patch('cartopy.mpl.geoaxes.GeoAxes.add_feature')
     @mock.patch('cartopy.feature.ShapelyFeature')

--- a/lib/cartopy/tests/mpl/test_caching.py
+++ b/lib/cartopy/tests/mpl/test_caching.py
@@ -98,8 +98,6 @@ def test_coastline_loading_cache():
         f'The shapereader Reader class was created {counter.count} times, '
         f'indicating that the caching is not working.')
 
-    plt.close()
-
 
 @pytest.mark.natural_earth
 def test_shapefile_transform_cache():
@@ -147,8 +145,6 @@ def test_shapefile_transform_cache():
     assert len(FeatureArtist._geom_key_to_geometry_cache) == 0
     assert len(FeatureArtist._geom_key_to_path_cache) == 0
 
-    plt.close()
-
 
 def test_contourf_transform_path_counting():
     fig = plt.figure()
@@ -182,8 +178,6 @@ def test_contourf_transform_path_counting():
     plt.clf()
     gc.collect()
     assert len(cgeoaxes._PATH_TRANSFORM_CACHE) == initial_cache_size
-
-    plt.close()
 
 
 @pytest.mark.filterwarnings("ignore:TileMatrixLimits")

--- a/lib/cartopy/tests/mpl/test_caching.py
+++ b/lib/cartopy/tests/mpl/test_caching.py
@@ -20,7 +20,6 @@ from cartopy.io.ogc_clients import WMTSRasterSource, _OWSLIB_AVAILABLE
 import cartopy.io.shapereader
 import cartopy.mpl.geoaxes as cgeoaxes
 import cartopy.mpl.patch
-from cartopy.tests.mpl import ImageTesting
 
 
 def sample_data(shape=(73, 145)):
@@ -102,10 +101,7 @@ def test_coastline_loading_cache():
     plt.close()
 
 
-# Use an empty ImageTesting decorator to force the switch to
-# the Agg backend (fails on macosx without it)
 @pytest.mark.natural_earth
-@ImageTesting([])
 def test_shapefile_transform_cache():
     # a5caae040ee11e72a62a53100fe5edc355304419 added shapefile mpl
     # geometry caching based on geometry object id. This test ensures

--- a/lib/cartopy/tests/mpl/test_examples.py
+++ b/lib/cartopy/tests/mpl/test_examples.py
@@ -12,26 +12,8 @@ import cartopy.crs as ccrs
 from cartopy.tests.mpl import MPL_VERSION, ImageTesting
 
 
-class ExampleImageTesting(ImageTesting):
-    """Subclasses ImageTesting to nullify the plt.show commands."""
-    def __call__(self, test_func):
-        fn = ImageTesting.__call__(self, test_func)
-
-        def new_fn(*args, **kwargs):
-            try:
-                show = plt.show
-                plt.show = lambda *args, **kwargs: None
-                r = fn(*args, **kwargs)
-            finally:
-                plt.show = show
-            return r
-
-        new_fn.__name__ = fn.__name__
-        return new_fn
-
-
 @pytest.mark.natural_earth
-@ExampleImageTesting(['global_map'])
+@ImageTesting(['global_map'])
 def test_global_map():
     fig = plt.figure(figsize=(10, 5))
     ax = fig.add_subplot(1, 1, 1, projection=ccrs.Robinson())
@@ -49,10 +31,8 @@ def test_global_map():
 
 
 @pytest.mark.natural_earth
-@ExampleImageTesting(['contour_label'],
-                     tolerance=(9.9
-                                if MPL_VERSION < parse_version("3.2")
-                                else 0.5))
+@ImageTesting(['contour_label'],
+              tolerance=(9.9 if MPL_VERSION < parse_version('3.2') else 0.5))
 def test_contour_label():
     from cartopy.tests.mpl.test_caching import sample_data
     fig = plt.figure()

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -346,7 +346,6 @@ def test_gridliner_default_fmtloc(
     plt.figure()
     ax = plt.subplot(111, projection=proj)
     gl = ax.gridlines(crs=gcrs, draw_labels=False, xlocs=xloc, xformatter=xfmt)
-    plt.close()
     assert isinstance(gl.xlocator, xloc_expected)
     assert isinstance(gl.xformatter, xfmt_expected)
 

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -58,57 +58,57 @@ TEST_PROJS = [
 def test_gridliner():
     ny, nx = 2, 4
 
-    plt.figure(figsize=(10, 10))
+    fig = plt.figure(figsize=(10, 10))
 
-    ax = plt.subplot(nx, ny, 1, projection=ccrs.PlateCarree())
+    ax = fig.add_subplot(nx, ny, 1, projection=ccrs.PlateCarree())
     ax.set_global()
     ax.coastlines(resolution="110m")
     ax.gridlines(linestyle=':')
 
-    ax = plt.subplot(nx, ny, 2, projection=ccrs.OSGB(approx=False))
+    ax = fig.add_subplot(nx, ny, 2, projection=ccrs.OSGB(approx=False))
     ax.set_global()
     ax.coastlines(resolution="110m")
     ax.gridlines(linestyle=':')
 
-    ax = plt.subplot(nx, ny, 3, projection=ccrs.OSGB(approx=False))
+    ax = fig.add_subplot(nx, ny, 3, projection=ccrs.OSGB(approx=False))
     ax.set_global()
     ax.coastlines(resolution="110m")
     ax.gridlines(ccrs.PlateCarree(), color='blue', linestyle='-')
     ax.gridlines(ccrs.OSGB(approx=False), linestyle=':')
 
-    ax = plt.subplot(nx, ny, 4, projection=ccrs.PlateCarree())
+    ax = fig.add_subplot(nx, ny, 4, projection=ccrs.PlateCarree())
     ax.set_global()
     ax.coastlines(resolution="110m")
     ax.gridlines(ccrs.NorthPolarStereo(), alpha=0.5,
                  linewidth=1.5, linestyle='-')
 
-    ax = plt.subplot(nx, ny, 5, projection=ccrs.PlateCarree())
+    ax = fig.add_subplot(nx, ny, 5, projection=ccrs.PlateCarree())
     ax.set_global()
     ax.coastlines(resolution="110m")
     osgb = ccrs.OSGB(approx=False)
     ax.set_extent(tuple(osgb.x_limits) + tuple(osgb.y_limits), crs=osgb)
     ax.gridlines(osgb, linestyle=':')
 
-    ax = plt.subplot(nx, ny, 6, projection=ccrs.NorthPolarStereo())
+    ax = fig.add_subplot(nx, ny, 6, projection=ccrs.NorthPolarStereo())
     ax.set_global()
     ax.coastlines(resolution="110m")
     ax.gridlines(alpha=0.5, linewidth=1.5, linestyle='-')
 
-    ax = plt.subplot(nx, ny, 7, projection=ccrs.NorthPolarStereo())
+    ax = fig.add_subplot(nx, ny, 7, projection=ccrs.NorthPolarStereo())
     ax.set_global()
     ax.coastlines(resolution="110m")
     osgb = ccrs.OSGB(approx=False)
     ax.set_extent(tuple(osgb.x_limits) + tuple(osgb.y_limits), crs=osgb)
     ax.gridlines(osgb, linestyle=':')
 
-    ax = plt.subplot(nx, ny, 8,
-                     projection=ccrs.Robinson(central_longitude=135))
+    ax = fig.add_subplot(nx, ny, 8,
+                         projection=ccrs.Robinson(central_longitude=135))
     ax.set_global()
     ax.coastlines(resolution="110m")
     ax.gridlines(ccrs.PlateCarree(), alpha=0.5, linewidth=1.5, linestyle='-')
 
     delta = 1.5e-2
-    plt.subplots_adjust(left=0 + delta, right=1 - delta,
+    fig.subplots_adjust(left=0 + delta, right=1 - delta,
                         top=1 - delta, bottom=0 + delta)
 
 
@@ -164,7 +164,7 @@ def test_grid_labels():
     gl = ax.gridlines(draw_labels=True)
     gl.xlabel_style = gl.ylabel_style = {'size': 9}
 
-    ax = plt.subplot(3, 2, 4, projection=crs_pc)
+    ax = fig.add_subplot(3, 2, 4, projection=crs_pc)
     ax.coastlines(resolution="110m")
     gl = ax.gridlines(
         crs=crs_pc, linewidth=2, color='gray', alpha=0.5, linestyle=':')
@@ -205,7 +205,7 @@ def test_grid_labels():
     gl.xlabel_style = gl.ylabel_style = {'size': 9}
 
     # Increase margins between plots to stop them bumping into one another.
-    plt.subplots_adjust(wspace=0.25, hspace=0.25)
+    fig.subplots_adjust(wspace=0.25, hspace=0.25)
 
 
 @pytest.mark.skipif(geos_version == (3, 9, 0), reason="GEOS intersection bug")
@@ -253,17 +253,17 @@ def test_grid_labels_tight():
 @pytest.mark.natural_earth
 @ImageTesting([grid_label_inline_image], tolerance=grid_label_inline_tol)
 def test_grid_labels_inline():
-    plt.figure(figsize=(35, 35))
+    fig = plt.figure(figsize=(35, 35))
     for i, proj in enumerate(TEST_PROJS, 1):
         if isinstance(proj, tuple):
             proj, kwargs = proj
         else:
             kwargs = {}
-        ax = plt.subplot(7, 4, i, projection=proj(**kwargs))
+        ax = fig.add_subplot(7, 4, i, projection=proj(**kwargs))
         ax.gridlines(draw_labels=True, auto_inline=True)
         ax.coastlines(resolution="110m")
         ax.set_title(proj, y=1.075)
-    plt.subplots_adjust(wspace=0.35, hspace=0.35)
+    fig.subplots_adjust(wspace=0.35, hspace=0.35)
 
 
 @pytest.mark.skipif(geos_version == (3, 9, 0), reason="GEOS intersection bug")
@@ -275,13 +275,13 @@ def test_grid_labels_inline_usa():
     left = -124.7844079  # west long
     right = -66.9513812  # east long
     bottom = 24.7433195  # south lat
-    plt.figure(figsize=(35, 35))
+    fig = plt.figure(figsize=(35, 35))
     for i, proj in enumerate(TEST_PROJS, 1):
         if isinstance(proj, tuple):
             proj, kwargs = proj
         else:
             kwargs = {}
-        ax = plt.subplot(7, 4, i, projection=proj(**kwargs))
+        ax = fig.add_subplot(7, 4, i, projection=proj(**kwargs))
         try:
             ax.set_extent([left, right, bottom, top],
                           crs=ccrs.PlateCarree())
@@ -291,7 +291,7 @@ def test_grid_labels_inline_usa():
         ax.gridlines(draw_labels=True, auto_inline=True, clip_on=True)
         ax.coastlines(resolution="110m")
 
-    plt.subplots_adjust(wspace=0.35, hspace=0.35)
+    fig.subplots_adjust(wspace=0.35, hspace=0.35)
 
 
 @pytest.mark.skipif(geos_version == (3, 9, 0), reason="GEOS intersection bug")
@@ -302,22 +302,20 @@ def test_gridliner_labels_bbox_style():
     right = -66.9513812  # east long
     bottom = 24.7433195  # south lat
 
-    plt.figure(figsize=(6, 3))
-    ax = plt.subplot(1, 1, 1, projection=ccrs.PlateCarree())
+    fig = plt.figure(figsize=(6, 3))
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
     ax.coastlines(resolution="110m")
     ax.set_extent([left, right, bottom, top],
                   crs=ccrs.PlateCarree())
     gl = ax.gridlines(draw_labels=True)
 
-    bbox_style = {
+    gl.labels_bbox_style = {
         "pad": 0,
         "visible": True,
         "facecolor": "white",
         "edgecolor": "black",
         "boxstyle": "round, pad=0.2",
     }
-
-    gl.labels_bbox_style = bbox_style
 
 
 @pytest.mark.parametrize(
@@ -343,8 +341,8 @@ def test_gridliner_labels_bbox_style():
     ])
 def test_gridliner_default_fmtloc(
         proj, gcrs, xloc, xfmt, xloc_expected, xfmt_expected):
-    plt.figure()
-    ax = plt.subplot(111, projection=proj)
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1, projection=proj)
     gl = ax.gridlines(crs=gcrs, draw_labels=False, xlocs=xloc, xformatter=xfmt)
     assert isinstance(gl.xlocator, xloc_expected)
     assert isinstance(gl.xformatter, xfmt_expected)
@@ -352,7 +350,7 @@ def test_gridliner_default_fmtloc(
 
 def test_gridliner_line_limits():
     fig = plt.figure()
-    ax = plt.subplot(1, 1, 1, projection=ccrs.NorthPolarStereo())
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.NorthPolarStereo())
     ax.set_global()
     # Test a single value passed in which represents (-lim, lim)
     xlim, ylim = 125, 75
@@ -413,7 +411,7 @@ def test_gridliner_line_limits():
 def test_gridliner_draw_labels_param(draw_labels, result):
     fig = plt.figure()
     lambert_crs = ccrs.LambertConformal(central_longitude=105)
-    ax = plt.axes(projection=lambert_crs)
+    ax = fig.add_subplot(projection=lambert_crs)
     ax.set_extent([75, 130, 18, 54], crs=ccrs.PlateCarree())
     gl = ax.gridlines(draw_labels=draw_labels, rotate_labels=False, dms=True,
                       x_inline=False, y_inline=False)
@@ -429,7 +427,7 @@ def test_gridliner_draw_labels_param(draw_labels, result):
 
 def test_gridliner_formatter_kwargs():
     fig = plt.figure()
-    ax = plt.subplot(1, 1, 1, projection=ccrs.PlateCarree())
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
     ax.set_extent([-80, -40.0, 10.0, -30.0])
     gl = ax.gridlines(draw_labels=True, dms=False,
                       formatter_kwargs=dict(cardinal_labels={'west': 'O'}))

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -44,8 +44,9 @@ def test_web_tiles():
                                    [extent[0], extent[3]],
                                    [extent[0], extent[1]]])
     map_prj = cimgt.GoogleTiles().crs
+    fig = plt.figure()
 
-    ax = plt.subplot(2, 2, 1, projection=map_prj)
+    ax = fig.add_subplot(2, 2, 1, projection=map_prj)
     gt = cimgt.GoogleTiles()
     gt._image_url = types.MethodType(ctest_tiles.GOOGLE_IMAGE_URL_REPLACEMENT,
                                      gt)
@@ -54,14 +55,14 @@ def test_web_tiles():
               interpolation='bilinear', origin=origin)
     ax.coastlines(color='white')
 
-    ax = plt.subplot(2, 2, 2, projection=map_prj)
+    ax = fig.add_subplot(2, 2, 2, projection=map_prj)
     qt = cimgt.QuadtreeTiles()
     img, extent, origin = qt.image_for_domain(target_domain, 1)
     ax.imshow(np.array(img), extent=extent, transform=qt.crs,
               interpolation='bilinear', origin=origin)
     ax.coastlines(color='white')
 
-    ax = plt.subplot(2, 2, 3, projection=map_prj)
+    ax = fig.add_subplot(2, 2, 3, projection=map_prj)
     osm = cimgt.OSM()
     img, extent, origin = osm.image_for_domain(target_domain, 1)
     ax.imshow(np.array(img), extent=extent, transform=osm.crs,
@@ -94,7 +95,7 @@ def test_image_merge():
     ax = plt.axes(projection=gt.crs)
     ax.set_global()
     ax.coastlines()
-    plt.imshow(img, origin=origin, extent=extent, alpha=0.5)
+    ax.imshow(img, origin=origin, extent=extent, alpha=0.5)
 
 
 @ImageTesting(['imshow_natural_earth_ortho'], tolerance=0.7)

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -145,7 +145,6 @@ def test_imshow_rgba():
     ax.set_extent([-30, -20, 60, 70], crs=latlon_crs)
     img = ax.imshow(z1, extent=[-26, -24, 64, 66], transform=latlon_crs)
     assert sum(img.get_array().data[:, 0, 3]) == 0
-    plt.close()
 
 
 def test_imshow_rgb():
@@ -158,7 +157,6 @@ def test_imshow_rgb():
     ax.set_extent([-30, -20, 60, 70], crs=latlon_crs)
     img = ax.imshow(z, extent=[-26, -24, 64, 66], transform=latlon_crs)
     assert sum(img.get_array().data[:, 0, 3]) == 0
-    plt.close()
 
 
 @ImageTesting(['imshow_natural_earth_ortho'], tolerance=0.7)
@@ -194,9 +192,7 @@ def test_alpha_2d_warp():
     fake_alphas = np.zeros(fake_data.shape)
     image = ax.imshow(fake_data, extent=coords, transform=latlon_crs,
                       alpha=fake_alphas)
-    plt.close()
     image_data = image.get_array()
     image_alpha = image.get_alpha()
 
     assert image_data.shape == image_alpha.shape
-    plt.close()

--- a/lib/cartopy/tests/mpl/test_img_transform.py
+++ b/lib/cartopy/tests/mpl/test_img_transform.py
@@ -106,20 +106,20 @@ def test_regrid_image():
                                 target_proj, target_x, target_y)
 
     # Plot
-    plt.figure(figsize=(10, 10))
+    fig = plt.figure(figsize=(10, 10))
     gs = mpl.gridspec.GridSpec(nrows=4, ncols=1,
                                hspace=1.5, wspace=0.5)
     # Set up axes and title
-    ax = plt.subplot(gs[0], projection=target_proj)
-    plt.imshow(new_array, origin='lower', extent=target_extent)
+    ax = fig.add_subplot(gs[0], projection=target_proj)
+    ax.imshow(new_array, origin='lower', extent=target_extent)
     ax.coastlines()
     # Plot each color slice (tests masking)
     cmaps = {'red': 'Reds', 'green': 'Greens', 'blue': 'Blues'}
     for i, color in enumerate(['red', 'green', 'blue']):
-        ax = plt.subplot(gs[i + 1], projection=target_proj)
-        plt.imshow(new_array[:, :, i], extent=target_extent, origin='lower',
-                   cmap=cmaps[color])
+        ax = fig.add_subplot(gs[i + 1], projection=target_proj)
+        ax.imshow(new_array[:, :, i], extent=target_extent, origin='lower',
+                  cmap=cmaps[color])
         ax.coastlines()
 
     # Tighten up layout
-    gs.tight_layout(plt.gcf())
+    gs.tight_layout(fig)

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -28,7 +28,7 @@ def test_global_contour_wrap_new_transform():
     ax.coastlines()
     x, y = np.meshgrid(np.linspace(0, 360), np.linspace(-90, 90))
     data = np.sin(np.sqrt(x ** 2 + y ** 2))
-    plt.contour(x, y, data, transform=ccrs.PlateCarree())
+    ax.contour(x, y, data, transform=ccrs.PlateCarree())
 
 
 @pytest.mark.natural_earth
@@ -39,7 +39,7 @@ def test_global_contour_wrap_no_transform():
     ax.coastlines()
     x, y = np.meshgrid(np.linspace(0, 360), np.linspace(-90, 90))
     data = np.sin(np.sqrt(x ** 2 + y ** 2))
-    plt.contour(x, y, data)
+    ax.contour(x, y, data)
 
 
 @pytest.mark.natural_earth
@@ -49,7 +49,7 @@ def test_global_contourf_wrap_new_transform():
     ax.coastlines()
     x, y = np.meshgrid(np.linspace(0, 360), np.linspace(-90, 90))
     data = np.sin(np.sqrt(x ** 2 + y ** 2))
-    plt.contourf(x, y, data, transform=ccrs.PlateCarree())
+    ax.contourf(x, y, data, transform=ccrs.PlateCarree())
 
 
 @pytest.mark.natural_earth
@@ -59,7 +59,7 @@ def test_global_contourf_wrap_no_transform():
     ax.coastlines()
     x, y = np.meshgrid(np.linspace(0, 360), np.linspace(-90, 90))
     data = np.sin(np.sqrt(x ** 2 + y ** 2))
-    plt.contourf(x, y, data)
+    ax.contourf(x, y, data)
 
 
 @pytest.mark.natural_earth
@@ -69,7 +69,7 @@ def test_global_pcolor_wrap_new_transform():
     ax.coastlines()
     x, y = np.meshgrid(np.linspace(0, 360), np.linspace(-90, 90))
     data = np.sin(np.sqrt(x ** 2 + y ** 2))[:-1, :-1]
-    plt.pcolor(x, y, data, transform=ccrs.PlateCarree())
+    ax.pcolor(x, y, data, transform=ccrs.PlateCarree())
 
 
 @pytest.mark.natural_earth
@@ -79,7 +79,7 @@ def test_global_pcolor_wrap_no_transform():
     ax.coastlines()
     x, y = np.meshgrid(np.linspace(0, 360), np.linspace(-90, 90))
     data = np.sin(np.sqrt(x ** 2 + y ** 2))[:-1, :-1]
-    plt.pcolor(x, y, data)
+    ax.pcolor(x, y, data)
 
 
 @pytest.mark.natural_earth
@@ -92,7 +92,7 @@ def test_global_scatter_wrap_new_transform():
     ax.coastlines(zorder=0)
     x, y = np.meshgrid(np.linspace(0, 360), np.linspace(-90, 90))
     data = np.sin(np.sqrt(x ** 2 + y ** 2))
-    plt.scatter(x, y, c=data, transform=ccrs.PlateCarree())
+    ax.scatter(x, y, c=data, transform=ccrs.PlateCarree())
 
 
 @pytest.mark.natural_earth
@@ -102,7 +102,7 @@ def test_global_scatter_wrap_no_transform():
     ax.coastlines(zorder=0)
     x, y = np.meshgrid(np.linspace(0, 360), np.linspace(-90, 90))
     data = np.sin(np.sqrt(x ** 2 + y ** 2))
-    plt.scatter(x, y, c=data)
+    ax.scatter(x, y, c=data)
 
 
 @pytest.mark.natural_earth
@@ -113,7 +113,7 @@ def test_global_hexbin_wrap():
     ax.coastlines(zorder=2)
     x, y = np.meshgrid(np.arange(-179, 181), np.arange(-90, 91))
     data = np.sin(np.sqrt(x**2 + y**2))
-    plt.hexbin(
+    ax.hexbin(
         x.flatten(),
         y.flatten(),
         C=data.flatten(),
@@ -132,7 +132,7 @@ def test_global_hexbin_wrap_transform():
     # wrap values so to match x values from test_global_hexbin_wrap
     x_wrap = np.where(x >= 180, x-360, x)
     data = np.sin(np.sqrt(x_wrap**2 + y**2))
-    plt.hexbin(
+    ax.hexbin(
         x.flatten(),
         y.flatten(),
         C=data.flatten(),
@@ -144,25 +144,25 @@ def test_global_hexbin_wrap_transform():
 @ImageTesting(['global_map'],
               tolerance=0.55)
 def test_global_map():
-    plt.axes(projection=ccrs.Robinson())
+    ax = plt.axes(projection=ccrs.Robinson())
 #    ax.coastlines()
 #    ax.gridlines(5)
 
-    plt.plot(-0.08, 51.53, 'o', transform=ccrs.PlateCarree())
+    ax.plot(-0.08, 51.53, 'o', transform=ccrs.PlateCarree())
 
-    plt.plot([-0.08, 132], [51.53, 43.17], color='red',
-             transform=ccrs.PlateCarree())
+    ax.plot([-0.08, 132], [51.53, 43.17], color='red',
+            transform=ccrs.PlateCarree())
 
-    plt.plot([-0.08, 132], [51.53, 43.17], color='blue',
-             transform=ccrs.Geodetic())
+    ax.plot([-0.08, 132], [51.53, 43.17], color='blue',
+            transform=ccrs.Geodetic())
 
 
 @pytest.mark.filterwarnings("ignore:Unable to determine extent")
 @pytest.mark.natural_earth
 @ImageTesting(['simple_global'])
 def test_simple_global():
-    plt.axes(projection=ccrs.PlateCarree())
-    plt.gca().coastlines()
+    ax = plt.axes(projection=ccrs.PlateCarree())
+    ax.coastlines()
     # produces a global map, despite not having needed to set the limits
 
 
@@ -205,11 +205,11 @@ def test_multiple_projections():
 
         ax.coastlines(resolution="110m")
 
-        plt.plot(-0.08, 51.53, 'o', transform=ccrs.PlateCarree())
-        plt.plot([-0.08, 132], [51.53, 43.17], color='red',
-                 transform=ccrs.PlateCarree())
-        plt.plot([-0.08, 132], [51.53, 43.17], color='blue',
-                 transform=prj.as_geodetic())
+        ax.plot(-0.08, 51.53, 'o', transform=ccrs.PlateCarree())
+        ax.plot([-0.08, 132], [51.53, 43.17], color='red',
+                transform=ccrs.PlateCarree())
+        ax.plot([-0.08, 132], [51.53, 43.17], color='blue',
+                transform=prj.as_geodetic())
 
 
 @pytest.mark.natural_earth
@@ -286,16 +286,15 @@ def test_pcolormesh_global_with_wrap1():
     x, y = np.meshgrid(xbnds, ybnds)
     data = np.exp(np.sin(np.deg2rad(x)) + np.cos(np.deg2rad(y)))
     data = data[:-1, :-1]
+    fig = plt.figure()
 
-    ax = plt.subplot(211, projection=ccrs.PlateCarree())
-    plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(),
-                   snap=False)
+    ax = fig.add_subplot(2, 1, 1, projection=ccrs.PlateCarree())
+    ax.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(), snap=False)
     ax.coastlines()
     ax.set_global()  # make sure everything is visible
 
-    ax = plt.subplot(212, projection=ccrs.PlateCarree(180))
-    plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(),
-                   snap=False)
+    ax = fig.add_subplot(2, 1, 2, projection=ccrs.PlateCarree(180))
+    ax.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(), snap=False)
     ax.coastlines()
     ax.set_global()  # make sure everything is visible
 
@@ -309,9 +308,10 @@ def test_pcolormesh_get_array_with_mask():
     x, y = np.meshgrid(xbnds, ybnds)
     data = np.exp(np.sin(np.deg2rad(x)) + np.cos(np.deg2rad(y)))
     data = data[:-1, :-1]
+    fig = plt.figure()
 
-    ax = plt.subplot(211, projection=ccrs.PlateCarree())
-    c = plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree())
+    ax = fig.add_subplot(2, 1, 1, projection=ccrs.PlateCarree())
+    c = ax.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree())
     assert c._wrapped_collection_fix is not None, \
         'No pcolormesh wrapping was done when it should have been.'
 
@@ -330,8 +330,8 @@ def test_pcolormesh_get_array_with_mask():
     data = np.exp(np.sin(np.deg2rad(x)) + np.cos(np.deg2rad(y)))
     data2 = data[:-1, :-1]
 
-    ax = plt.subplot(212, projection=ccrs.PlateCarree())
-    c = plt.pcolormesh(xbnds, ybnds, data2, transform=ccrs.PlateCarree())
+    ax = fig.add_subplot(2, 1, 2, projection=ccrs.PlateCarree())
+    c = ax.pcolormesh(xbnds, ybnds, data2, transform=ccrs.PlateCarree())
     ax.coastlines()
     ax.set_global()  # make sure everything is visible
 
@@ -357,16 +357,15 @@ def test_pcolormesh_global_with_wrap2():
     x, y = np.meshgrid(xbnds, ybnds)
     data = np.exp(np.sin(np.deg2rad(x)) + np.cos(np.deg2rad(y)))
     data = data[:-1, :-1]
+    fig = plt.figure()
 
-    ax = plt.subplot(211, projection=ccrs.PlateCarree())
-    plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(),
-                   snap=False)
+    ax = fig.add_subplot(2, 1, 1, projection=ccrs.PlateCarree())
+    ax.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(), snap=False)
     ax.coastlines()
     ax.set_global()  # make sure everything is visible
 
-    ax = plt.subplot(212, projection=ccrs.PlateCarree(180))
-    plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(),
-                   snap=False)
+    ax = fig.add_subplot(2, 1, 2, projection=ccrs.PlateCarree(180))
+    ax.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(), snap=False)
     ax.coastlines()
     ax.set_global()  # make sure everything is visible
 
@@ -389,25 +388,24 @@ def test_pcolormesh_global_with_wrap3():
 
     data = data[:-1, :-1]
     data = np.ma.masked_greater(data, 2.6)
+    fig = plt.figure()
 
-    ax = plt.subplot(311, projection=ccrs.PlateCarree(-45))
-    c = plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(),
-                       snap=False)
+    ax = fig.add_subplot(3, 1, 1, projection=ccrs.PlateCarree(-45))
+    c = ax.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(),
+                      snap=False)
     assert c._wrapped_collection_fix is not None, \
         'No pcolormesh wrapping was done when it should have been.'
 
     ax.coastlines()
     ax.set_global()  # make sure everything is visible
 
-    ax = plt.subplot(312, projection=ccrs.PlateCarree(-1.87499952))
-    plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(),
-                   snap=False)
+    ax = fig.add_subplot(3, 1, 2, projection=ccrs.PlateCarree(-1.87499952))
+    ax.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(), snap=False)
     ax.coastlines()
     ax.set_global()  # make sure everything is visible
 
-    ax = plt.subplot(313, projection=ccrs.Robinson(-2))
-    plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(),
-                   snap=False)
+    ax = fig.add_subplot(3, 1, 3, projection=ccrs.Robinson(-2))
+    ax.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(), snap=False)
     ax.coastlines()
     ax.set_global()  # make sure everything is visible
 
@@ -435,11 +433,11 @@ def test_pcolormesh_set_array_with_mask():
     bad_data = np.ones(data.shape)
     # Start with the opposite mask and then swap back in the set_array call
     bad_data_mask = np.ma.array(bad_data, mask=~data.mask)
+    fig = plt.figure()
 
-    ax = plt.subplot(311, projection=ccrs.PlateCarree(-45))
-    c = plt.pcolormesh(xbnds, ybnds, bad_data,
-                       norm=norm, transform=ccrs.PlateCarree(),
-                       snap=False)
+    ax = fig.add_subplot(3, 1, 1, projection=ccrs.PlateCarree(-45))
+    c = ax.pcolormesh(xbnds, ybnds, bad_data,
+                      norm=norm, transform=ccrs.PlateCarree(), snap=False)
     c.set_array(data.ravel())
     assert c._wrapped_collection_fix is not None, \
         'No pcolormesh wrapping was done when it should have been.'
@@ -447,17 +445,15 @@ def test_pcolormesh_set_array_with_mask():
     ax.coastlines()
     ax.set_global()  # make sure everything is visible
 
-    ax = plt.subplot(312, projection=ccrs.PlateCarree(-1.87499952))
-    c2 = plt.pcolormesh(xbnds, ybnds, bad_data_mask,
-                        norm=norm, transform=ccrs.PlateCarree(),
-                        snap=False)
+    ax = fig.add_subplot(3, 1, 2, projection=ccrs.PlateCarree(-1.87499952))
+    c2 = ax.pcolormesh(xbnds, ybnds, bad_data_mask,
+                       norm=norm, transform=ccrs.PlateCarree(), snap=False)
     c2.set_array(data.ravel())
     ax.coastlines()
     ax.set_global()  # make sure everything is visible
 
-    ax = plt.subplot(313, projection=ccrs.Robinson(-2))
-    plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(),
-                   snap=False)
+    ax = fig.add_subplot(3, 1, 3, projection=ccrs.Robinson(-2))
+    ax.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(), snap=False)
     ax.coastlines()
     ax.set_global()  # make sure everything is visible
 
@@ -483,25 +479,24 @@ def test_pcolormesh_set_clim_with_mask():
     data = np.ma.masked_greater(data, 2.6)
 
     bad_initial_norm = plt.Normalize(-100, 100)
+    fig = plt.figure()
 
-    ax = plt.subplot(311, projection=ccrs.PlateCarree(-45))
-    c = plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(),
-                       norm=bad_initial_norm, snap=False)
+    ax = fig.add_subplot(3, 1, 1, projection=ccrs.PlateCarree(-45))
+    c = ax.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(),
+                      norm=bad_initial_norm, snap=False)
     assert c._wrapped_collection_fix is not None, \
         'No pcolormesh wrapping was done when it should have been.'
 
     ax.coastlines()
     ax.set_global()  # make sure everything is visible
 
-    ax = plt.subplot(312, projection=ccrs.PlateCarree(-1.87499952))
-    plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(),
-                   snap=False)
+    ax = fig.add_subplot(3, 1, 2, projection=ccrs.PlateCarree(-1.87499952))
+    ax.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(), snap=False)
     ax.coastlines()
     ax.set_global()  # make sure everything is visible
 
-    ax = plt.subplot(313, projection=ccrs.Robinson(-2))
-    plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(),
-                   snap=False)
+    ax = fig.add_subplot(3, 1, 3, projection=ccrs.Robinson(-2))
+    ax.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree(), snap=False)
     ax.coastlines()
     ax.set_global()  # make sure everything is visible
 
@@ -523,31 +518,30 @@ def test_pcolormesh_limited_area_wrap():
 
     rp = ccrs.RotatedPole(pole_longitude=177.5, pole_latitude=37.5)
 
-    plt.figure(figsize=(10, 6))
+    fig = plt.figure(figsize=(10, 6))
 
-    ax = plt.subplot(221, projection=ccrs.PlateCarree())
-    plt.pcolormesh(xbnds, ybnds, data, transform=rp, cmap='Spectral',
-                   snap=False)
+    ax = fig.add_subplot(2, 2, 1, projection=ccrs.PlateCarree())
+    ax.pcolormesh(xbnds, ybnds, data, transform=rp, cmap='Spectral',
+                  snap=False)
     ax.coastlines()
 
-    ax = plt.subplot(222, projection=ccrs.PlateCarree(180))
-    plt.pcolormesh(xbnds, ybnds, data, transform=rp, cmap='Spectral',
-                   snap=False)
+    ax = fig.add_subplot(2, 2, 2, projection=ccrs.PlateCarree(180))
+    ax.pcolormesh(xbnds, ybnds, data, transform=rp, cmap='Spectral',
+                  snap=False)
     ax.coastlines()
     ax.set_global()
 
     # draw the same plot, only more zoomed in, and using the 2d versions
     # of the coordinates (just to test that 1d and 2d are both suitably
     # being fixed)
-    ax = plt.subplot(223, projection=ccrs.PlateCarree())
-    plt.pcolormesh(x, y, data, transform=rp, cmap='Spectral',
-                   snap=False)
+    ax = fig.add_subplot(2, 2, 3, projection=ccrs.PlateCarree())
+    ax.pcolormesh(x, y, data, transform=rp, cmap='Spectral', snap=False)
     ax.coastlines()
     ax.set_extent([-70, 0, 0, 80])
 
-    ax = plt.subplot(224, projection=rp)
-    plt.pcolormesh(xbnds, ybnds, data, transform=rp, cmap='Spectral',
-                   snap=False)
+    ax = fig.add_subplot(2, 2, 4, projection=rp)
+    ax.pcolormesh(xbnds, ybnds, data, transform=rp, cmap='Spectral',
+                  snap=False)
     ax.coastlines()
 
 
@@ -566,12 +560,12 @@ def test_pcolormesh_single_column_wrap():
 
     rp = ccrs.RotatedPole(pole_longitude=177.5, pole_latitude=37.5)
 
-    plt.figure(figsize=(10, 6))
+    fig = plt.figure(figsize=(10, 6))
 
-    ax = plt.subplot(111, projection=ccrs.PlateCarree(180))
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree(180))
     # TODO: Remove snap when updating this image
-    plt.pcolormesh(xbnds, ybnds, data, transform=rp, cmap='Spectral',
-                   snap=False)
+    ax.pcolormesh(xbnds, ybnds, data, transform=rp, cmap='Spectral',
+                  snap=False)
     ax.coastlines()
     ax.set_global()
 
@@ -660,14 +654,14 @@ def test_quiver_plate_carree():
     v = np.cos(2. * np.deg2rad(x2d))
     mag = (u**2 + v**2)**.5
     plot_extent = [-60, 40, 30, 70]
-    plt.figure(figsize=(6, 6))
+    fig = plt.figure(figsize=(6, 6))
     # plot on native projection
-    ax = plt.subplot(211, projection=ccrs.PlateCarree())
+    ax = fig.add_subplot(2, 1, 1, projection=ccrs.PlateCarree())
     ax.set_extent(plot_extent, crs=ccrs.PlateCarree())
     ax.coastlines(resolution="110m")
     ax.quiver(x, y, u, v, mag)
     # plot on a different projection
-    ax = plt.subplot(212, projection=ccrs.NorthPolarStereo())
+    ax = fig.add_subplot(2, 1, 2, projection=ccrs.NorthPolarStereo())
     ax.set_extent(plot_extent, crs=ccrs.PlateCarree())
     ax.coastlines()
     ax.quiver(x, y, u, v, mag, transform=ccrs.PlateCarree())
@@ -686,13 +680,13 @@ def test_quiver_rotated_pole():
     rp = ccrs.RotatedPole(pole_longitude=177.5, pole_latitude=37.5)
     plot_extent = [x[0], x[-1], y[0], y[-1]]
     # plot on native projection
-    plt.figure(figsize=(6, 6))
-    ax = plt.subplot(211, projection=rp)
+    fig = plt.figure(figsize=(6, 6))
+    ax = fig.add_subplot(2, 1, 1, projection=rp)
     ax.set_extent(plot_extent, crs=rp)
     ax.coastlines()
     ax.quiver(x, y, u, v, mag)
     # plot on different projection
-    ax = plt.subplot(212, projection=ccrs.PlateCarree())
+    ax = fig.add_subplot(2, 1, 2, projection=ccrs.PlateCarree())
     ax.set_extent(plot_extent, crs=rp)
     ax.coastlines()
     ax.quiver(x, y, u, v, mag, transform=rp)
@@ -744,14 +738,14 @@ def test_barbs():
     u = 40 * np.cos(np.deg2rad(y2d))
     v = 40 * np.cos(2. * np.deg2rad(x2d))
     plot_extent = [-60, 40, 30, 70]
-    plt.figure(figsize=(6, 6))
+    fig = plt.figure(figsize=(6, 6))
     # plot on native projection
-    ax = plt.subplot(211, projection=ccrs.PlateCarree())
+    ax = fig.add_subplot(2, 1, 1, projection=ccrs.PlateCarree())
     ax.set_extent(plot_extent, crs=ccrs.PlateCarree())
     ax.coastlines(resolution="110m")
     ax.barbs(x, y, u, v, length=4, linewidth=.25)
     # plot on a different projection
-    ax = plt.subplot(212, projection=ccrs.NorthPolarStereo())
+    ax = fig.add_subplot(2, 1, 2, projection=ccrs.NorthPolarStereo())
     ax.set_extent(plot_extent, crs=ccrs.PlateCarree())
     ax.coastlines(resolution="110m")
     ax.barbs(x, y, u, v, transform=ccrs.PlateCarree(), length=4, linewidth=.25)

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -253,8 +253,6 @@ def test_cursor_values():
                      b'\\(22.09[0-9]{4}N, 173.70[0-9]{4}E\\)',
                      r.encode('ascii', 'ignore'))
 
-    plt.close()
-
 
 @pytest.mark.natural_earth
 @ImageTesting(['natural_earth_interface'], tolerance=0.21)

--- a/lib/cartopy/tests/mpl/test_pseudo_color.py
+++ b/lib/cartopy/tests/mpl/test_pseudo_color.py
@@ -46,8 +46,8 @@ def test_savefig_tight():
     data = np.exp(np.sin(np.deg2rad(x)) + np.cos(np.deg2rad(y)))
     data = data[:-1, :-1]
 
-    plt.subplot(211, projection=ccrs.Robinson())
-    plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree())
+    ax = plt.subplot(2, 1, 1, projection=ccrs.Robinson())
+    ax.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree())
     buf = io.BytesIO()
     plt.savefig(buf, format='png', bbox_inches='tight')
 
@@ -63,7 +63,7 @@ def test_pcolormesh_arg_interpolation():
     # Z with the same shape as X/Y to force the interpolation
     z = np.zeros(xs.shape)
 
-    ax = plt.subplot(211, projection=ccrs.PlateCarree())
+    ax = plt.subplot(2, 1, 1, projection=ccrs.PlateCarree())
     coll = ax.pcolormesh(xs, ys, z, shading='auto',
                          transform=ccrs.PlateCarree())
 

--- a/lib/cartopy/tests/mpl/test_pseudo_color.py
+++ b/lib/cartopy/tests/mpl/test_pseudo_color.py
@@ -23,7 +23,6 @@ def test_pcolormesh_partially_masked():
         ax.pcolormesh(np.linspace(0, 360, 30), np.linspace(-90, 90, 40), data)
         assert pcolor.call_count == 1, ("pcolor should have been called "
                                         "exactly once.")
-        plt.close()
 
 
 def test_pcolormesh_invisible():
@@ -36,7 +35,6 @@ def test_pcolormesh_invisible():
                       transform=ccrs.PlateCarree())
         assert pcolor.call_count == 0, ("pcolor shouldn't have been called, "
                                         "but was.")
-        plt.close()
 
 
 def test_savefig_tight():
@@ -52,7 +50,6 @@ def test_savefig_tight():
     plt.pcolormesh(xbnds, ybnds, data, transform=ccrs.PlateCarree())
     buf = io.BytesIO()
     plt.savefig(buf, format='png', bbox_inches='tight')
-    plt.close()
 
 
 def test_pcolormesh_arg_interpolation():

--- a/lib/cartopy/tests/mpl/test_set_extent.py
+++ b/lib/cartopy/tests/mpl/test_set_extent.py
@@ -104,13 +104,13 @@ def test_limits_contour():
 
     ax = plt.axes(projection=ccrs.PlateCarree())
     ax.coastlines()
-    plt.contourf(xs, ys, data, transform=ccrs.PlateCarree(180))
+    ax.contourf(xs, ys, data, transform=ccrs.PlateCarree(180))
     assert_array_almost_equal(ax.dataLim, resulting_extent)
 
     plt.figure()
     ax = plt.axes(projection=ccrs.PlateCarree())
     ax.coastlines()
-    plt.contour(xs, ys, data, transform=ccrs.PlateCarree(180))
+    ax.contour(xs, ys, data, transform=ccrs.PlateCarree(180))
     assert_array_almost_equal(ax.dataLim, resulting_extent)
 
 
@@ -122,13 +122,13 @@ def test_limits_pcolor():
 
     ax = plt.axes(projection=ccrs.PlateCarree())
     ax.coastlines()
-    plt.pcolor(xs, ys, data, transform=ccrs.PlateCarree(180))
+    ax.pcolor(xs, ys, data, transform=ccrs.PlateCarree(180))
     assert_array_almost_equal(ax.dataLim, resulting_extent)
 
     plt.figure()
     ax = plt.axes(projection=ccrs.PlateCarree())
     ax.coastlines()
-    plt.pcolormesh(xs, ys, data, transform=ccrs.PlateCarree(180))
+    ax.pcolormesh(xs, ys, data, transform=ccrs.PlateCarree(180))
     assert_array_almost_equal(ax.dataLim, resulting_extent)
 
 
@@ -137,7 +137,7 @@ def test_view_lim_autoscaling():
     y = np.linspace(0.03739792, 0.33029076)
     x, y = np.meshgrid(x, y)
     ax = plt.axes(projection=ccrs.RotatedPole(37.5, 357.5))
-    plt.scatter(x, y, x * y, transform=ccrs.PlateCarree())
+    ax.scatter(x, y, x * y, transform=ccrs.PlateCarree())
 
     expected = np.array([[86.12433701, 52.51570463],
                          [86.69696603, 52.86372057]])

--- a/lib/cartopy/tests/mpl/test_set_extent.py
+++ b/lib/cartopy/tests/mpl/test_set_extent.py
@@ -94,7 +94,6 @@ def test_update_lim():
     ax.update_datalim([(-10, -10), (-5, -5)])
     assert_array_almost_equal(ax.dataLim.get_points(),
                               np.array([[-10., -10.], [-5., -5.]]))
-    plt.close()
 
 
 def test_limits_contour():
@@ -107,13 +106,12 @@ def test_limits_contour():
     ax.coastlines()
     plt.contourf(xs, ys, data, transform=ccrs.PlateCarree(180))
     assert_array_almost_equal(ax.dataLim, resulting_extent)
-    plt.close()
 
+    plt.figure()
     ax = plt.axes(projection=ccrs.PlateCarree())
     ax.coastlines()
     plt.contour(xs, ys, data, transform=ccrs.PlateCarree(180))
     assert_array_almost_equal(ax.dataLim, resulting_extent)
-    plt.close()
 
 
 def test_limits_pcolor():
@@ -126,13 +124,12 @@ def test_limits_pcolor():
     ax.coastlines()
     plt.pcolor(xs, ys, data, transform=ccrs.PlateCarree(180))
     assert_array_almost_equal(ax.dataLim, resulting_extent)
-    plt.close()
 
+    plt.figure()
     ax = plt.axes(projection=ccrs.PlateCarree())
     ax.coastlines()
     plt.pcolormesh(xs, ys, data, transform=ccrs.PlateCarree(180))
     assert_array_almost_equal(ax.dataLim, resulting_extent)
-    plt.close()
 
 
 def test_view_lim_autoscaling():
@@ -154,7 +151,6 @@ def test_view_lim_autoscaling():
     expected_non_tight = np.array([[86, 52.45], [86.8, 52.9]])
     assert_array_almost_equal(ax.viewLim.frozen().get_points(),
                               expected_non_tight, decimal=1)
-    plt.close()
 
 
 def test_view_lim_default_global(tmp_path):
@@ -166,4 +162,3 @@ def test_view_lim_default_global(tmp_path):
     expected = np.array([[-180, -90], [180, 90]])
     assert_array_almost_equal(ax.viewLim.frozen().get_points(),
                               expected)
-    plt.close()

--- a/lib/cartopy/tests/mpl/test_shapely_to_mpl.py
+++ b/lib/cartopy/tests/mpl/test_shapely_to_mpl.py
@@ -23,8 +23,9 @@ from cartopy.tests.mpl import ImageTesting
 @pytest.mark.natural_earth
 @ImageTesting(['poly_interiors'], tolerance=3.1)
 def test_polygon_interiors():
+    fig = plt.figure()
 
-    ax = plt.subplot(211, projection=ccrs.PlateCarree())
+    ax = fig.add_subplot(2, 1, 1, projection=ccrs.PlateCarree())
     ax.coastlines()
     ax.set_global()
 
@@ -54,8 +55,8 @@ def test_polygon_interiors():
     ax.add_collection(collection)
 
     # test multiple interior polygons
-    ax = plt.subplot(212, projection=ccrs.PlateCarree(),
-                     xlim=[-5, 15], ylim=[-5, 15])
+    ax = fig.add_subplot(2, 1, 2, projection=ccrs.PlateCarree(),
+                         xlim=[-5, 15], ylim=[-5, 15])
     ax.coastlines(resolution="110m")
 
     exterior = np.array(sgeom.box(0, 0, 12, 12).exterior.coords)
@@ -81,16 +82,16 @@ def test_contour_interiors():
     lons, lats = np.meshgrid(np.linspace(-50, 50, nx),
                              np.linspace(-45, 45, ny))
     data = np.sin(np.sqrt(lons ** 2 + lats ** 2))
+    fig = plt.figure()
 
-    ax = plt.subplot(221, projection=ccrs.PlateCarree())
+    ax = fig.add_subplot(2, 2, 1, projection=ccrs.PlateCarree())
     ax.set_global()
-    plt.contourf(lons, lats, data, numlev, transform=ccrs.PlateCarree())
+    ax.contourf(lons, lats, data, numlev, transform=ccrs.PlateCarree())
     ax.coastlines()
 
-    plt.subplot(222, projection=ccrs.Robinson())
-    ax = plt.gca()
+    ax = fig.add_subplot(2, 2, 2, projection=ccrs.Robinson())
     ax.set_global()
-    plt.contourf(lons, lats, data, numlev, transform=ccrs.PlateCarree())
+    ax.contourf(lons, lats, data, numlev, transform=ccrs.PlateCarree())
     ax.coastlines()
 
     # produces singular polygons (zero area polygons)
@@ -102,13 +103,12 @@ def test_contour_interiors():
     lats = np.arange(dim) + 30
     lons = np.arange(dim) - 20
 
-    ax = plt.subplot(223, projection=ccrs.PlateCarree())
+    ax = fig.add_subplot(2, 2, 3, projection=ccrs.PlateCarree())
     ax.set_global()
-    plt.contourf(lons, lats, data, numlev, transform=ccrs.PlateCarree())
+    ax.contourf(lons, lats, data, numlev, transform=ccrs.PlateCarree())
     ax.coastlines()
 
-    plt.subplot(224, projection=ccrs.Robinson())
-    ax = plt.gca()
+    ax = fig.add_subplot(2, 2, 4, projection=ccrs.Robinson())
     ax.set_global()
-    plt.contourf(lons, lats, data, numlev, transform=ccrs.PlateCarree())
+    ax.contourf(lons, lats, data, numlev, transform=ccrs.PlateCarree())
     ax.coastlines()

--- a/lib/cartopy/tests/mpl/test_ticker.py
+++ b/lib/cartopy/tests/mpl/test_ticker.py
@@ -259,7 +259,6 @@ def test_lonlatformatter_non_geoaxes(cls, letter):
     fig.canvas.draw()
     ticklabels = [t.get_text() for t in ax.get_xticklabels()]
     assert ticklabels == [f'{v:g}{letter}' for v in ticks]
-    plt.close()
 
 
 @pytest.mark.parametrize("cls,vmin,vmax,expected",

--- a/lib/cartopy/tests/mpl/test_ticker.py
+++ b/lib/cartopy/tests/mpl/test_ticker.py
@@ -252,7 +252,7 @@ def test_LatitudeFormatter_minutes_seconds(test_ticks, expected):
 def test_lonlatformatter_non_geoaxes(cls, letter):
     ticks = [2, 2.5]
     fig = plt.figure()
-    ax = plt.subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.plot([0, 10], [0, 1])
     ax.set_xticks(ticks)
     ax.xaxis.set_major_formatter(cls(degree_symbol='', dms=False))

--- a/lib/cartopy/tests/mpl/test_ticks.py
+++ b/lib/cartopy/tests/mpl/test_ticks.py
@@ -37,7 +37,6 @@ def test_set_xticks_non_cylindrical():
         ax.set_xticks([-180, -90, 0, 90, 180], crs=ccrs.Geodetic())
     with pytest.raises(RuntimeError):
         ax.set_xticks([-135, -45, 45, 135], minor=True, crs=ccrs.Geodetic())
-    plt.close()
 
 
 @pytest.mark.natural_earth
@@ -68,7 +67,6 @@ def test_set_yticks_non_cylindrical():
     with pytest.raises(RuntimeError):
         ax.set_yticks([-75, -45, -15, 15, 45, 75], minor=True,
                       crs=ccrs.Geodetic())
-    plt.close()
 
 
 @pytest.mark.natural_earth

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -322,6 +322,7 @@ def test_cache(cache_dir, tmp_path):
 
     # Fetch tiles and save them in the cache
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
         gt = cimgt.GoogleTiles(cache=tmpdir_str)
     gt._image_url = types.MethodType(GOOGLE_IMAGE_URL_REPLACEMENT, gt)
 


### PR DESCRIPTION
See commits for details:
* Remove unnecessary `ImageTesting` usage
* Remove unnecessary `plt.close` in tests
* Reduce `plt` usage in tests
* Remove `ExampleImageTesting`
* Use `pytest.warns` in tests
* Parametrize ticker tests more
* Replace CallCounter by mock patching
* Report all test result types on CI 