### PR TITLE
Pyproj geodesic trace

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -30,12 +30,12 @@ jobs:
         if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'
         id: minimum-packages
         run: |
-          echo "PACKAGES=cython=0.29.15 matplotlib-base=3.2.1 numpy=1.19 owslib=0.19.1 pyproj=3.0 proj=8.0 scipy=1.4.0 shapely=1.6.4" >> $GITHUB_ENV
+          echo "PACKAGES=cython=0.29.15 matplotlib-base=3.2.1 numpy=1.19 owslib=0.19.1 pyproj=3.0 scipy=1.4.0 shapely=1.6.4" >> $GITHUB_ENV
 
       - name: Latest packages
         if: steps.minimum-packages.conclusion == 'skipped'
         run: |
-          echo "PACKAGES=cython fiona matplotlib-base numpy pyproj 'proj>=8' pykdtree scipy shapely" >> $GITHUB_ENV
+          echo "PACKAGES=cython fiona matplotlib-base numpy pyproj pykdtree scipy shapely" >> $GITHUB_ENV
 
       - name: Coverage packages
         id: coverage

--- a/INSTALL
+++ b/INSTALL
@@ -70,7 +70,7 @@ _______________
 
 On Debian, you can install the required system libraries using the system package manager::
 
-    sudo apt -y install libproj-dev libgeos-dev
+    sudo apt -y install libgeos-dev
 
 Then you can proceed to install cartopy using a python package manager::
 
@@ -81,7 +81,7 @@ _____
 
 For macOS, the required dependencies can be installed in the following way::
 
-    brew install proj geos
+    brew install geos
     pip3 install --upgrade pyshp
     # shapely needs to be built from source to link to geos. If it is already
     # installed, uninstall it by: pip3 uninstall shapely
@@ -123,9 +123,6 @@ Further information about the required dependencies can be found here:
 
 **pyshp** 2.1 or later (https://pypi.python.org/pypi/pyshp)
     Pure Python read/write support for ESRI Shapefile format.
-
-**PROJ** 8.0.0 or later (https://proj.org/)
-    Coordinate transformation library.
 
 **pyproj** 3.0.0 or later (https://github.com/pyproj4/pyproj/)
     Python interface to PROJ (cartographic projections and coordinate transformations library).

--- a/environment.yml
+++ b/environment.yml
@@ -14,8 +14,6 @@ dependencies:
   - geos>=3.7.2
   - pyshp>=2.1
   - pyproj>=3.0.0
-  # PROJ is still required for now
-  - proj>=8
   # The testing label has the proper version of freetype included
   - conda-forge/label/testing::matplotlib-base>=3.1
 

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -35,7 +35,6 @@ except ImportError:
 
 __document_these__ = ['CRS', 'Geocentric', 'Geodetic', 'Globe']
 
-PROJ_VERSION = cartopy.trace.PROJ_VERSION
 WGS84_SEMIMAJOR_AXIS = 6378137.0
 WGS84_SEMIMINOR_AXIS = 6356752.3142
 

--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -54,19 +54,8 @@ import warnings
 
 import shapely.geometry as sgeom
 from shapely.geos import lgeos
-from pyproj import Geod, Transformer, proj_version_str
+from pyproj import Geod, Transformer
 from pyproj.exceptions import ProjError
-
-
-_match = re.search(r"\d+\.\d+.\d+", proj_version_str)
-if _match is not None:
-    PROJ_VERSION = tuple(int(v) for v in _match.group().split('.'))
-    if PROJ_VERSION < (8, 0, 0):
-        warnings.warn(
-            "PROJ 8+ is required. Current version: {}".format(proj_version_str)
-        )
-else:
-    PROJ_VERSION = ()
 
 
 cdef GEOSContextHandle_t get_geos_context_handle():

--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -49,33 +49,12 @@ cdef extern from "geos_c.h":
     void GEOSPreparedGeom_destroy_r(GEOSContextHandle_t handle, const GEOSPreparedGeometry* g) nogil
     cdef int GEOS_MULTILINESTRING
 
-cdef extern from "geodesic.h":
-    # External imports of Proj4.9 functions
-    cdef struct geod_geodesic:
-        pass
-    cdef struct geod_geodesicline:
-        pass
-
-    void geod_init(geod_geodesic*, double, double) nogil
-    double geod_geninverse(geod_geodesic*, double, double, double, double,
-                           double*, double*, double*, double*, double*,
-                           double*, double*) nogil
-    void geod_lineinit(geod_geodesicline*, geod_geodesic*, double, double,
-                       double, int) nogil
-    void geod_genposition(geod_geodesicline*, int, double, double*,
-                          double*, double*, double*, double*, double*,
-                          double*, double*) nogil
-
-    cdef int GEOD_ARCMODE
-    cdef int GEOD_LATITUDE
-    cdef int GEOD_LONGITUDE
-
 import re
 import warnings
 
 import shapely.geometry as sgeom
 from shapely.geos import lgeos
-from pyproj import Transformer, proj_version_str
+from pyproj import Geod, Transformer, proj_version_str
 from pyproj.exceptions import ProjError
 
 
@@ -251,9 +230,9 @@ cdef class CartesianInterpolator(Interpolator):
 
 
 cdef class SphericalInterpolator(Interpolator):
-    cdef geod_geodesic geod
-    cdef geod_geodesicline geod_line
-    cdef double a13
+    cdef object geod
+    cdef double azim
+    cdef double s12
 
     cdef void init(self, src_crs, dest_crs) except *:
         self.transformer = Transformer.from_crs(src_crs, dest_crs, always_xy=True)
@@ -262,23 +241,16 @@ cdef class SphericalInterpolator(Interpolator):
         cdef double flattening = 0
         if src_crs.ellipsoid.inverse_flattening > 0:
             flattening = 1 / src_crs.ellipsoid.inverse_flattening
-        geod_init(&self.geod, major_axis, flattening)
+        self.geod = Geod(a=major_axis, f=flattening)
 
     cdef void set_line(self, const Point &start, const Point &end):
-        cdef double azi1
-        self.a13 = geod_geninverse(&self.geod,
-                                   start.y, start.x, end.y, end.x,
-                                   NULL, &azi1, NULL, NULL, NULL, NULL, NULL)
-        geod_lineinit(&self.geod_line, &self.geod, start.y, start.x, azi1,
-                      GEOD_LATITUDE | GEOD_LONGITUDE);
+        Interpolator.set_line(self, start, end)
+        self.azim, _, self.s12 = self.geod.inv(start.x, start.y, end.x, end.y)
 
     cdef Point interpolate(self, double t) except *:
         cdef Point lonlat
 
-        geod_genposition(&self.geod_line, GEOD_ARCMODE, self.a13 * t,
-                         &lonlat.y, &lonlat.x, NULL, NULL, NULL, NULL, NULL,
-                         NULL)
-
+        lonlat.x, lonlat.y, _ = self.geod.fwd(self.start.x, self.start.y, self.azim, self.s12 * t)
         return self.project(lonlat)
 
 


### PR DESCRIPTION
This is @QuLogic's work in the first commit, and removes the last remaining remnants of PROJ required for installation. I removed all the mentions of the library and requirements in the second commit.

This will likely be slower (only with geodesic calculations), similar to the previous move to pyproj in v0.20, but I think it will greatly simplify the installation, making up for the loss in speed and moving us one step closer to building wheels...