### PR TITLE
Address test failures and remove some xfails

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -35,7 +35,7 @@ jobs:
         if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'
         id: minimum-packages
         run: |
-          echo "PACKAGES=cython=0.29.15 matplotlib-base=3.2.1 numpy=1.19 owslib=0.19.1 pyproj=3.0 scipy=1.4.0 shapely=1.6.4" >> $GITHUB_ENV
+          echo "PACKAGES=cython=0.29.15 matplotlib-base=3.2.1 numpy=1.19 owslib=0.20.0 pyproj=3.0 scipy=1.4.0 shapely=1.6.4" >> $GITHUB_ENV
 
       - name: Latest packages
         if: steps.minimum-packages.conclusion == 'skipped' && !matrix.shapely-dev

--- a/INSTALL
+++ b/INSTALL
@@ -147,7 +147,7 @@ to install these optional dependencies.
 **SciPy** 1.3.1 or later (https://www.scipy.org/)
     A Python package for scientific computing.
 
-**OWSLib** 0.18 (https://pypi.python.org/pypi/OWSLib)
+**OWSLib** 0.20 or later (https://pypi.python.org/pypi/OWSLib)
      A Python package for client programming with the Open Geospatial
      Consortium (OGC) web service, and which gives access to Cartopy ogc
      clients.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,8 +22,6 @@ import sys
 
 import cartopy
 import matplotlib
-import owslib
-from packaging.version import parse as parse_version
 from sphinx_gallery.sorting import ExampleTitleSortKey, ExplicitOrder
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -83,17 +81,6 @@ version = cartopy.__version__
 release = cartopy.__version__
 
 
-if (hasattr(owslib, '__version__') and
-        parse_version(owslib.__version__) >= parse_version('0.19.2')):
-    expected_failing_examples = []
-else:
-    # OWSLib WMTS support is broken.
-    expected_failing_examples = [
-        '../../examples/web_services/reprojected_wmts.py',
-        '../../examples/web_services/wmts.py',
-        '../../examples/web_services/wmts_time.py',
-    ]
-
 subsection_order = ExplicitOrder(['../../examples/lines_and_polygons',
                                   '../../examples/scalar_data',
                                   '../../examples/vector_data',
@@ -111,7 +98,6 @@ sphinx_gallery_conf = {
     'doc_module': ('cartopy',),
     'reference_url': {'cartopy': None},
     'backreferences_dir': '../build/backrefs',
-    'expected_failing_examples': expected_failing_examples,
     'subsection_order': subsection_order,
     'matplotlib_animations': True,
 }

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - conda-forge/label/testing::matplotlib-base>=3.1
 
   # OWS
-  - owslib>=0.18.0
+  - owslib>=0.20.0
   - pillow>=6.1.0
   # Plotting
   - gdal>=2.3.2

--- a/lib/cartopy/tests/io/test_ogc_clients.py
+++ b/lib/cartopy/tests/io/test_ogc_clients.py
@@ -5,6 +5,7 @@
 # licensing details.
 
 from unittest import mock
+from xml.etree.ElementTree import ParseError
 
 import numpy as np
 try:
@@ -229,6 +230,8 @@ class TestWFSGeometrySource:
         with pytest.raises(ValueError, match=msg):
             source.fetch_geometries(ccrs.PlateCarree(), [-180, 180, -90, 90])
 
+    @pytest.mark.xfail(raises=ParseError,
+                       reason="Bad XML returned from the URL")
     def test_fetch_geometries(self):
         source = ogc.WFSGeometrySource(self.URI, self.typename)
         # Extent covering New Zealand.

--- a/lib/cartopy/tests/io/test_ogc_clients.py
+++ b/lib/cartopy/tests/io/test_ogc_clients.py
@@ -127,7 +127,6 @@ class TestWMSRasterSource:
 @pytest.mark.filterwarnings("ignore:TileMatrixLimits")
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
-@pytest.mark.xfail(raises=KeyError, reason='OWSLib WMTS support is broken.')
 class TestWMTSRasterSource:
     URI = 'https://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi'
     layer_name = 'VIIRS_CityLights_2012'

--- a/lib/cartopy/tests/mpl/test_caching.py
+++ b/lib/cartopy/tests/mpl/test_caching.py
@@ -144,7 +144,6 @@ def test_contourf_transform_path_counting():
 @pytest.mark.filterwarnings("ignore:TileMatrixLimits")
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
-@pytest.mark.xfail(raises=KeyError, reason='OWSLib WMTS support is broken.')
 def test_wmts_tile_caching():
     image_cache = WMTSRasterSource._shared_image_cache
     image_cache.clear()

--- a/lib/cartopy/tests/mpl/test_features.py
+++ b/lib/cartopy/tests/mpl/test_features.py
@@ -3,6 +3,7 @@
 # This file is part of Cartopy and is released under the LGPL license.
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
+from xml.etree.ElementTree import ParseError
 
 import matplotlib.pyplot as plt
 import pytest
@@ -58,6 +59,8 @@ def test_gshhs():
 
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
+@pytest.mark.xfail(raises=ParseError,
+                   reason="Bad XML returned from the URL")
 @pytest.mark.mpl_image_compare(filename='wfs.png')
 def test_wfs():
     ax = plt.axes(projection=ccrs.OSGB(approx=True))

--- a/lib/cartopy/tests/mpl/test_web_services.py
+++ b/lib/cartopy/tests/mpl/test_web_services.py
@@ -14,7 +14,6 @@ from cartopy.io.ogc_clients import _OWSLIB_AVAILABLE
 @pytest.mark.filterwarnings("ignore:TileMatrixLimits")
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
-@pytest.mark.xfail(raises=KeyError, reason='OWSLib WMTS support is broken.')
 @pytest.mark.mpl_image_compare(filename='wmts.png', tolerance=0)
 def test_wmts():
     ax = plt.axes(projection=ccrs.PlateCarree())

--- a/lib/cartopy/tests/test_img_nest.py
+++ b/lib/cartopy/tests/test_img_nest.py
@@ -234,7 +234,7 @@ def test_nest(nest_from_config):
         assert ('aerial z1 test', img) in nest_z0_z1._ancestry[key]
 
     x1_y0_z1, = (img for img in z1.images
-                 if img.filename.endswith('z_1/x_1_y_0.png'))
+                 if img.filename.endswith('x_1_y_0.png'))
 
     assert (1, 0, 1) == _tile_from_img(x1_y0_z1)
 

--- a/lib/cartopy/tests/test_img_nest.py
+++ b/lib/cartopy/tests/test_img_nest.py
@@ -191,7 +191,6 @@ class RoundedImg(cimg_nest.Img):
         return extent, pix_size
 
 
-@pytest.mark.xfail(reason='MapQuest is unavailable')
 @pytest.mark.network
 def test_nest(nest_from_config):
     crs = cimgt.GoogleTiles().crs
@@ -338,7 +337,6 @@ def wmts_data():
             img.save(fname)
 
 
-@pytest.mark.xfail(reason='MapQuest is unavailable')
 @pytest.mark.network
 def test_find_images(wmts_data):
     z2_dir = os.path.join(_TEST_DATA_DIR, 'z_2')

--- a/requirements/ows.txt
+++ b/requirements/ows.txt
@@ -1,2 +1,2 @@
-OWSLib>=0.18.0
+OWSLib>=0.20.0
 pillow>=6.1.0


### PR DESCRIPTION
* Add an xfail when parsing bad XML for the two recent tests that are failing now.
* owslib 0.20 was released over two years ago now and fixed some of the reasons for test failures so we can remove some xfails that should always pass.