### PR TITLE
added missing shapefile group to download script

### DIFF
--- a/tools/cartopy_feature_download.py
+++ b/tools/cartopy_feature_download.py
@@ -63,7 +63,8 @@ FEATURE_DEFN_GROUPS = {
         ('cultural', 'admin_0_tiny_countries', '110m'),
         ('cultural', 'admin_0_pacific_groupings', '110m'),
         ('cultural', 'admin_1_states_provinces', '110m'),
-        ('cultural', 'admin_1_states_provinces_lines', '110m'),
+        ('cultural', 'admin_1_states_provinces_lines', '110m').
+        ('cultural', 'admin_1_states_provinces_lakes', '110m'),
         ('cultural', 'admin_1_states_provinces_lakes', '50m'),
     ),
 }

--- a/tools/cartopy_feature_download.py
+++ b/tools/cartopy_feature_download.py
@@ -64,8 +64,7 @@ FEATURE_DEFN_GROUPS = {
         ('cultural', 'admin_0_pacific_groupings', '110m'),
         ('cultural', 'admin_1_states_provinces', '110m'),
         ('cultural', 'admin_1_states_provinces_lines', '110m'),
-        ('cultural', 'admin_1_states_provinces_lakes', '110m'),
-        ('cultural', 'admin_1_states_provinces_lakes', '50m'),
+        ('cultural', 'admin_1_states_provinces_lakes', ALL_SCALES),
     ),
 }
 

--- a/tools/cartopy_feature_download.py
+++ b/tools/cartopy_feature_download.py
@@ -63,7 +63,7 @@ FEATURE_DEFN_GROUPS = {
         ('cultural', 'admin_0_tiny_countries', '110m'),
         ('cultural', 'admin_0_pacific_groupings', '110m'),
         ('cultural', 'admin_1_states_provinces', '110m'),
-        ('cultural', 'admin_1_states_provinces_lines', '110m').
+        ('cultural', 'admin_1_states_provinces_lines', '110m'),
         ('cultural', 'admin_1_states_provinces_lakes', '110m'),
         ('cultural', 'admin_1_states_provinces_lakes', '50m'),
     ),

--- a/tools/cartopy_feature_download.py
+++ b/tools/cartopy_feature_download.py
@@ -64,6 +64,7 @@ FEATURE_DEFN_GROUPS = {
         ('cultural', 'admin_0_pacific_groupings', '110m'),
         ('cultural', 'admin_1_states_provinces', '110m'),
         ('cultural', 'admin_1_states_provinces_lines', '110m'),
+        ('cultural', 'admin_1_states_provinces_lakes', '50m'),
     ),
 }
 


### PR DESCRIPTION
## Rationale

Using cartopy.features.STATES with matplotlib causes an error because the shapefile group that is used is not available. Adding these missing groups to the download script will allow it to be used to obtain the files needed to run.

The group that is used to draw state/province boundaries is admin_1_states_provinces_lakes:

https://github.com/SciTools/cartopy/blob/859f15b4d7fc641e5c94a219729635a4195c4430/lib/cartopy/feature/__init__.py#L482-L484

The files are available in the new location on the web:

https://naturalearth.s3.amazonaws.com/50m_cultural/ne_50m_admin_1_states_provinces_lakes.zip
https://naturalearth.s3.amazonaws.com/110m_cultural/ne_110m_admin_1_states_provinces_lakes.zip


## Implications

Additional files will be downloaded when a user runs the script specifying the 'cultural-extra' group. However, these files are very small.

I tested the changes by obtaining the script from my branch and running it, then rerunning the use case that was failing. I confirmed that the use case now runs without error.
