### PR TITLE
Fix Axes clearing with Matplotlib 3.6+

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -575,9 +575,8 @@ class GeoAxes(matplotlib.axes.Axes):
     def __str__(self):
         return '< GeoAxes: %s >' % self.projection
 
-    def cla(self):
-        """Clear the current axes and adds boundary lines."""
-        result = super().cla()
+    def __clear(self):
+        """Clear the current axes and add boundary lines."""
         self.xaxis.set_visible(False)
         self.yaxis.set_visible(False)
         # Enable tight autoscaling.
@@ -593,7 +592,18 @@ class GeoAxes(matplotlib.axes.Axes):
         self.dataLim.intervalx = self.projection.x_limits
         self.dataLim.intervaly = self.projection.y_limits
 
-        return result
+    if mpl.__version__ >= '3.6':
+        def clear(self):
+            """Clear the current Axes and add boundary lines."""
+            result = super().clear()
+            self.__clear()
+            return result
+    else:
+        def cla(self):
+            """Clear the current Axes and add boundary lines."""
+            result = super().cla()
+            self.__clear()
+            return result
 
     def format_coord(self, x, y):
         """

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -9,7 +9,6 @@ import types
 
 import numpy as np
 import matplotlib.pyplot as plt
-import matplotlib.cm as cm
 import matplotlib.colors as colors
 from PIL import Image
 import pytest
@@ -143,7 +142,7 @@ def test_imshow_rgba():
     # tests that the alpha of a RGBA array passed to imshow is set to 0
     # instead of masked
     z = np.full((100, 100), 0.5)
-    cmap = cm.get_cmap()
+    cmap = plt.get_cmap()
     norm = colors.Normalize(vmin=0, vmax=1)
     z1 = cmap(norm(z))
     plt_crs = ccrs.LambertAzimuthalEqualArea()

--- a/lib/cartopy/tests/mpl/test_pseudo_color.py
+++ b/lib/cartopy/tests/mpl/test_pseudo_color.py
@@ -92,7 +92,7 @@ def test_pcolormesh_datalim():
     # Z with the same shape as X/Y to force the interpolation
     z = np.zeros(xs.shape)
 
-    ax = plt.subplot(2, 1, 1, projection=ccrs.PlateCarree())
+    ax = plt.subplot(3, 1, 1, projection=ccrs.PlateCarree())
     coll = ax.pcolormesh(xs, ys, z, shading='auto',
                          transform=ccrs.PlateCarree())
 
@@ -104,7 +104,7 @@ def test_pcolormesh_datalim():
     y = [-10, 10]
 
     xs, ys = np.meshgrid(x, y)
-    ax = plt.subplot(2, 1, 1, projection=ccrs.PlateCarree())
+    ax = plt.subplot(3, 1, 2, projection=ccrs.PlateCarree())
     coll = ax.pcolormesh(xs, ys, z, shading='auto',
                          transform=ccrs.PlateCarree())
 
@@ -116,7 +116,7 @@ def test_pcolormesh_datalim():
     y = [-10, 10]
 
     xs, ys = np.meshgrid(x, y)
-    ax = plt.subplot(2, 1, 1, projection=ccrs.Orthographic())
+    ax = plt.subplot(3, 1, 3, projection=ccrs.Orthographic())
     coll = ax.pcolormesh(xs, ys, z, shading='auto',
                          transform=ccrs.PlateCarree())
 


### PR DESCRIPTION
## Rationale

Matplotlib 3.6 expired the `cla`/`clear` alias, so `GeoAxes` were not being correctly cleared with Matplotlib 3.6.

## Implications

Plots don't get spectacularly broken.