### PR TITLE
Replace _autoscaleX_on with get_autoscalex_on() in GeoAxes

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -462,15 +462,16 @@ class GeoAxes(matplotlib.axes.Axes):
         data_lim = self.dataLim.frozen().get_points()
         view_lim = self.viewLim.frozen().get_points()
         other = (self.ignore_existing_data_limits,
-                 self._autoscaleXon, self._autoscaleYon)
+                 self.get_autoscalex_on(), self.get_autoscaley_on())
         try:
             yield
         finally:
             if hold:
                 self.dataLim.set_points(data_lim)
                 self.viewLim.set_points(view_lim)
-                (self.ignore_existing_data_limits,
-                    self._autoscaleXon, self._autoscaleYon) = other
+                self.ignore_existing_data_limits = other[0]
+                self.set_autoscalex_on(other[1])
+                self.set_autoscaley_on(other[2])
 
     def _draw_preprocess(self, renderer):
         """
@@ -881,11 +882,11 @@ class GeoAxes(matplotlib.axes.Axes):
         """
         super().autoscale_view(tight=tight, scalex=scalex, scaley=scaley)
         # Limit the resulting bounds to valid area.
-        if scalex and self._autoscaleXon:
+        if scalex and self.get_autoscalex_on():
             bounds = self.get_xbound()
             self.set_xbound(max(bounds[0], self.projection.x_limits[0]),
                             min(bounds[1], self.projection.x_limits[1]))
-        if scaley and self._autoscaleYon:
+        if scaley and self.get_autoscaley_on():
             bounds = self.get_ybound()
             self.set_ybound(max(bounds[0], self.projection.y_limits[0]),
                             min(bounds[1], self.projection.y_limits[1]))


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

Modern implementations of matplotlib have removed the variables `_autoscaleXon` and `_autoscaleYon`.
`mpl/geoaxes.py` references these variables, resulting in an error when running cartopy: 
```
AttributeError: 'GeoAxesSubplot' object has no attribute '_autoscaleXon'
```

This PR replaces the deprecated variables with the functions `get_autoscalex_on()` (and `set_autoscalex_on()`), that are present in matplotlib.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

As far as I can tell, the change was introduced with matplotlib version 3.5.2, released May 3rd, 2022.
Based on what I can see from the matplotlib github site, the change should be compatible with previous versions of matplotlib. 

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
