### PR TITLE
FIX: Change PlateCarree vector handling

### DIFF
--- a/lib/cartopy/tests/test_vector_transform.py
+++ b/lib/cartopy/tests/test_vector_transform.py
@@ -144,11 +144,11 @@ class Test_vector_scalar_to_grid:
                                     [7.5, 7.5, 7.5, 7.5, 7.5],
                                     [10., 10., 10., 10., 10]])
         expected_u_grid = np.array([[np.nan, np.nan, np.nan, np.nan, np.nan],
-                                    [np.nan, 2.3838, 3.5025, 2.6152, np.nan],
-                                    [2, 3.0043, 4, 2.9022, 2]])
+                                    [np.nan, 2.3893, 3.5097, 2.6194, np.nan],
+                                    [2, 3.0005, 4, 2.8977, 2]])
         expected_v_grid = np.array([[np.nan, np.nan, np.nan, np.nan, np.nan],
-                                    [np.nan, 2.6527, 2.1904, 2.4192, np.nan],
-                                    [5.5, 4.6483, 4, 4.47, 5.5]])
+                                    [np.nan, 2.6486, 2.1878, 2.4138, np.nan],
+                                    [5.5, 4.6497, 4, 4.4702, 5.5]])
 
         x_grid, y_grid, u_grid, v_grid = vec_trans.vector_scalar_to_grid(
             src_crs, target_crs, (5, 3), x_nps, y_nps, u_nps, v_nps)


### PR DESCRIPTION
If a PlateCarree projection is used for transforming vectors, users likely have their data in longitude/latitude for the locations and the measurement of the field is in North/South. To handle this situation with PlateCarree requires an additional scaling by the latitude of the point. This also requires some additional care for handling points near the pole when applying this scaling.

I haven't updated the image tests yet, as I thought it might be easiest to leave them failing for now so people can download the diff and see what they look like. Overall, I think this is an improvement, but it comes at the cost of special-casing the PlateCarree transform. We could also add a keyword argument 'latlon=True', or something similar to keep this as an opt-in and not change any of the old behavior.

closes #1179