### PR TITLE
ENH: Allow a single geometry in add_geometries

### DIFF
--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -214,6 +214,8 @@ class ShapelyFeature(Feature):
 
         """
         super().__init__(crs, **kwargs)
+        if isinstance(geometries, sgeom.base.BaseGeometry):
+            geometries = [geometries]
         self._geoms = tuple(geometries)
 
     def geometries(self):

--- a/lib/cartopy/tests/mpl/test_axes.py
+++ b/lib/cartopy/tests/mpl/test_axes.py
@@ -13,6 +13,7 @@ import numpy as np
 import pytest
 
 import cartopy.crs as ccrs
+import cartopy.feature as cfeature
 from cartopy.mpl.geoaxes import InterProjectionTransform, GeoAxes
 
 
@@ -107,6 +108,14 @@ class Test_Axes_add_geometries:
 
         add_feature_method.assert_called_once_with(
             ShapelyFeature(), styler=mock.sentinel.styler)
+
+    @pytest.mark.natural_earth
+    def test_single_geometry(self):
+        # A single geometry is acceptable
+        proj = ccrs.PlateCarree()
+        ax = GeoAxes(plt.figure(), [0, 0, 1, 1],
+                     map_projection=proj)
+        ax.add_geometries(next(cfeature.COASTLINE.geometries()), crs=proj)
 
 
 @cleanup


### PR DESCRIPTION
Allow single geometries to be added to a geoaxes, even though the method is plural. This will make it more user friendly to highlight single geometry objects without having to remember to make it an iterable list.

Closes #1303