### PR TITLE
Use contextlib.ExitStack in more places

### DIFF
--- a/lib/cartopy/tests/mpl/conftest.py
+++ b/lib/cartopy/tests/mpl/conftest.py
@@ -3,22 +3,23 @@
 # This file is part of Cartopy and is released under the LGPL license.
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
+from contextlib import ExitStack
+
 import matplotlib.pyplot as plt
 import pytest
 
 
 @pytest.fixture(autouse=True)
 def mpl_test_cleanup(request):
-    """Runs tests in a context manager and closes figures after each test"""
-    try:
+    """Run tests in a context manager and close figures after each test."""
+    with ExitStack() as stack:
+        # At exit, close all open figures and switch backend back to original.
+        stack.callback(plt.switch_backend, plt.get_backend())
+
         # Run each test in a context manager so that state does not leak out
-        orig_backend = plt.get_backend()
         plt.switch_backend('Agg')
-        with plt.rc_context():
-            yield
-    finally:
-        # Closes all open figures and switches backend back to original
-        plt.switch_backend(orig_backend)
+        stack.enter_context(plt.rc_context())
+        yield
 
 
 def pytest_itemcollected(item):


### PR DESCRIPTION
## Rationale

Less manual `try`/`finally`

## Implications