### PR TITLE
DOC: What's new for v0.21 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ deps-run: &deps-install
         pyshp \
         scipy \
         setuptools_scm \
-        shapely \
+        'shapely<2' \
         $EXTRA_PACKAGES \
         --file docs/doc-requirements.txt
     conda list -n test-environment

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Latest packages
         if: steps.minimum-packages.conclusion == 'skipped'
         run: |
-          echo "PACKAGES=cython fiona matplotlib-base numpy pyproj pykdtree scipy shapely" >> $GITHUB_ENV
+          echo "PACKAGES=cython fiona matplotlib-base numpy pyproj pykdtree scipy shapely<2" >> $GITHUB_ENV
 
       - name: Coverage packages
         id: coverage
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: |
           PACKAGES="$PACKAGES owslib pep8 pillow pyshp pytest pytest-mpl!=0.16.0"
-          PACKAGES="$PACKAGES pytest-xdist setuptools_scm shapely"
+          PACKAGES="$PACKAGES pytest-xdist setuptools_scm shapely<2"
           conda install $PACKAGES
           conda info -a
           conda list

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           PACKAGES="cython fiona matplotlib-base numpy pyproj pykdtree scipy"
           PACKAGES="$PACKAGES owslib pep8 pillow pyshp pytest"
-          PACKAGES="$PACKAGES pytest-xdist setuptools_scm shapely"
+          PACKAGES="$PACKAGES pytest-xdist setuptools_scm shapely<2"
           conda install $PACKAGES
 
       - name: Create sdist

--- a/INSTALL
+++ b/INSTALL
@@ -85,7 +85,7 @@ For macOS, the required dependencies can be installed in the following way::
     pip3 install --upgrade pyshp
     # shapely needs to be built from source to link to geos. If it is already
     # installed, uninstall it by: pip3 uninstall shapely
-    pip3 install shapely --no-binary shapely
+    pip3 install "shapely<2" --no-binary shapely
 
 Still on macOS, make sure you have installed pkg-config and set the
 `PKG_CONFIG_PATH` environment variable as follows::
@@ -117,7 +117,7 @@ Further information about the required dependencies can be found here:
     GEOS is an API of spatial predicates and functions for processing geometry
     written in C++.
 
-**Shapely** 1.6.4 or later (https://github.com/Toblerity/Shapely)
+**Shapely** between 1.6.4 and 1.8.4 (https://github.com/Toblerity/Shapely)
     Python package for the manipulation and analysis of planar geometric
     objects.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -371,10 +371,10 @@ intersphinx_mapping = {
 
 ############ extlinks extension ############
 extlinks = {'issues': ('https://github.com/SciTools/cartopy/labels/%s',
-                      'issues labeled with '),
+                       'issues labeled with %s'),
             'issue': ('https://github.com/SciTools/cartopy/issues/%s',
-                      'Issue #'),
-            'pull': ('https://github.com/SciTools/cartopy/pull/%s', 'PR #'),
+                      'Issue #%s'),
+            'pull': ('https://github.com/SciTools/cartopy/pull/%s', 'PR #%s'),
             }
 
 

--- a/docs/source/whatsnew/index.rst
+++ b/docs/source/whatsnew/index.rst
@@ -14,6 +14,7 @@ Versions
 .. toctree::
    :maxdepth: 2
 
+   v0.21
    v0.20
    v0.19
    v0.18

--- a/docs/source/whatsnew/v0.21.rst
+++ b/docs/source/whatsnew/v0.21.rst
@@ -1,0 +1,133 @@
+Version 0.21 (September XXX, 2022)
+==================================
+
+For a full list of included Pull Requests and closed Issues, please see the
+`0.21 milestone <https://github.com/SciTools/cartopy/milestone/30>`_.
+
+Features
+--------
+
+* The requirement to install with a local PROJ installation has been removed.
+  The previous C PROJ library calls have been replaced by pyproj.
+  (:pull:`2069`)
+
+* Many test improvements, including moving to pytest-mpl for image comparisons
+  and parametrizing many tests where possible.
+  (:pull:`1887`, :pull:`1891`, :pull:`1900`)
+
+* The UTF8 degree symbol is now used for latitude and longitude labels.
+  (:pull:`1885`)
+
+* Clément fixed an issue that would ignore the alpha channel when
+  reprojecting RGBA images. (:pull:`1906`)
+
+    .. plot::
+       :width: 400pt
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import cartopy.crs as ccrs
+
+        dy, dx = (4, 10)
+        rgba = np.linspace(0, 255*31, dx*dy*4, dtype=np.uint8).reshape((dy, dx, 4))
+        rgba[:, :, 3]  = np.linspace(0, 255, dx, dtype=np.uint8).reshape(1, dx)
+
+        fig = plt.figure(figsize=(10, 5))
+        ax = plt.axes(projection=ccrs.Orthographic(central_latitude=45))
+        ax.imshow(rgba, transform=ccrs.PlateCarree())
+
+        plt.show()
+
+* Filled features no longer set the edgecolor by default. The edgecolor can
+  still be explicitly set when adding the feature
+  ``ax.add_feature(LAND, edgecolor='k')``. (:pull:`1933`)
+
+* The **approx** keyword to TransverseMercator, OSGB, and OSNI projections
+  now defaults to False. (:pull:`1957`)
+
+* ``geoaxes.add_geometries()`` now accepts both a list of geometries and a
+  single geometry. (:pull:`1999`)
+
+* Better handling of non-ndarray inputs like ``xarray.DataArray``.
+  (:pull:`2050`)
+
+* Alan Brammer added the ability to pass CRS's for the text and xy coordinates
+  used in ``ax.annotate()``. (:pull:`2065`)
+
+    .. plot::
+       :width: 400pt
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import cartopy.crs as ccrs
+
+        map_projection = ccrs.InterruptedGoodeHomolosine()
+
+        fig = plt.figure(figsize=(10, 5))
+        ax = fig.add_subplot(1, 1, 1, projection=map_projection)
+        ax.set_global()
+        ax.coastlines()
+        arrowprops = {'facecolor': 'red',
+                      'arrowstyle': "-|>",
+                      'connectionstyle': "arc3,rad=-0.2",
+                      }
+        platecarree = ccrs.PlateCarree()
+        mpltransform = platecarree._as_mpl_transform(ax)
+
+        ax.annotate('mpl xycoords', (-45, 43), xycoords=mpltransform,
+                    size=5)
+
+        # Add annotation with xycoords as projection
+        ax.annotate('crs xycoords', (-75, 13), xycoords=platecarree,
+                    size=5)
+
+        # set up coordinates in map projection space
+        map_coords = map_projection.transform_point(-175, -35, platecarree)
+        # Dont specifiy any args, default xycoords='data', transform=map projection
+        ax.annotate('default crs', map_coords, size=5)
+
+        # data in map projection using default transform, with
+        # text positioned in platecaree transform
+        ax.annotate('mixed crs transforms', map_coords, xycoords='data',
+                    xytext=(-175, -55),
+                    textcoords=platecarree,
+                    size=5,
+                    arrowprops=arrowprops,
+                    )
+
+        # Add annotation with point and text via transform
+        ax.annotate('crs transform', (-75, -20), xytext=(0, -55),
+                    transform=platecarree,
+                    arrowprops=arrowprops,
+                    )
+
+        # Add annotation with point via transform and text non transformed
+        ax.annotate('offset textcoords', (-149.8, 61.22), transform=platecarree,
+                    xytext=(-35, 10), textcoords='offset points',
+                    size=5,
+                    ha='right',
+                    arrowprops=arrowprops,
+                    )
+
+        plt.show()
+
+Deprecations
+------------
+
+* Passing **map_projection** as a keyword when manually creating a GeoAxes
+  object is deprecated, use **projection** instead.
+
+Removals
+--------
+
+The following functions and classes have been removed after being deprecated
+multiple versions prior. See the previous What's New notes for replacements.
+  
+* ``geoaxes.outline_patch()``
+* ``geoaxes.background_patch()``
+* ``geoaxes.natural_earth_shp()``
+* The argument ``secant_latitudes`` to the LambertConformal projection.
+* ``img_tiles.StamenTerrain``
+* ``srtm.SRTM3_retrieve``, ``srtm.srtm``, ``srtm.srtm_composite``, and
+  ``srtm.fill_gaps``
+* ``clip_path.clip_path``

--- a/docs/source/whatsnew/v0.21.rst
+++ b/docs/source/whatsnew/v0.21.rst
@@ -1,5 +1,8 @@
-Version 0.21 (September XXX, 2022)
-==================================
+Version 0.21 (September 9, 2022)
+================================
+
+Cartopy v0.21 is not compatible with Shapely 2.0, so this release
+has an upper pin on Shapely to avoid installing newer versions.
 
 For a full list of included Pull Requests and closed Issues, please see the
 `0.21 milestone <https://github.com/SciTools/cartopy/milestone/30>`_.

--- a/environment.yml
+++ b/environment.yml
@@ -4,13 +4,13 @@
 #   conda activate cartopy-dev
 #   pip install -e .
 #
-name: cartopy-dev
+name: cartopy-dev2
 channels:
   - conda-forge
 dependencies:
   - cython>=0.28.5
   - numpy>=1.18
-  - shapely>=1.6.4
+  - shapely>=1.6.4,<2
   - geos>=3.7.2
   - pyshp>=2.1
   - pyproj>=3.0.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
 numpy>=1.18
 matplotlib>=3.1
-shapely>=1.6.4
+shapely>=1.6.4,<2
 pyshp>=2.1
 pyproj>=3.0.0


### PR DESCRIPTION
Preparing for a new v0.21 release by adding a What's New page and documenting what was removed and deprecated in this version.

It doesn't look like we ever settled on moving the docs somewhere else (xref: https://github.com/SciTools/cartopy/issues/1765) , so we will likely have to manually upload them again.

NOTE: Date still needs to be added to the top of the page.