### PR TITLE
Use geometries.geoms to fix deprecation warning

### DIFF
--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -214,7 +214,7 @@ class ShapelyFeature(Feature):
 
         """
         super().__init__(crs, **kwargs)
-        self._geoms = tuple(geometries)
+        self._geoms = tuple(geometries.geoms)
 
     def geometries(self):
         return iter(self._geoms)


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

Fix deprecation warning from Shapely, in the vein of https://github.com/SciTools/cartopy/pull/1930.

## Implications

None.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->

Fixes https://github.com/SciTools/cartopy/issues/1984.