### PR TITLE
Calculate vertical coord, even if not explicitely requested

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -48,7 +48,8 @@ def _get_transformer_from_crs(src_crs, tgt_crs):
 def _safe_pj_transform(src_crs, tgt_crs, x, y, z=None, trap=True):
     transformer = _get_transformer_from_crs(src_crs, tgt_crs)
 
-    # if a projection is essentially 2d there should be no harm in setting its z to 0
+    # if a projection is essentially 2d there
+    # should be no harm in setting its z to 0
     if z is None:
         z = np.zeros_like(x)
 

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -47,13 +47,12 @@ def _get_transformer_from_crs(src_crs, tgt_crs):
 
 def _safe_pj_transform(src_crs, tgt_crs, x, y, z=None, trap=True):
     transformer = _get_transformer_from_crs(src_crs, tgt_crs)
-    transformed_coords = transformer.transform(x, y, z, errcheck=trap)
+
+    # if a projection is essentially 2d there should be no harm in setting its z to 0
     if z is None:
-        xx, yy = transformed_coords
-        zz = 0
-    else:
-        xx, yy, zz = transformed_coords
-    return xx, yy, zz
+        z = np.zeros_like(x)
+
+    return transformer.transform(x, y, z, errcheck=trap)
 
 
 class Globe:

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -303,8 +303,7 @@ def test_transform_points_outside_domain():
     crs = ccrs.Orthographic()
     result = crs.transform_points(ccrs.PlateCarree(),
                                   np.array([-120]), np.array([80]))
-    assert np.all(np.isnan(result[..., :2]))
-    assert result[..., -1] == 0
+    assert np.all(np.isnan(result))
     result = crs.transform_points(ccrs.PlateCarree(),
                                   np.array([-120]), np.array([80]),
                                   trap=True)


### PR DESCRIPTION
Compute and return vertical coordinate `z` even if the input coordinates contain only x,y, and `z=None`. This covers the transformation from lat/lon coordinates to the 3d spatial coordinates with the origin at the Earth's center.

For this assume that `z=0` for all 2d inputs.

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Fixes: #2032

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
I guess this might slow down the code slightly in cases when the z coordinate is not needed, but it should be really minimal.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
