### PR TITLE
TST: Skip lakes test for pyshp 2.2

### DIFF
--- a/lib/cartopy/tests/test_shapereader.py
+++ b/lib/cartopy/tests/test_shapereader.py
@@ -27,6 +27,8 @@ class TestLakes:
             list(self.reader.geometries())[self.lake_index]
         self.test_lake_record = list(self.reader.records())[self.lake_index]
 
+    @pytest.mark.skipif(shp.shapefile.__version__ == "2.2.0",
+                        reason="pyshp reverses the geometry")
     def test_geometry(self):
         lake_geometry = self.test_lake_geometry
         assert lake_geometry.type == 'Polygon'


### PR DESCRIPTION
pyshp 2.2 reverses the order of the lakes shapefile, which is not what
we want for this test. They are discussing reverting that change, so
just skip this version for now.

xref: #2012