### PR TITLE
Significantly improve tight layout performance in presence of cartopy axes

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -21,6 +21,7 @@ import weakref
 import matplotlib as mpl
 import matplotlib.artist
 import matplotlib.axes
+import matplotlib.axis
 import matplotlib.contour
 from matplotlib.image import imread
 import matplotlib.transforms as mtransforms
@@ -489,6 +490,23 @@ class GeoAxes(matplotlib.axes.Axes):
         self.apply_aspect()
         for gl in self._gridliners:
             gl._draw_gridliner(renderer=renderer)
+
+    def get_default_bbox_extra_artists(self):
+        """
+        Return a default list of artists that are used for the bounding box
+        calculation. Artists are excluded by not being visible, by being clipped
+        by the axes patch path, or by ``artist.set_in_layout(False)``.
+        """
+        artists_keep = (
+            matplotlib.axes.Axes, matplotlib.axis.Axis, matplotlib.spines.Spine
+        )
+        artists = [
+            artist for artist in super().get_default_bbox_extra_artists()
+            if isinstance(artist, artists_keep)
+            or not isinstance(artist.get_clip_path(), mtransforms.TransformedPatchPath)
+            or artist.get_clip_path()._patch is not self.patch
+        ]
+        return artists
 
     def get_tightbbox(self, renderer, *args, **kwargs):
         """

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -494,16 +494,17 @@ class GeoAxes(matplotlib.axes.Axes):
     def get_default_bbox_extra_artists(self):
         """
         Return a default list of artists that are used for the bounding box
-        calculation. Artists are excluded by not being visible, by being clipped
-        by the axes patch path, or by ``artist.set_in_layout(False)``.
+        calculation. Artists are excluded by not being visible, by being
+        clipped by the axes patch path, or by ``artist.set_in_layout(False)``.
         """
         artists_keep = (
             matplotlib.axes.Axes, matplotlib.axis.Axis, matplotlib.spines.Spine
         )
+        transform = mtransforms.TransformedPatchPath
         artists = [
             artist for artist in super().get_default_bbox_extra_artists()
             if isinstance(artist, artists_keep)
-            or not isinstance(artist.get_clip_path(), mtransforms.TransformedPatchPath)
+            or not isinstance(artist.get_clip_path(), transform)
             or artist.get_clip_path()._patch is not self.patch
         ]
         return artists


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

This was a surprising discovery....

Matplotlib's `get_tightbbox()` automatically skips artists that are clipped by the subplot edge to speed things up. Without [these lines](https://github.com/matplotlib/matplotlib/blob/9765379ce6e7343070e815afc0988874041b98e2/lib/matplotlib/axes/_base.py#L4646-L4657), in the presence of lots of plotted content, every single draw will take about twice as long (a pre-draw to get the bounding box extents, and then the actual draw to render the figure).

Apparently, those `get_tightbbox()` lines do not remove clipped cartopy artists. That means that cartopy quad meshes, contour sets, etc. are needlessly slowing down the tight layout algorithm.

The problem is that cartopy artists are only clipped with `clip_path`, not `clip_box` (used by the [`_get_clipped_bbox`](https://github.com/matplotlib/matplotlib/blob/fc4f0ccb831596ff57cc43ea3c38da0d922a4c77/lib/matplotlib/artist.py#L323-L338) method to bypass artists in `get_tightbbox`). I presume cartopy does not set `clip_box` because the subplot bounds are usually "curved" rather than rectangluar boxes.

I implemented a solution in lukelbd/proplot#306 (copying here) that additionally skips artists whose `clip_path` is a `TransformedPatchPath` derived from the axes patch (i.e. artists clipped by the map edge, as is the default behavior). It also bypasses this check for the three objects that matplotlib (evidently) *intends* to ignore by removing `clip_box`: children axes, x and y axis objects, and spine objects. I also verified that this block is removing the artists I think it is (try adding `print(set(super().get_default_bbox_extra_artists() - set(artists))` before the return statement).

Note this could also be accomplished by directly comparing the path coordinates... but that could be very labor-intensive, and this solution is valid all the way back to [matplotlib 2.1](https://github.com/matplotlib/matplotlib/commit/8357131482fcdfff307a9846128ebbb5e9df7c03) when `TransformedPatchPath` was first added.

This speedup from this PR is very gratifying. Looking forward to your thoughts. Since this seemed fairly cartopy-specific, I've submitted here, but let me know if I should submit to matplotlib instead.


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

Faster plots and happier scientists.

## Tests

Some sample code:

```python
import numpy as np
import matplotlib.pyplot as plt
import cartopy.crs as ccrs
fig, ax = plt.subplots(subplot_kw={'projection': ccrs.Robinson()})
N = 5000  # large dataset
lon = np.linspace(-180, 180, N)
lat = np.linspace(-90, 90, N)
data = np.random.rand(N, N)
m = ax.pcolormesh(lon, lat, data, transform=ccrs.PlateCarree())
print(m.get_clip_box() is None)  # returns True
%timeit fig.tight_layout()
```

Performance before:

```
638 ms ± 67.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Performance after:

```
2.37 ms ± 60.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

And of course the performance difference is larger the larger the dataset.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
