### PR TITLE
Updated Ordnance Survey img_tile to new OS API

### DIFF
--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -577,8 +577,10 @@ class OrdnanceSurvey(GoogleWTS):
                          cache=cache)
         self.apikey = apikey
 
-        if layer not in ["Road_3857", "Outdoor_3857", "Light_3857"]:
+        if layer not in ("Road_3857", "Outdoor_3857", "Light_3857", "Road", "Outdoor", "Light"):
             raise ValueError(f'Invalid layer {layer}')
+        elif layer in ("Road", "Outdoor", "Light"):
+            layer += "_3857"
 
         self.layer = layer
 

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -543,15 +543,15 @@ class OrdnanceSurvey(GoogleWTS):
     """
     Implement web tile retrieval from Ordnance Survey map data.
     To use this tile image source you will need to obtain an
-    API key from Ordnance Survey.
+    API key from Ordnance Survey. You can get a free API key from https://osdatahub.os.uk
 
     For more details on Ordnance Survey layer styles, see
-    https://apidocs.os.uk/docs/map-styles.
+    https://osdatahub.os.uk/docs/wmts/technicalSpecification.
 
     For the API framework agreement, see
-    https://developer.ordnancesurvey.co.uk/os-api-framework-agreement.
+    https://osdatahub.os.uk/legal/apiTermsConditions.
     """
-    # API Documentation: https://apidocs.os.uk/docs/os-maps-wmts
+    # API Documentation: https://osdatahub.os.uk/docs/wmts/overview
 
     def __init__(self,
                  apikey,

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -555,7 +555,7 @@ class OrdnanceSurvey(GoogleWTS):
 
     def __init__(self,
                  apikey,
-                 layer='Road',
+                 layer='Road_3857',
                  desired_tile_form='RGB',
                  cache=False):
         """
@@ -577,19 +577,14 @@ class OrdnanceSurvey(GoogleWTS):
                          cache=cache)
         self.apikey = apikey
 
-        if layer not in ['Outdoor', 'Road', 'Light', 'Night', 'Leisure']:
+        if layer not in ["Road_3857", "Outdoor_3857", "Light_3857"]:
             raise ValueError(f'Invalid layer {layer}')
 
         self.layer = layer
 
     def _image_url(self, tile):
         x, y, z = tile
-        return (
-            f'https://api2.ordnancesurvey.co.uk/mapping_api/v1/service/wmts?'
-            f'key={self.apikey}&height=256&width=256&version=1.0.0&'
-            f'tilematrixSet=EPSG%3A3857&style=true&layer={self.layer}%203857&'
-            f'SERVICE=WMTS&REQUEST=GetTile&format=image%2Fpng&'
-            f'TileMatrix=EPSG%3A3857%3A{z}&TileRow={y}&TileCol={x}')
+        return f"https://api.os.uk/maps/raster/v1/zxy/{self.layer}/{z}/{x}/{y}.png?key={self.apikey}"
 
 
 def _merge_tiles(tiles):

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -543,7 +543,8 @@ class OrdnanceSurvey(GoogleWTS):
     """
     Implement web tile retrieval from Ordnance Survey map data.
     To use this tile image source you will need to obtain an
-    API key from Ordnance Survey. You can get a free API key from https://osdatahub.os.uk
+    API key from Ordnance Survey. You can get a free API key from
+    https://osdatahub.os.uk
 
     For more details on Ordnance Survey layer styles, see
     https://osdatahub.os.uk/docs/wmts/technicalSpecification.

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -577,7 +577,8 @@ class OrdnanceSurvey(GoogleWTS):
                          cache=cache)
         self.apikey = apikey
 
-        if layer not in ("Road_3857", "Outdoor_3857", "Light_3857", "Road", "Outdoor", "Light"):
+        if layer not in ("Road_3857", "Outdoor_3857", "Light_3857",
+                         "Road", "Outdoor", "Light"):
             raise ValueError(f'Invalid layer {layer}')
         elif layer in ("Road", "Outdoor", "Light"):
             layer += "_3857"
@@ -586,7 +587,8 @@ class OrdnanceSurvey(GoogleWTS):
 
     def _image_url(self, tile):
         x, y, z = tile
-        return f"https://api.os.uk/maps/raster/v1/zxy/{self.layer}/{z}/{x}/{y}.png?key={self.apikey}"
+        return f"https://api.os.uk/maps/raster/v1/zxy/" \
+               f"{self.layer}/{z}/{x}/{y}.png?key={self.apikey}"
 
 
 def _merge_tiles(tiles):

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -232,7 +232,7 @@ def test_ordnance_survey_tile_styles():
     assert url == ref_url.format(layer="Road_3857",
                                  z=tile[2], y=tile[1], x=tile[0])
 
-    for layer in ["Road_3857", "Light_3857", "Outdoor_3857", "Road", "Light"]:
+    for layer in ["Road_3857", "Light_3857", "Outdoor_3857", "Road", "Light", "Outdoor"]:
         os = cimgt.OrdnanceSurvey(dummy_apikey, layer=layer)
         url = os._image_url(tile)
         layer = layer if layer.endswith("_3857") else layer + "_3857"

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -222,21 +222,16 @@ def test_ordnance_survey_tile_styles():
     """
     dummy_apikey = "None"
 
-    ref_url = ('https://api2.ordnancesurvey.co.uk/'
-               'mapping_api/v1/service/wmts?'
-               'key=None&height=256&width=256&version=1.0.0&'
-               'tilematrixSet=EPSG%3A3857&style=true&layer={layer}%203857&'
-               'SERVICE=WMTS&REQUEST=GetTile&format=image%2Fpng&'
-               'TileMatrix=EPSG%3A3857%3A{z}&TileRow={y}&TileCol={x}')
+    ref_url = "https://api.os.uk/maps/raster/v1/zxy/{layer}/{z}/{x}/{y}.png?key=None"
     tile = ["1", "2", "3"]
 
-    # Default is Road.
+    # Default is Road_3857.
     os = cimgt.OrdnanceSurvey(dummy_apikey)
     url = os._image_url(tile)
-    assert url == ref_url.format(layer="Road",
+    assert url == ref_url.format(layer="Road_3857",
                                  z=tile[2], y=tile[1], x=tile[0])
 
-    for layer in ['Outdoor', 'Light', 'Night', 'Leisure']:
+    for layer in ["Road_3857", "Light_3857"]:
         os = cimgt.OrdnanceSurvey(dummy_apikey, layer=layer)
         url = os._image_url(tile)
         assert url == ref_url.format(layer=layer,

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -235,8 +235,9 @@ def test_ordnance_survey_tile_styles():
     for layer in ["Road_3857", "Light_3857", "Outdoor_3857", "Road", "Light"]:
         os = cimgt.OrdnanceSurvey(dummy_apikey, layer=layer)
         url = os._image_url(tile)
-        assert url == ref_url.format(layer=layer if layer.endswith("_3857")
-        else layer + "_3857", z=tile[2], y=tile[1], x=tile[0])
+        layer = layer if layer.endswith("_3857") else layer + "_3857"
+        assert url == ref_url.format(layer=layer,
+                                     z=tile[2], y=tile[1], x=tile[0])
 
     # Exception is raised if unknown style is passed.
     with pytest.raises(ValueError):

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -231,10 +231,10 @@ def test_ordnance_survey_tile_styles():
     assert url == ref_url.format(layer="Road_3857",
                                  z=tile[2], y=tile[1], x=tile[0])
 
-    for layer in ["Road_3857", "Light_3857"]:
+    for layer in ["Road_3857", "Light_3857", "Outdoor_3857", "Road", "Light"]:
         os = cimgt.OrdnanceSurvey(dummy_apikey, layer=layer)
         url = os._image_url(tile)
-        assert url == ref_url.format(layer=layer,
+        assert url == ref_url.format(layer=layer if layer.endswith("_3857") else layer+"_3857",
                                      z=tile[2], y=tile[1], x=tile[0])
 
     # Exception is raised if unknown style is passed.
@@ -251,8 +251,8 @@ def test_ordnance_survey_get_image():
     except KeyError:
         pytest.skip('ORDNANCE_SURVEY_API_KEY environment variable is unset.')
 
-    os1 = cimgt.OrdnanceSurvey(api_key, layer="Outdoor")
-    os2 = cimgt.OrdnanceSurvey(api_key, layer="Night")
+    os1 = cimgt.OrdnanceSurvey(api_key, layer="Outdoor_3857")
+    os2 = cimgt.OrdnanceSurvey(api_key, layer="Light_3857")
 
     tile = (500, 300, 10)
 

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -222,7 +222,8 @@ def test_ordnance_survey_tile_styles():
     """
     dummy_apikey = "None"
 
-    ref_url = "https://api.os.uk/maps/raster/v1/zxy/{layer}/{z}/{x}/{y}.png?key=None"
+    ref_url = "https://api.os.uk/maps/raster/v1/zxy/" \
+              "{layer}/{z}/{x}/{y}.png?key=None"
     tile = ["1", "2", "3"]
 
     # Default is Road_3857.
@@ -234,8 +235,8 @@ def test_ordnance_survey_tile_styles():
     for layer in ["Road_3857", "Light_3857", "Outdoor_3857", "Road", "Light"]:
         os = cimgt.OrdnanceSurvey(dummy_apikey, layer=layer)
         url = os._image_url(tile)
-        assert url == ref_url.format(layer=layer if layer.endswith("_3857") else layer+"_3857",
-                                     z=tile[2], y=tile[1], x=tile[0])
+        assert url == ref_url.format(layer=layer if layer.endswith("_3857") \
+            else layer+"_3857", z=tile[2], y=tile[1], x=tile[0])
 
     # Exception is raised if unknown style is passed.
     with pytest.raises(ValueError):

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -92,9 +92,9 @@ def test_google_wts():
     with pytest.raises(AssertionError):
         list(gt.find_images(target_domain, -1))
     assert (tuple(gt.find_images(target_domain, 0)) ==
-                 ((0, 0, 0),))
+            ((0, 0, 0),))
     assert (tuple(gt.find_images(target_domain, 2)) ==
-                 ((1, 1, 2), (2, 1, 2)))
+            ((1, 1, 2), (2, 1, 2)))
 
     assert (list(gt.subtiles((0, 0, 0))) ==
             [(0, 0, 1), (0, 1, 1), (1, 0, 1), (1, 1, 1)])
@@ -235,8 +235,8 @@ def test_ordnance_survey_tile_styles():
     for layer in ["Road_3857", "Light_3857", "Outdoor_3857", "Road", "Light"]:
         os = cimgt.OrdnanceSurvey(dummy_apikey, layer=layer)
         url = os._image_url(tile)
-        assert url == ref_url.format(layer=layer if layer.endswith("_3857") \
-            else layer+"_3857", z=tile[2], y=tile[1], x=tile[0])
+        assert url == ref_url.format(layer=layer if layer.endswith("_3857")
+        else layer + "_3857", z=tile[2], y=tile[1], x=tile[0])
 
     # Exception is raised if unknown style is passed.
     with pytest.raises(ValueError):
@@ -364,9 +364,9 @@ def test_cache(cache_dir, tmp_path):
     files = [i for i in os.listdir(cache_dir_res)]
     hashes = {
         f:
-        hashlib.md5(
-            np.load(os.path.join(cache_dir_res, f), allow_pickle=True).data
-        ).hexdigest()
+            hashlib.md5(
+                np.load(os.path.join(cache_dir_res, f), allow_pickle=True).data
+            ).hexdigest()
         for f in files
     }
 

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -232,7 +232,8 @@ def test_ordnance_survey_tile_styles():
     assert url == ref_url.format(layer="Road_3857",
                                  z=tile[2], y=tile[1], x=tile[0])
 
-    for layer in ["Road_3857", "Light_3857", "Outdoor_3857", "Road", "Light", "Outdoor"]:
+    for layer in ("Road_3857", "Light_3857", "Outdoor_3857",
+                  "Road", "Light", "Outdoor"):
         os = cimgt.OrdnanceSurvey(dummy_apikey, layer=layer)
         url = os._image_url(tile)
         layer = layer if layer.endswith("_3857") else layer + "_3857"


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
The Ordnance Survey API has been updated and refactored, breaking the original API that Cartopy used (#2036). Cartopy needs to be brought up to date with OS' newest APIs. 

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
The Ordnance Survey img tile should now work! 

The new api does not support the Night layer, and only supports Leisure for EPSG:27700. Therefore, these 2 map styles will no longer work with the new API in Cartopy (I only implemented support for EPSG:3857).

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
