### PR TITLE
API: GH #2013 make regrid arguments, docstring consistent

### DIFF
--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -325,7 +325,7 @@ def regrid(array, source_x_coords, source_y_coords, source_proj, target_proj,
                                                       desired_nx)
 
         bounds = _determine_bounds(source_x_coords, source_y_coords,
-                                    source_proj)
+                                   source_proj)
 
         outside_source_domain = ((target_in_source_y >= bounds['y'][1]) |
                                  (target_in_source_y <= bounds['y'][0]))

--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -219,8 +219,8 @@ def _determine_bounds(x_coords, y_coords, source_cs):
     return bounds
 
 
-def regrid(array, source_x_coords, source_y_coords, source_cs, target_proj,
-           target_x_points, target_y_points, mask_extrapolated=False):
+def regrid(array, source_x_coords, source_y_coords, source_proj, target_proj,
+           target_x_points, target_y_points, mask_extrapolated=False, source_cs=None):
     """
     Regrid the data array from the source projection to the target projection.
 
@@ -235,9 +235,9 @@ def regrid(array, source_x_coords, source_y_coords, source_cs, target_proj,
     source_y_coords
         A 2-dimensional source projection :class:`numpy.ndarray` of
         y-direction sample points.
-    source_cs
+    source_proj
         The source :class:`~cartopy.crs.Projection` instance.
-    target_cs
+    target_proj
         The target :class:`~cartopy.crs.Projection` instance.
     target_x_points
         A 2-dimensional target projection :class:`numpy.ndarray` of
@@ -249,6 +249,8 @@ def regrid(array, source_x_coords, source_y_coords, source_cs, target_proj,
         Assume that the source coordinate is rectilinear and so mask the
         resulting target grid values which lie outside the source grid domain.
         Defaults to False.
+    source_cs
+        Deprecated, please use source_proj instead.
 
     Returns
     -------
@@ -256,12 +258,16 @@ def regrid(array, source_x_coords, source_y_coords, source_cs, target_proj,
         The data array regridded in the target projection.
 
     """
+    if source_cs is not None:
+        warnings.warn("The source_cs keyword argument is deprecated. Please use source_proj instead.")
+        source_proj = source_cs
+
     # Stack our original xyz array, this will also wrap coords when necessary
-    xyz = source_cs.transform_points(source_cs,
+    xyz = source_proj.transform_points(source_proj,
                                      source_x_coords.flatten(),
                                      source_y_coords.flatten())
     # Transform the target points into the source projection
-    target_xyz = source_cs.transform_points(target_proj,
+    target_xyz = source_proj.transform_points(target_proj,
                                             target_x_points.flatten(),
                                             target_y_points.flatten())
 
@@ -293,7 +299,7 @@ def regrid(array, source_x_coords, source_y_coords, source_cs, target_proj,
     # to the same point to within a fixed fractional offset.
     # NOTE: This only needs to be done for (pseudo-)cylindrical projections,
     # or any others which have the concept of wrapping
-    back_to_target_xyz = target_proj.transform_points(source_cs,
+    back_to_target_xyz = target_proj.transform_points(source_proj,
                                                       target_xyz[:, 0],
                                                       target_xyz[:, 1])
     back_to_target_x = back_to_target_xyz[:, 0].reshape(desired_ny,
@@ -323,7 +329,7 @@ def regrid(array, source_x_coords, source_y_coords, source_cs, target_proj,
         target_in_source_y = target_xyz[:, 1].reshape(desired_ny,
                                                       desired_nx)
 
-        bounds = _determine_bounds(source_x_coords, source_y_coords, source_cs)
+        bounds = _determine_bounds(source_x_coords, source_y_coords, source_proj)
 
         outside_source_domain = ((target_in_source_y >= bounds['y'][1]) |
                                  (target_in_source_y <= bounds['y'][0]))

--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -249,8 +249,9 @@ def regrid(array, source_x_coords, source_y_coords, source_proj, target_proj,
         Assume that the source coordinate is rectilinear and so mask the
         resulting target grid values which lie outside the source grid domain.
         Defaults to False.
-    source_cs
-        Deprecated, please use source_proj instead.
+    source_cs: optional
+        .. deprecated:: 0.20.3
+           Please use `source_proj` argument instead.
 
     Returns
     -------
@@ -259,7 +260,7 @@ def regrid(array, source_x_coords, source_y_coords, source_proj, target_proj,
 
     """
     if source_cs is not None:
-        warnings.warn("The source_cs keyword argument is deprecated. Please use source_proj instead.")
+        warnings.warn("The source_cs argument is deprecated. Please use source_proj instead.")
         source_proj = source_cs
 
     # Stack our original xyz array, this will also wrap coords when necessary

--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -220,7 +220,7 @@ def _determine_bounds(x_coords, y_coords, source_cs):
 
 
 def regrid(array, source_x_coords, source_y_coords, source_proj, target_proj,
-           target_x_points, target_y_points, mask_extrapolated=False, source_cs=None):
+           target_x_points, target_y_points, mask_extrapolated=False):
     """
     Regrid the data array from the source projection to the target projection.
 
@@ -249,9 +249,6 @@ def regrid(array, source_x_coords, source_y_coords, source_proj, target_proj,
         Assume that the source coordinate is rectilinear and so mask the
         resulting target grid values which lie outside the source grid domain.
         Defaults to False.
-    source_cs: optional
-        .. deprecated:: 0.20.3
-           Please use `source_proj` argument instead.
 
     Returns
     -------
@@ -259,9 +256,6 @@ def regrid(array, source_x_coords, source_y_coords, source_proj, target_proj,
         The data array regridded in the target projection.
 
     """
-    if source_cs is not None:
-        warnings.warn("The source_cs argument is deprecated. Please use source_proj instead.")
-        source_proj = source_cs
 
     # Stack our original xyz array, this will also wrap coords when necessary
     xyz = source_proj.transform_points(source_proj,

--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -324,7 +324,8 @@ def regrid(array, source_x_coords, source_y_coords, source_proj, target_proj,
         target_in_source_y = target_xyz[:, 1].reshape(desired_ny,
                                                       desired_nx)
 
-        bounds = _determine_bounds(source_x_coords, source_y_coords, source_proj)
+        bounds = _determine_bounds(source_x_coords, source_y_coords,
+                                    source_proj)
 
         outside_source_domain = ((target_in_source_y >= bounds['y'][1]) |
                                  (target_in_source_y <= bounds['y'][0]))


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale
Addresses #2013 
<!-- Please provide detail as to *why* you are making this change. -->


## Implications
#### This is a change to the API for `img_transform.regrid`

I changed the name of the 4th argument from `source_cs` to `source_proj` to be consistent with other argument names. It's probably uncommon for source projection object to be passed as a keyword argument since it's the fourth of six positional arguments.
<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

#### Old function signature:
https://github.com/SciTools/cartopy/blob/22cdafca511744143c5b673598a1889f169c1e3d/lib/cartopy/img_transform.py#L222-L223

#### New function signature:
```python
def regrid(array, source_x_coords, source_y_coords, source_proj, target_proj,
           target_x_points, target_y_points, mask_extrapolated=False)
```


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
