### PR TITLE
examples: define 'sample_data' for all examples

### DIFF
--- a/examples/scalar_data/contour_labels.py
+++ b/examples/scalar_data/contour_labels.py
@@ -8,7 +8,23 @@ An example of adding contour labels to matplotlib contours.
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 
-from waves import sample_data
+
+def sample_data(shape=(73, 145)):
+    """Return ``lons``, ``lats`` and ``data`` of some fake data."""
+    import numpy as np
+
+    nlats, nlons = shape
+    lats = np.linspace(-np.pi / 2, np.pi / 2, nlats)
+    lons = np.linspace(0, 2 * np.pi, nlons)
+    lons, lats = np.meshgrid(lons, lats)
+    wave = 0.75 * (np.sin(2 * lats) ** 8) * np.cos(4 * lons)
+    mean = 0.5 * np.cos(2 * lats) * ((np.sin(2 * lats)) ** 2 + 2)
+
+    lats = np.rad2deg(lats)
+    lons = np.rad2deg(lons)
+    data = wave + mean
+
+    return lons, lats, data
 
 
 def main():
@@ -19,7 +35,7 @@ def main():
     ax.set_global()
     ax.coastlines('110m', alpha=0.1)
 
-    # Use the waves example to provide some sample data, but make it
+    # Use the same sample data as the waves example, but make it
     # more dependent on y for more interesting contours.
     x, y, z = sample_data((20, 40))
     z = z * -1.5 * y

--- a/examples/scalar_data/contour_transforms.py
+++ b/examples/scalar_data/contour_transforms.py
@@ -14,12 +14,28 @@ second axes that the data does not extend to the full global extent.
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 
-from waves import sample_data
+
+def sample_data(shape=(73, 145)):
+    """Return ``lons``, ``lats`` and ``data`` of some fake data."""
+    import numpy as np
+
+    nlats, nlons = shape
+    lats = np.linspace(-np.pi / 2, np.pi / 2, nlats)
+    lons = np.linspace(0, 2 * np.pi, nlons)
+    lons, lats = np.meshgrid(lons, lats)
+    wave = 0.75 * (np.sin(2 * lats) ** 8) * np.cos(4 * lons)
+    mean = 0.5 * np.cos(2 * lats) * ((np.sin(2 * lats)) ** 2 + 2)
+
+    lats = np.rad2deg(lats)
+    lons = np.rad2deg(lons)
+    data = wave + mean
+
+    return lons, lats, data
 
 
 def main():
 
-    # Use the waves example to provide some sample data, but make it
+    # Use the same sample data as the waves example, but make it
     # more dependent on y for more interesting contours.
     x, y, z = sample_data((20, 40))
     z = z * -1.5 * y

--- a/examples/vector_data/barbs.py
+++ b/examples/vector_data/barbs.py
@@ -8,7 +8,28 @@ Plotting barbs.
 import matplotlib.pyplot as plt
 
 import cartopy.crs as ccrs
-from arrows import sample_data
+
+
+def sample_data(shape=(20, 30)):
+    """
+    Return ``(x, y, u, v, crs)`` of some vector data
+    computed mathematically. The returned crs will be a rotated
+    pole CRS, meaning that the vectors will be unevenly spaced in
+    regular PlateCarree space.
+
+    """
+    import numpy as np
+
+    crs = ccrs.RotatedPole(pole_longitude=177.5, pole_latitude=37.5)
+
+    x = np.linspace(311.9, 391.1, shape[1])
+    y = np.linspace(-23.6, 24.8, shape[0])
+
+    x2d, y2d = np.meshgrid(x, y)
+    u = 10 * (2 * np.cos(2 * np.deg2rad(x2d) + 3 * np.deg2rad(y2d + 30)) ** 2)
+    v = 20 * np.cos(6 * np.deg2rad(x2d))
+
+    return x, y, u, v, crs
 
 
 def main():

--- a/examples/vector_data/streamplot.py
+++ b/examples/vector_data/streamplot.py
@@ -8,7 +8,28 @@ Generating a vector-based streamplot.
 import matplotlib.pyplot as plt
 
 import cartopy.crs as ccrs
-from arrows import sample_data
+
+
+def sample_data(shape=(20, 30)):
+    """
+    Return ``(x, y, u, v, crs)`` of some vector data
+    computed mathematically. The returned crs will be a rotated
+    pole CRS, meaning that the vectors will be unevenly spaced in
+    regular PlateCarree space.
+
+    """
+    import numpy as np
+
+    crs = ccrs.RotatedPole(pole_longitude=177.5, pole_latitude=37.5)
+
+    x = np.linspace(311.9, 391.1, shape[1])
+    y = np.linspace(-23.6, 24.8, shape[0])
+
+    x2d, y2d = np.meshgrid(x, y)
+    u = 10 * (2 * np.cos(2 * np.deg2rad(x2d) + 3 * np.deg2rad(y2d + 30)) ** 2)
+    v = 20 * np.cos(6 * np.deg2rad(x2d))
+
+    return x, y, u, v, crs
 
 
 def main():


### PR DESCRIPTION
Ever since 297e1cb0 (Moving sample_data imports out of cartopy
namespace., 2020-07-23), some examples are not self-contained since they
want to import 'sample_data' from a non-existing module like 'waves' or
'arrows'.

Add the required 'sample_data' function to make all examples
self-contained. For 'contour_labels.py' and 'contour_transforms.py', the
function is copied from 'waves.py'. For 'barbs.py' and 'streamplot.py',
the function is copied from 'arrows.py'.

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Make all examples self-contained.


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
Examples can be downloaded and ran individually.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
