### PR TITLE
Rename master branch to main

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -28,7 +28,7 @@ installed using the pip installer::
 
     pip install cartopy
 
-To instead install the most recent version found on the GitHub master branch,
+To instead install the most recent version found on the GitHub main branch,
 use::
 
     pip install git+https://github.com/SciTools/cartopy.git

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@
 <a href="https://github.com/SciTools/cartopy/releases">
 <img src="https://img.shields.io/github/tag/SciTools/cartopy.svg"
  alt="Latest version" /></a>
-<a href="https://github.com/SciTools/cartopy/commits/master">
+<a href="https://github.com/SciTools/cartopy/commits/main">
 <img src="https://img.shields.io/github/commits-since/SciTools/cartopy/latest.svg"
  alt="Commits since last release" /></a>
 <a href="https://github.com/SciTools/cartopy/graphs/contributors">
 <img src="https://img.shields.io/github/contributors/SciTools/cartopy.svg"
  alt="# contributors" /></a>
 <a href="https://travis-ci.org/SciTools/cartopy/branches">
-<img src="https://api.travis-ci.org/repositories/SciTools/cartopy.svg?branch=master"
+<img src="https://api.travis-ci.org/repositories/SciTools/cartopy.svg?branch=main"
  alt="Travis-CI" /></a>
 <a href="https://zenodo.org/badge/latestdoi/5282596">
 <img src="https://zenodo.org/badge/5282596.svg"

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -15,7 +15,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    // "branches": ["master"], // for git
+    "branches": ["main"],
 
     // The tool to use to create environments.  May be "conda",
     // "virtualenv" or other value depending on the plugins in use.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,8 +65,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The root toctree document (variable renamed in Sphinx 4.)
+root_doc = master_doc = 'index'
 
 # General information about the project.
 project = 'cartopy'


### PR DESCRIPTION
## Rationale

Matplotlib renamed the default branch, and it's been annoying to switch back and forth.
There fortunately seem to be very few mentions of the default branch in the source code.

## Implications

Nothing right now until we toggle the branch in settings.