### PR TITLE
FIX: Remove edgecolor from filled features

### DIFF
--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -493,19 +493,19 @@ COASTLINE = NaturalEarthFeature(
 
 LAKES = NaturalEarthFeature(
     'physical', 'lakes', auto_scaler,
-    edgecolor='face', facecolor=COLORS['water'])
+    edgecolor='none', facecolor=COLORS['water'])
 """Automatically scaled natural and artificial lakes."""
 
 
 LAND = NaturalEarthFeature(
     'physical', 'land', auto_scaler,
-    edgecolor='face', facecolor=COLORS['land'], zorder=-1)
+    edgecolor='none', facecolor=COLORS['land'], zorder=-1)
 """Automatically scaled land polygons, including major islands."""
 
 
 OCEAN = NaturalEarthFeature(
     'physical', 'ocean', auto_scaler,
-    edgecolor='face', facecolor=COLORS['water'], zorder=-1)
+    edgecolor='none', facecolor=COLORS['water'], zorder=-1)
 """Automatically scaled ocean polygons."""
 
 

--- a/lib/cartopy/tests/mpl/test_features.py
+++ b/lib/cartopy/tests/mpl/test_features.py
@@ -17,11 +17,16 @@ from cartopy.io.ogc_clients import _OWSLIB_AVAILABLE
 @pytest.mark.mpl_image_compare(filename='natural_earth.png')
 def test_natural_earth():
     ax = plt.axes(projection=ccrs.PlateCarree())
-    ax.add_feature(cfeature.LAND)
-    ax.add_feature(cfeature.OCEAN)
+    # NOTE: edgecolor is set to face for backwards compatibility with the
+    #       the original image. If updating this test remove edgecolors for
+    #       the filled features below (LAND, OCEAN, LAKES).
+    ec = 'face'
+    ax.add_feature(cfeature.LAND, edgecolor=ec)
+    # To match with the old default style and not update an image
+    ax.add_feature(cfeature.OCEAN, edgecolor=ec)
     ax.coastlines()
     ax.add_feature(cfeature.BORDERS, linestyle=':')
-    ax.add_feature(cfeature.LAKES, alpha=0.5)
+    ax.add_feature(cfeature.LAKES, alpha=0.5, edgecolor=ec)
     ax.add_feature(cfeature.RIVERS)
     ax.set_xlim((-20, 60))
     ax.set_ylim((-40, 40))


### PR DESCRIPTION
Filled features only need a facecolor and the edgecolor can be set to none, which produces crisper features in the output. This can be over-ridden by users still.

closes #1922