### PR TITLE
Additional support for LINZ Maps Tiles

### DIFF
--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -682,3 +682,19 @@ class AzureMapsTiles(GoogleWTS):
             f'https://atlas.microsoft.com/map/tile?'
             f'api-version={self.api_version}&tilesetId={self.tileset_id}&'
             f'x={x}&y={y}&zoom={z}&subscription-key={self.subscription_key}')
+
+class LINZMapsTiles(GoogleWTS):
+    
+    def __init__(self, subscription_key, layer_id, api_version="v4", desired_tile_form='RGB', cache=False):
+        
+        super().__init__(desired_tile_form=desired_tile_form, cache=cache)
+        self.subscription_key = subscription_key
+        self.layer_id = layer_id
+        self.api_version = api_version
+        
+    def _image_url(self, tile):
+        x, y, z = tile
+        return (
+            f'https://tiles-a.koordinates.com/services;'
+            f'key={self.subscription_key}/tiles/{self.api_version}/'
+            f'layer={self.layer_id}/EPSG:3857/{z}/{x}/{y}.png') 

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -699,4 +699,4 @@ class LINZMapsTiles(GoogleWTS):
         return (
             f'https://tiles-a.koordinates.com/services;'
             f'key={self.subscription_key}/tiles/{self.api_version}/'
-            f'layer={self.layer_id}/EPSG:3857/{z}/{x}/{y}.png') 
+            f'layer={self.layer_id}/EPSG:3857/{z}/{x}/{y}.png')

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -683,9 +683,11 @@ class AzureMapsTiles(GoogleWTS):
             f'api-version={self.api_version}&tilesetId={self.tileset_id}&'
             f'x={x}&y={y}&zoom={z}&subscription-key={self.subscription_key}')
 
+
 class LINZMapsTiles(GoogleWTS):
     
-    def __init__(self, subscription_key, layer_id, api_version="v4", desired_tile_form='RGB', cache=False):
+    def __init__(self, subscription_key, layer_id, api_version="v4",
+                 desired_tile_form='RGB', cache=False):
         
         super().__init__(desired_tile_form=desired_tile_form, cache=cache)
         self.subscription_key = subscription_key

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -686,7 +686,7 @@ class AzureMapsTiles(GoogleWTS):
 
 class LINZMapsTiles(GoogleWTS):
 
-    def __init__(self, API_key, layer_id, api_version="v4",
+    def __init__(self, apikey, layer_id, api_version="v4",
                  desired_tile_form='RGB', cache=False):
         """
         Set up a new instance to retrieve tiles from The LINZ
@@ -698,7 +698,7 @@ class LINZMapsTiles(GoogleWTS):
 
         Parameters
         ----------
-        API_key
+        apikey
             A valid LINZ API key specific for every users.
         layer_id
             A layer ID for a map. See the "Technical Details" lower down the
@@ -708,7 +708,7 @@ class LINZMapsTiles(GoogleWTS):
 
         """
         super().__init__(desired_tile_form=desired_tile_form, cache=cache)
-        self.API_key = API_key
+        self.apikey = apikey
         self.layer_id = layer_id
         self.api_version = api_version
 
@@ -716,5 +716,5 @@ class LINZMapsTiles(GoogleWTS):
         x, y, z = tile
         return (
             f'https://tiles-a.koordinates.com/services;'
-            f'key={self.API_key}/tiles/{self.api_version}/'
+            f'key={self.apikey}/tiles/{self.api_version}/'
             f'layer={self.layer_id}/EPSG:3857/{z}/{x}/{y}.png')

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -685,18 +685,36 @@ class AzureMapsTiles(GoogleWTS):
 
 
 class LINZMapsTiles(GoogleWTS):
-    
-    def __init__(self, subscription_key, layer_id, api_version="v4",
+
+    def __init__(self, API_key, layer_id, api_version="v4",
                  desired_tile_form='RGB', cache=False):
+        """
+        Set up a new instance to retrieve tiles from The LINZ
+        aka. Land Information New Zealand
         
+        Access to LINZ WMTS GetCapabilities requires an API key.
+        Register yourself free in https://id.koordinates.com/signup/
+        to gain access into the LINZ database.
+        
+        Parameters
+        ----------
+        API_key
+            A valid LINZ API key specific for every users.
+        layer_id
+            A layer ID for a map. See the "Technical Details" lower down the
+            "About" tab for each layer displayed in the LINZ data service.
+        api_version
+            API version to use. Defaults to v4 for now.
+
+        """
         super().__init__(desired_tile_form=desired_tile_form, cache=cache)
-        self.subscription_key = subscription_key
+        self.API_key = API_key
         self.layer_id = layer_id
         self.api_version = api_version
-        
+
     def _image_url(self, tile):
         x, y, z = tile
         return (
             f'https://tiles-a.koordinates.com/services;'
-            f'key={self.subscription_key}/tiles/{self.api_version}/'
+            f'key={self.API_key}/tiles/{self.api_version}/'
             f'layer={self.layer_id}/EPSG:3857/{z}/{x}/{y}.png')

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -691,11 +691,11 @@ class LINZMapsTiles(GoogleWTS):
         """
         Set up a new instance to retrieve tiles from The LINZ
         aka. Land Information New Zealand
-        
+
         Access to LINZ WMTS GetCapabilities requires an API key.
         Register yourself free in https://id.koordinates.com/signup/
         to gain access into the LINZ database.
-        
+
         Parameters
         ----------
         API_key


### PR DESCRIPTION
This is to add support for plotting NZ Map tiles, which is in EPSG:3857 (https://epsg.io/3857) already and in png format. Layer ID can be read in every layer's "About" tab, and the "subscription key" parameter is actually an API key given to the registered users. Tested in Python 3.8 and runs well.

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

To add support to plotting LINZ Map Tiles, which are used widely within the Australia-New Zealand region.


## Implications

More cartopy applicability for Australia-New Zealand users.


<!--
## Checklist

*There is no test suite within cartopy that is applicable to this change. Any registered LINZ users can try this addition.

-->
