### PR TITLE
avoid an edge case with base=0 in Gridliner._round

### DIFF
--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -570,7 +570,7 @@ class Gridliner:
 
     @staticmethod
     def _round(x, base=5):
-        if np.isnan(base):
+        if np.isnan(base) or base == 0:
             base = 5
         return int(base * round(x / base))
 


### PR DESCRIPTION

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

The round function does not work when base=0.
The existing code for testing nan might be enough to justify testing 0.


