### PR TITLE
FIX: Allow values less than -180 to be wrapped too

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -402,7 +402,7 @@ class CRS(_CRS):
                     self.is_geodetic()):
                 # convert from [0,360] to [-180,180]
                 x = np.array(x, copy=True)
-                to_180 = x > 180
+                to_180 = (x > 180) | (x < -180)
                 x[to_180] = (((x[to_180] + 180) % 360) - 180)
             try:
                 result[:, 0], result[:, 1], result[:, 2] = \

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -173,6 +173,17 @@ class TestCRS:
         assert_arr_almost_eq(glon, soly)
         assert_arr_almost_eq(galt, solz)
 
+    def test_transform_points_180(self):
+        # Test that values less than -180 and more than 180
+        # get mapped to the -180, 180 interval
+        x = np.array([-190, 190])
+        y = np.array([0, 0])
+
+        proj = ccrs.PlateCarree()
+
+        res = proj.transform_points(x=x, y=y, src_crs=proj)
+        assert_array_equal(res[..., :2], [[170, 0], [-170, 0]])
+
     def test_globe(self):
         # Ensure the globe affects output.
         rugby_globe = ccrs.Globe(semimajor_axis=9000000,

--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -231,7 +231,7 @@ cdef class Interpolator:
             else:
                 raise
 
-        if self.to_180 and xx > 180 and xx != HUGE_VAL:
+        if self.to_180 and (xx > 180 or xx < -180) and xx != HUGE_VAL:
             xx = (((xx + 180) % 360) - 180)
 
         dest_xy.x = xx * self.dest_scale


### PR DESCRIPTION
This adds a check for values less than -180, effectively clipping
all PlateCarree values to be between -180 and 180 after transforms.

Closes #1997