### PR TITLE
TST: Removing unnecessary cleanup decorator

### DIFF
--- a/lib/cartopy/tests/mpl/test_axes.py
+++ b/lib/cartopy/tests/mpl/test_axes.py
@@ -6,7 +6,6 @@
 
 from unittest import mock
 
-from matplotlib.testing.decorators import cleanup
 import matplotlib.path as mpath
 import matplotlib.pyplot as plt
 import numpy as np
@@ -118,7 +117,6 @@ class Test_Axes_add_geometries:
         ax.add_geometries(next(cfeature.COASTLINE.geometries()), crs=proj)
 
 
-@cleanup
 def test_geoaxes_subplot():
     ax = plt.subplot(1, 1, 1, projection=ccrs.PlateCarree())
     assert str(ax.__class__) == "<class 'cartopy.mpl.geoaxes.GeoAxesSubplot'>"

--- a/lib/cartopy/tests/mpl/test_contour.py
+++ b/lib/cartopy/tests/mpl/test_contour.py
@@ -5,7 +5,6 @@
 # licensing details.
 
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import cleanup
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 import pytest
@@ -15,7 +14,6 @@ from scipy.signal import convolve2d
 import cartopy.crs as ccrs
 
 
-@cleanup
 def test_contour_plot_bounds():
     x = np.linspace(-2763217.0, 2681906.0, 200)
     y = np.linspace(-263790.62, 3230840.5, 130)
@@ -56,7 +54,6 @@ def test_contour_doesnt_shrink():
     assert_array_almost_equal(ax.get_extent(), expected)
 
 
-@cleanup
 def test_contour_linear_ring():
     """Test contourf with a section that only has 3 points."""
     ax = plt.axes([0.01, 0.05, 0.898, 0.85], projection=ccrs.Mercator(),
@@ -98,7 +95,6 @@ def test_contour_update_bounds():
 
 
 @pytest.mark.parametrize('func', ['contour', 'contourf'])
-@cleanup
 def test_contourf_transform_first(func):
     """Test the fast-path option for filled contours."""
     # Gridded data that needs to be wrapped

--- a/lib/cartopy/tests/mpl/test_crs.py
+++ b/lib/cartopy/tests/mpl/test_crs.py
@@ -5,7 +5,6 @@
 # licensing details.
 
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import cleanup
 import pytest
 
 import cartopy.crs as ccrs
@@ -46,7 +45,6 @@ def test_lambert_south():
 
 
 @pytest.mark.natural_earth
-@cleanup
 def test_repr_html():
     pc = ccrs.PlateCarree()
     html = pc._repr_html_()

--- a/lib/cartopy/tests/mpl/test_quiver.py
+++ b/lib/cartopy/tests/mpl/test_quiver.py
@@ -8,7 +8,6 @@ from unittest import mock
 
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import cleanup
 import pytest
 
 import cartopy.crs as ccrs
@@ -28,7 +27,6 @@ class TestQuiverShapes:
         self.fig = plt.figure()
         self.ax = plt.axes(projection=self.pc)
 
-    @cleanup
     def test_quiver_transform_xyuv_1d(self):
         with mock.patch('matplotlib.axes.Axes.quiver') as patch:
             self.ax.quiver(self.x2d.ravel(), self.y2d.ravel(),
@@ -40,7 +38,6 @@ class TestQuiverShapes:
         # Assert that all the shapes have been broadcast.
         assert shapes == [(70, )] * 4
 
-    @cleanup
     def test_quiver_transform_xy_1d_uv_2d(self):
         with mock.patch('matplotlib.axes.Axes.quiver') as patch:
             self.ax.quiver(self.x, self.y, self.u, self.v, transform=self.rp)

--- a/lib/cartopy/tests/mpl/test_set_extent.py
+++ b/lib/cartopy/tests/mpl/test_set_extent.py
@@ -4,7 +4,6 @@
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-from matplotlib.testing.decorators import cleanup
 import matplotlib.pyplot as plt
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
@@ -12,7 +11,6 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 import cartopy.crs as ccrs
 
 
-@cleanup
 def test_extents():
     # tests that one can set the extents of a map in a variety of coordinate
     # systems, for a variety of projection
@@ -48,7 +46,6 @@ def test_extents():
                               )
 
 
-@cleanup
 def test_get_extent():
     # tests that getting the extents of a map produces something reasonable.
     uk = [-12.5, 4, 49, 60]
@@ -68,7 +65,6 @@ def test_get_extent():
     assert_array_almost_equal(ax.get_extent(uk_crs), uk, decimal=1)
 
 
-@cleanup
 def test_domain_extents():
     # Setting the extent to global or the domain limits.
     ax = plt.axes(projection=ccrs.PlateCarree())

--- a/lib/cartopy/tests/mpl/test_web_services.py
+++ b/lib/cartopy/tests/mpl/test_web_services.py
@@ -5,7 +5,6 @@
 # licensing details.
 
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import cleanup
 import pytest
 
 import cartopy.crs as ccrs
@@ -27,7 +26,6 @@ def test_wmts():
 
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
-@cleanup
 def test_wms_tight_layout():
     ax = plt.axes(projection=ccrs.PlateCarree())
     url = 'http://vmap0.tiles.osgeo.org/wms/vmap0'


### PR DESCRIPTION
This removes the Matplotlib cleanup decorator as we are already handling the cleanup with the autouse fixture.
https://github.com/SciTools/cartopy/blob/22cdafca511744143c5b673598a1889f169c1e3d/lib/cartopy/tests/mpl/conftest.py#L10-L21

closes #2020