### PR TITLE
Remove use of setuptools_scm_git_archive

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,8 +16,7 @@ install:
   - conda config --add channels conda-forge/label/testing
   - set ENV_NAME=test-environment
   - set PACKAGES=%PACKAGES% owslib pep8 pillow pyshp pytest pytest-mpl
-  - set PACKAGES=%PACKAGES% setuptools_scm setuptools_scm_git_archive
-  - set PACKAGES=%PACKAGES% shapely
+  - set PACKAGES=%PACKAGES% setuptools_scm shapely
   - conda create -n %ENV_NAME% python=%PYTHON_VERSION% %PACKAGES%
   - activate %ENV_NAME%
   - set INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,6 @@ deps-run: &deps-install
         pyshp \
         scipy \
         setuptools_scm \
-        setuptools_scm_git_archive \
         shapely \
         $EXTRA_PACKAGES \
         --file docs/doc-requirements.txt

--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,1 +1,0 @@
-ref-names: $Format:%D$

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -49,8 +49,7 @@ jobs:
       - name: Install dependencies
         run: |
           PACKAGES="$PACKAGES owslib pep8 pillow pyshp pytest pytest-mpl"
-          PACKAGES="$PACKAGES pytest-xdist setuptools_scm"
-          PACKAGES="$PACKAGES setuptools_scm_git_archive shapely"
+          PACKAGES="$PACKAGES pytest-xdist setuptools_scm shapely"
           conda install $PACKAGES
           conda info -a
           conda list

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,7 @@ jobs:
         run: |
           PACKAGES="cython fiona matplotlib-base numpy pyproj pykdtree scipy"
           PACKAGES="$PACKAGES owslib pep8 pillow pyshp pytest"
-          PACKAGES="$PACKAGES pytest-xdist setuptools_scm"
-          PACKAGES="$PACKAGES setuptools_scm_git_archive shapely"
+          PACKAGES="$PACKAGES pytest-xdist setuptools_scm shapely"
           conda install $PACKAGES
 
       - name: Create sdist

--- a/environment.yml
+++ b/environment.yml
@@ -39,4 +39,3 @@ dependencies:
   - flake8
   - pykdtree
   - setuptools_scm
-  - setuptools_scm_git_archive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ requires = [
     "setuptools >= 40.6.0",
     "Cython >= 0.29.13",
     "oldest-supported-numpy",
-    "setuptools_scm",
-    "setuptools_scm_git_archive",
+    "setuptools_scm >= 7.0.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
The .git_archival.txt in the sdist is breaking installation with new versions of pip (version comes up 0.0). Support for git archives is baked into setuptools_scm itself now with version 7.

Fixes #2053 using the removal of `setuptools_scm_gitarchive` identified as the root cause there.