### PR TITLE
FIX: setup.py should output "... 8.0.0 *or later*" if proj is missing or too old

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ except ImportError:
 # Please keep in sync with INSTALL file.
 GEOS_MIN_VERSION = (3, 7, 2)
 PROJ_MIN_VERSION = (8, 0, 0)
+PROJ_MIN_VERSION_STRING = '.'.join(str(v) for v in PROJ_MIN_VERSION)
 
 
 def file_walk_relative(top, remove=''):
@@ -145,15 +146,14 @@ def find_proj_version_by_program(conda=None):
     proj = shutil.which('proj')
     if proj is None:
         print(
-            'Proj {} must be installed.'.format(
-                '.'.join(str(v) for v in PROJ_MIN_VERSION)),
+            f'Proj {PROJ_MIN_VERSION_STRING} or later must be installed.',
             file=sys.stderr)
         exit(1)
 
     if conda is not None and conda not in proj:
         print(
-            'Proj {} must be installed in Conda environment "{}".'.format(
-                '.'.join(str(v) for v in PROJ_MIN_VERSION), conda),
+            f'Proj {PROJ_MIN_VERSION_STRING} or later must be installed in'
+            f' Conda environment "{conda}".',
             file=sys.stderr)
         exit(1)
 
@@ -164,9 +164,9 @@ def find_proj_version_by_program(conda=None):
         proj_version = tuple(int(v.strip(b',')) for v in proj_version)
     except (OSError, IndexError, ValueError, subprocess.CalledProcessError):
         warnings.warn(
-            'Unable to determine Proj version. Ensure you have %s or later '
-            'installed, or installation may fail.' % (
-                '.'.join(str(v) for v in PROJ_MIN_VERSION), ))
+            f'Unable to determine Proj version. Ensure you have '
+            f'{PROJ_MIN_VERSION_STRING} or later installed, or installation may fail.'
+        )
         proj_version = (0, 0, 0)
 
     return proj_version
@@ -179,10 +179,10 @@ if conda is not None and conda in sys.prefix:
     # the version, though.
     proj_version = find_proj_version_by_program(conda)
     if proj_version < PROJ_MIN_VERSION:
+        proj_version_string = '.'.join(str(v) for v in proj_version)
         print(
-            'Proj version %s is installed, but cartopy requires at least '
-            'version %s.' % ('.'.join(str(v) for v in proj_version),
-                             '.'.join(str(v) for v in PROJ_MIN_VERSION)),
+            f'Proj version {proj_version_string} is installed, but cartopy requires '
+            f'at least version {PROJ_MIN_VERSION_STRING}',
             file=sys.stderr)
         exit(1)
 


### PR DESCRIPTION

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

When trying to install CartoPy with `proj` missing, this is the error message you get:
```
Proj 8.0.0 must be installed.
```

This is misleading since the [docs](https://scitools.org.uk/cartopy/docs/latest/installing.html) say "PROJ 8.0.0 **or later**". Therefore, the error message should be updated accordingly.


## Implications

No negative implications expected.


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
