### PR TITLE
docs: fix simple typo, noticable -> noticeable

### DIFF
--- a/benchmarks/cases/mpl_redraw.py
+++ b/benchmarks/cases/mpl_redraw.py
@@ -31,6 +31,6 @@ def time_second_figure():
     # Successive figures with Axes of the same projection
     # could have various caching mechanisms in place.
     # At the time of writing, there is no
-    # noticable performance speedup during the second figure :(
+    # noticeable performance speedup during the second figure :(
     create_pc_png()
     create_pc_png()


### PR DESCRIPTION
There is a small typo in benchmarks/cases/mpl_redraw.py.

Should read `noticeable` rather than `noticable`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md