### PR TITLE
Explicitly calling numpy asanyarray over the inputs.

### DIFF
--- a/lib/cartopy/tests/test_vector_transform.py
+++ b/lib/cartopy/tests/test_vector_transform.py
@@ -190,3 +190,35 @@ class Test_vector_scalar_to_grid:
         assert_array_almost_equal(u_grid, expected_u_grid)
         assert_array_almost_equal(v_grid, expected_v_grid)
         assert_array_almost_equal(s_grid, expected_s_grid)
+
+    def test_with_scalar_field_non_ndarray_data(self):
+        # Transform and regrid vector (with no projection transform) with an
+        # additional scalar field wich is not a ndarray.
+        expected_x_grid = np.array([[-10., -5., 0., 5., 10.],
+                                    [-10., -5., 0., 5., 10.],
+                                    [-10., -5., 0., 5., 10.]])
+        expected_y_grid = np.array([[5., 5., 5., 5., 5.],
+                                    [7.5, 7.5, 7.5, 7.5, 7.5],
+                                    [10., 10., 10., 10., 10]])
+        expected_u_grid = np.array([[np.nan, 2., 3., 2., np.nan],
+                                    [np.nan, 2.5, 3.5, 2.5, np.nan],
+                                    [2., 3., 4., 3., 2.]])
+        expected_v_grid = np.array([[np.nan, .8, .3, .8, np.nan],
+                                    [np.nan, 2.675, 2.15, 2.675, np.nan],
+                                    [5.5, 4.75, 4., 4.75, 5.5]])
+        expected_s_grid = np.array([[np.nan, 2., 3., 2., np.nan],
+                                    [np.nan, 2.5, 3.5, 2.5, np.nan],
+                                    [2., 3., 4., 3., 2.]])
+
+        src_crs = target_crs = ccrs.PlateCarree()
+        x_grid, y_grid, u_grid, v_grid, s_grid = \
+            vec_trans.vector_scalar_to_grid(src_crs, target_crs, (5, 3),
+                                            list(self.x), list(self.y),
+                                            list(self.u), list(self.v),
+                                            list(self.s))
+
+        assert_array_equal(x_grid, expected_x_grid)
+        assert_array_equal(y_grid, expected_y_grid)
+        assert_array_almost_equal(u_grid, expected_u_grid)
+        assert_array_almost_equal(v_grid, expected_v_grid)
+        assert_array_almost_equal(s_grid, expected_s_grid)

--- a/lib/cartopy/vector_transform.py
+++ b/lib/cartopy/vector_transform.py
@@ -109,6 +109,11 @@ def vector_scalar_to_grid(src_crs, target_proj, regrid_shape, x, y, u, v,
         scalar fields is the same as the number that were passed in.
 
     """
+    x = np.asanyarray(x)
+    y = np.asanyarray(y)
+    u = np.asanyarray(u)
+    v = np.asanyarray(v)
+
     if u.shape != v.shape:
         raise ValueError('u and v must be the same shape')
     if x.shape != u.shape:
@@ -117,10 +122,14 @@ def vector_scalar_to_grid(src_crs, target_proj, regrid_shape, x, y, u, v,
             raise ValueError('x and y coordinates are not compatible '
                              'with the shape of the vector components')
     if scalars:
+        np_like_scalars = ()
         for s in scalars:
+            s = np.asanyarray(s)
+            np_like_scalars = np_like_scalars + (s,)
             if s.shape != u.shape:
                 raise ValueError('scalar fields must have the same '
                                  'shape as the vector components')
+        scalars = np_like_scalars
     try:
         nx, ny = regrid_shape
     except TypeError:


### PR DESCRIPTION
Applying asanyarray to x, y, u, v, and all possible scalars to allow the 
use of objects that implements a `__array__`, like `xarray.DataArray`.

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

Cartopy was falling when non-ndarray inputs like `xarray.DataArray` is used.
More details on issue #2049 
