### PR TITLE
FIX: change deprecated map_projection in test suite

### DIFF
--- a/lib/cartopy/tests/mpl/test_axes.py
+++ b/lib/cartopy/tests/mpl/test_axes.py
@@ -113,7 +113,7 @@ class Test_Axes_add_geometries:
         # A single geometry is acceptable
         proj = ccrs.PlateCarree()
         ax = GeoAxes(plt.figure(), [0, 0, 1, 1],
-                     map_projection=proj)
+                     projection=proj)
         ax.add_geometries(next(cfeature.COASTLINE.geometries()), crs=proj)
 
 


### PR DESCRIPTION
Looks like this test also needed to be updated to remove the internal warning after PR: https://github.com/SciTools/cartopy/pull/1980