### PR TITLE
Remove Google Group link

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,3 +1,5 @@
  * Ask usage questions on [StackOverflow](https://stackoverflow.com/questions/tagged/cartopy).
+ * For less well defined questions, ideas, general discussion or announcements of related projects use the
+  [Cartopy category on Matplotlib's Discourse](https://discourse.matplotlib.org/c/3rdparty/cartopy/19).
  * Report bugs, suggest features or view the source code on [GitHub](https://github.com/SciTools/cartopy).
  * To chat with developers and other users you can use the [Gitter Chat](https://gitter.im/SciTools/cartopy).

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,3 +1,3 @@
  * Ask usage questions on [StackOverflow](https://stackoverflow.com/questions/tagged/cartopy).
- * For less well defined questions, ideas, general discussion or announcements of related projects use the [Google Group](https://groups.google.com/forum/#!forum/scitools-iris).
  * Report bugs, suggest features or view the source code on [GitHub](https://github.com/SciTools/cartopy).
+ * To chat with developers and other users you can use the [Gitter Chat](https://gitter.im/SciTools/cartopy)

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,3 +1,3 @@
  * Ask usage questions on [StackOverflow](https://stackoverflow.com/questions/tagged/cartopy).
  * Report bugs, suggest features or view the source code on [GitHub](https://github.com/SciTools/cartopy).
- * To chat with developers and other users you can use the [Gitter Chat](https://gitter.im/SciTools/cartopy)
+ * To chat with developers and other users you can use the [Gitter Chat](https://gitter.im/SciTools/cartopy).

--- a/README.md
+++ b/README.md
@@ -74,13 +74,10 @@ Documentation can be found at <https://scitools.org.uk/cartopy/docs/latest/>.
 
 - Ask usage questions on
   [StackOverflow](https://stackoverflow.com/questions/tagged/cartopy).
-- For less well defined questions, ideas, general discussion or announcements
-  of related projects use the
-  [Google Group](https://groups.google.com/forum/#!forum/scitools-iris).
 - Report bugs, suggest features or view the source code on
   [GitHub](https://github.com/SciTools/cartopy).
 - To chat with developers and other users you can use the
-  [Gitter Chat](https://gitter.im/SciTools/cartopy)
+  [Gitter Chat](https://gitter.im/SciTools/cartopy).
 
 
 ## Credits, copyright and license

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Documentation can be found at <https://scitools.org.uk/cartopy/docs/latest/>.
 
 - Ask usage questions on
   [StackOverflow](https://stackoverflow.com/questions/tagged/cartopy).
+- For less well defined questions, ideas, general discussion or announcements of
+  related projects use the
+  [Cartopy category on Matplotlib's Discourse](https://discourse.matplotlib.org/c/3rdparty/cartopy/19).
 - Report bugs, suggest features or view the source code on
   [GitHub](https://github.com/SciTools/cartopy).
 - To chat with developers and other users you can use the


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
The Google Group is not much used any more, and over in Iris we have been discussing retiring it (https://github.com/SciTools/iris/issues/3860).  Do you have any objections to that?  Iris have decided to use GitHub Discussions instead.  Possibly Cartopy doesn't need anything to replace it as there seems to be quite a lot of Cartopy activity on StackOverflow.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
One less place for users to ask questions, but also one less place that support people need to keep on top of.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
