### PR TITLE
TST: Update test path search and pytest deprecations

### DIFF
--- a/lib/cartopy/tests/mpl/test_style.py
+++ b/lib/cartopy/tests/mpl/test_style.py
@@ -37,6 +37,7 @@ from cartopy.mpl import style
      ([dict(color=None), dict(facecolor='red')],
       dict(facecolor='red', edgecolor=None)),
      ([dict(linewidth=1), dict(lw=None)], dict(linewidth=None)),
+     ([dict(facecolor='never'), dict(fc='NoNe')], dict(facecolor='never')),
      ]
 )
 def test_merge(styles, expected):
@@ -44,14 +45,10 @@ def test_merge(styles, expected):
     assert merged_style == expected
 
 
-@pytest.mark.parametrize(
-    ('case', 'should_warn'),
-    [[{'fc': 'red'}, True], [{'fc': 'NoNe'}, False], [{'fc': 1}, True]])
-def test_merge_warning(case, should_warn):
-    warn_type = UserWarning if should_warn else None
-    with pytest.warns(warn_type, match=r'defined as \"never\"') as record:
+@pytest.mark.parametrize("case", [{'fc': 'red'}, {'fc': 1}])
+def test_merge_warning(case):
+    with pytest.warns(UserWarning, match=r'defined as \"never\"'):
         style.merge({'facecolor': 'never'}, case)
-    assert len(record) == (1 if should_warn else 0)
 
 
 @pytest.mark.parametrize(

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,5 @@ exclude = \
 
 [tool:pytest]
 addopts = --mpl
+testpaths = lib
+python_files = test_*.py


### PR DESCRIPTION
Explicitly put the search paths in for pytest so we don't find
other potential files with test in the name.

`pytest.warns(None)` is deprecated, so rearrange the test that was using that.