### PR TITLE
TST: Use geom_type for Shapely geometry assertions

### DIFF
--- a/lib/cartopy/tests/mpl/__init__.py
+++ b/lib/cartopy/tests/mpl/__init__.py
@@ -17,7 +17,7 @@ def show(projection, geometry):
     orig_backend = mpl.get_backend()
     plt.switch_backend('tkagg')
 
-    if geometry.type == 'MultiPolygon' and 1:
+    if geometry.geom_type == 'MultiPolygon' and 1:
         multi_polygon = geometry
         for polygon in multi_polygon:
             import cartopy.mpl.patch as patch
@@ -29,20 +29,20 @@ def show(projection, geometry):
             line_string = polygon.exterior
             plt.plot(*zip(*line_string.coords),
                      marker='+', linestyle='-')
-    elif geometry.type == 'MultiPolygon':
+    elif geometry.geom_type == 'MultiPolygon':
         multi_polygon = geometry
         for polygon in multi_polygon:
             line_string = polygon.exterior
             plt.plot(*zip(*line_string.coords),
                      marker='+', linestyle='-')
 
-    elif geometry.type == 'MultiLineString':
+    elif geometry.geom_type == 'MultiLineString':
         multi_line_string = geometry
         for line_string in multi_line_string:
             plt.plot(*zip(*line_string.coords),
                      marker='+', linestyle='-')
 
-    elif geometry.type == 'LinearRing':
+    elif geometry.geom_type == 'LinearRing':
         plt.plot(*zip(*geometry.coords), marker='+', linestyle='-')
 
     if 1:

--- a/lib/cartopy/tests/test_shapereader.py
+++ b/lib/cartopy/tests/test_shapereader.py
@@ -29,7 +29,7 @@ class TestLakes:
 
     def test_geometry(self):
         lake_geometry = self.test_lake_geometry
-        assert lake_geometry.type == 'Polygon'
+        assert lake_geometry.geom_type == 'Polygon'
 
         # force an orientation due to potential reader differences
         # with pyshp 2.2.0 forcing a specific orientation.
@@ -89,7 +89,7 @@ class TestRivers:
 
     def test_geometry(self):
         geometry = self.test_river_geometry
-        assert geometry.type == 'LineString'
+        assert geometry.geom_type == 'LineString'
 
         linestring = geometry
         coords = linestring.coords


### PR DESCRIPTION
type has been deprecated in favor of geom_type in Shapely 2.0