### PR TITLE
DOC: Adding an environment file for development

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -52,6 +52,19 @@ other package managers such as apt-get (Linux) and brew (macOS). Many of these
 dependencies are built as part of Cartopy's conda distribution, and the recipes
 for these packages can be found at https://github.com/conda-forge/feedstocks.
 
+We include a conda environment file that contains a list of all the
+dependencies required to build and install cartopy, which can be used to
+install pre-built binaries of all the dependencies on your local system.
+To use it::
+
+    git clone https://github.com/SciTools/cartopy.git
+    cd cartopy
+    conda env create -f environment.yml
+    conda activate cartopy-dev
+    pip install -e .
+
+You can also use your system's package manager to install the dependencies.
+
 For macOS, the required dependencies can be installed in the following way::
 
     brew install proj geos

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,43 @@
+# To set up a development environment using conda, run:
+#
+#   conda env create -f environment.yml
+#   conda activate cartopy-dev
+#   pip install -e .
+#
+name: cartopy-dev
+channels:
+  - conda-forge
+dependencies:
+  - cython>=0.28.5
+  - numpy>=1.18
+  - shapely>=1.6.4
+  - geos>=3.7.2
+  - pyshp>=2.1
+  - pyproj>=3.0.0
+  # PROJ is still required for now
+  - proj>=8
+  # The testing label has the proper version of freetype included
+  - conda-forge/label/testing::matplotlib-base>=3.1
+
+  # OWS
+  - owslib>=0.18.0
+  - pillow>=6.1.0
+  # Plotting
+  - gdal>=2.3.2
+  - scipy>=1.3.1
+  # Testing
+  - flufl.lock
+  - packaging>=20
+  - pytest
+  - pytest-xdist
+  # Documentation
+  - beautifulsoup4
+  - pydata-sphinx-theme
+  - sphinx
+  - sphinx-gallery
+  # Extras
+  - flake8
+  - pykdtree
+  - requests
+  - setuptools_scm
+  - setuptools_scm_git_archive


### PR DESCRIPTION
This adds a conda environment file with all of the required dependencies to build Cartopy from source, test it, and build the documentation.

Hopefully makes it easier for people to contribute to Cartopy.