### PR TITLE
CI: Avoid newer openssl version due to WMTS tests

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -51,6 +51,10 @@ jobs:
           PACKAGES="$PACKAGES owslib pep8 pillow pyshp pytest pytest-mpl"
           PACKAGES="$PACKAGES pytest-xdist setuptools_scm"
           PACKAGES="$PACKAGES setuptools_scm_git_archive shapely"
+          # openssl 3.0 updated the legacy renegotiation default, which causes
+          # failures in NASA's WMTS server. They will need to update their
+          # server before we can use a newer openssl.
+          PACKAGES="$PACKAGES openssl<3"
           conda install $PACKAGES
           conda info -a
           conda list


### PR DESCRIPTION
The negotiation with a tile provider needed more up-to-date TLS/SSL protocols, so for now we just pin to a lower openssl
on the runners.

I am able to reproduce locally if I install openssl 3.0.0. I think this is a server-side issue on NASA's end, so we will have to wait for them to update to more secure protocols before unpinning.

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
