### PR TITLE
TST: Update test tolerances for MPL 3.5

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Latest packages
         if: steps.minimum-packages.conclusion == 'skipped'
         run: |
-          echo "PACKAGES=cython fiona matplotlib-base numpy pyproj pykdtree scipy shapely" >> $GITHUB_ENV
+          echo "PACKAGES=cython fiona matplotlib-base numpy pyproj 'proj>=8' pykdtree scipy shapely" >> $GITHUB_ENV
 
       - name: Coverage packages
         id: coverage
@@ -71,6 +71,7 @@ jobs:
           python tools/cartopy_feature_download.py gshhs physical --dry-run
           CARTOPY_GIT_DIR=$PWD
           PYPROJ_GLOBAL_CONTEXT=ON pytest -ra -n 4 --doctest-modules \
+              --color=yes \
               --mpl --mpl-generate-summary=html \
               --mpl-results-path="cartopy_test_output-${{ matrix.os }}-${{ matrix.python-version }}" \
               --pyargs cartopy ${EXTRA_TEST_ARGS}

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
+    if: github.repository == 'scitools/cartopy'
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -224,7 +224,8 @@ def test_multiple_projections():
 
 
 @pytest.mark.natural_earth
-@pytest.mark.mpl_image_compare(filename='multiple_projections520.png')
+@pytest.mark.mpl_image_compare(filename='multiple_projections520.png',
+                               tolerance=0.641)
 def test_multiple_projections_520():
     # Test projections added in Proj 5.2.0.
 
@@ -370,7 +371,7 @@ def test_pcolormesh_global_with_wrap2():
 
 @pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(filename='pcolormesh_global_wrap3.png',
-                               tolerance=1.39)
+                               tolerance=1.42)
 def test_pcolormesh_global_with_wrap3():
     nx, ny = 33, 17
     xbnds = np.linspace(-1.875, 358.125, nx, endpoint=True)
@@ -413,7 +414,7 @@ def test_pcolormesh_global_with_wrap3():
 
 @pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(filename='pcolormesh_global_wrap3.png',
-                               tolerance=1.39)
+                               tolerance=1.42)
 def test_pcolormesh_set_array_with_mask():
     """Testing that set_array works with masked arrays properly."""
     nx, ny = 33, 17
@@ -464,7 +465,7 @@ def test_pcolormesh_set_array_with_mask():
 
 @pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(filename='pcolormesh_global_wrap3.png',
-                               tolerance=1.39)
+                               tolerance=1.42)
 def test_pcolormesh_set_clim_with_mask():
     """Testing that set_clim works with masked arrays properly."""
     nx, ny = 33, 17

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -18,7 +18,7 @@ from cartopy.tests.mpl import MPL_VERSION
 
 @pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(filename='global_contour_wrap.png',
-                               style='mpl20')
+                               style='mpl20', tolerance=2.25)
 def test_global_contour_wrap_new_transform():
     ax = plt.axes(projection=ccrs.PlateCarree())
     ax.coastlines()
@@ -30,7 +30,7 @@ def test_global_contour_wrap_new_transform():
 
 @pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(filename='global_contour_wrap.png',
-                               style='mpl20')
+                               style='mpl20', tolerance=2.25)
 def test_global_contour_wrap_no_transform():
     ax = plt.axes(projection=ccrs.PlateCarree())
     ax.coastlines()


### PR DESCRIPTION
Matplotlib 3.5 caused some images to change slightly, so increase the tolerances on those tests since they were minor.

* The three pcolormesh tests are all using the same image and looks to be very minor with a new tolerance update acceptable.

* The `multiple_projections_520` test appears to have had the entire axes stretched up (or down, I can't tell which image is which here) ever so slightly. So, the boundaries and line all are shifted a pixel or two in the new result image. A tolerance increase is probably acceptable again.

* The contours is a little more troubling. It looks like the contours now follow the boundary to close on each other and get smeared on the far right edge, whereas that wasn't the case before. @QuLogic, I know you had to update some of the contour open/closed paths on the Matplotlib side, so perhaps you have some insight on this one.
![contour-result](https://user-images.githubusercontent.com/12417828/142071812-0d5fd13f-e07d-420d-80a2-d4a4b0e176d6.png)