### PR TITLE
CI: Fix min dependency build by switching to Linux

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -25,13 +25,12 @@ jobs:
           channels: conda-forge/label/testing,conda-forge
 
       - name: Minimum packages
-        # Only run on macos for now
+        # Only run on Linux for now
         # Conda's linux packages don't grab the testing label of matplotlib causing failures due to freetype differences
-        if: matrix.python-version == '3.7' && matrix.os == 'macos-latest'
+        if: matrix.python-version == '3.7' && matrix.os == 'ubuntu-latest'
         id: minimum-packages
         run: |
           echo "PACKAGES=cython=0.28.5 matplotlib=3.1 numpy=1.18 owslib=0.17 pyproj=3.0 proj=8.0 scipy=1.2.0 shapely=1.6.4" >> $GITHUB_ENV
-          echo "CFLAGS=-stdlib=libc++" >> $GITHUB_ENV
 
       - name: Latest packages
         if: steps.minimum-packages.conclusion == 'skipped'


### PR DESCRIPTION
There is some conda-forge issue with Shapely/geos so switch over to Linux for the min dependency tests. This will fix the macos 3.7 min version failures. Note this will still have failures that will be fixed by #1962.

I tried removing DYLD fallback library path and a few other things that didn't work, so this is the simplest solution for our test suite.

xref: 
https://github.com/shapely/shapely/issues/394
https://github.com/conda-forge/shapely-feedstock/issues/53

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
