### PR TITLE
MNT: Change map_projection to projection for Axes creation

### DIFF
--- a/examples/miscellanea/axes_grid_basic.py
+++ b/examples/miscellanea/axes_grid_basic.py
@@ -41,7 +41,7 @@ def sample_data_3d(shape):
 def main():
     projection = ccrs.PlateCarree()
     axes_class = (GeoAxes,
-                  dict(map_projection=projection))
+                  dict(projection=projection))
 
     lons, lats, times, data = sample_data_3d((6, 73, 145))
 

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -775,7 +775,7 @@ class Projection(CRS, metaclass=ABCMeta):
 
     def _as_mpl_axes(self):
         import cartopy.mpl.geoaxes as geoaxes
-        return geoaxes.GeoAxes, {'map_projection': self}
+        return geoaxes.GeoAxes, {'projection': self}
 
     def project_geometry(self, geometry, src_crs=None):
         """

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -399,16 +399,22 @@ class GeoAxes(matplotlib.axes.Axes):
 
         Parameters
         ----------
-        map_projection: optional
-            The target :class:`~cartopy.crs.Projection` of this Axes object.
-
-
-        All other args and keywords are passed through to
-        :class:`matplotlib.axes.Axes`.
-
+        projection : cartopy.crs.Projection
+            The target projection of this Axes.
         """
-        self.projection = kwargs.pop('map_projection')
-        """The :class:`cartopy.crs.Projection` of this GeoAxes."""
+        if "map_projection" in kwargs:
+            warnings.warn("The `map_projection` keyword argument is "
+                          "deprecated, use `projection` to instantiate a "
+                          "GeoAxes instead.")
+            projection = kwargs.pop("map_projection")
+        else:
+            projection = kwargs.pop("projection")
+
+        # The :class:`cartopy.crs.Projection` of this GeoAxes.
+        if not isinstance(projection, ccrs.Projection):
+            raise ValueError("A GeoAxes can only be created with a "
+                             "projection of type cartopy.crs.Projection")
+        self.projection = projection
 
         super().__init__(*args, **kwargs)
         self._gridliners = []

--- a/lib/cartopy/tests/mpl/test_axes.py
+++ b/lib/cartopy/tests/mpl/test_axes.py
@@ -98,7 +98,7 @@ class Test_Axes_add_geometries:
     @mock.patch('cartopy.feature.ShapelyFeature')
     def test_styler_kwarg(self, ShapelyFeature, add_feature_method):
         ax = GeoAxes(plt.figure(), [0, 0, 1, 1],
-                     map_projection=ccrs.Robinson())
+                     projection=ccrs.Robinson())
         ax.add_geometries(mock.sentinel.geometries, mock.sentinel.crs,
                           styler=mock.sentinel.styler, wibble='wobble')
 


### PR DESCRIPTION
The GeoAxes class now requires the `projection` keyword argument rather than `map_projection` to be more consistent with how a normal Axes is created. In particular, this makes working with AxesGrid and other toolkits easier by enabling a consistent keyword when passing `subplot_kw`, `axes_class`, etc...

closes #1979