### PR TITLE
FIX: plot after contour shouldn't shrink extent

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1620,6 +1620,9 @@ class GeoAxes(matplotlib.axes.Axes):
         if bboxes:
             extent = mtransforms.Bbox.union(bboxes)
             self.dataLim.update_from_data_xy(extent.get_points(), ignore=False)
+            # Ensure newly set limits aren't ignored by subsequent plotting
+            # functions.
+            self.ignore_existing_data_limits = False
 
         self.autoscale_view()
 
@@ -1668,6 +1671,9 @@ class GeoAxes(matplotlib.axes.Axes):
         if bboxes:
             extent = mtransforms.Bbox.union(bboxes)
             self.dataLim.update_from_data_xy(extent.get_points(), ignore=False)
+            # Ensure newly set limits aren't ignored by subsequent plotting
+            # functions.
+            self.ignore_existing_data_limits = False
 
         self.autoscale_view()
 

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1619,10 +1619,7 @@ class GeoAxes(matplotlib.axes.Axes):
                   if col.get_paths()]
         if bboxes:
             extent = mtransforms.Bbox.union(bboxes)
-            self.dataLim.update_from_data_xy(extent.get_points(), ignore=False)
-            # Ensure newly set limits aren't ignored by subsequent plotting
-            # functions.
-            self.ignore_existing_data_limits = False
+            self.update_datalim(extent.get_points())
 
         self.autoscale_view()
 
@@ -1670,10 +1667,7 @@ class GeoAxes(matplotlib.axes.Axes):
                   if col.get_paths()]
         if bboxes:
             extent = mtransforms.Bbox.union(bboxes)
-            self.dataLim.update_from_data_xy(extent.get_points(), ignore=False)
-            # Ensure newly set limits aren't ignored by subsequent plotting
-            # functions.
-            self.ignore_existing_data_limits = False
+            self.update_datalim(extent.get_points())
 
         self.autoscale_view()
 

--- a/lib/cartopy/tests/mpl/test_contour.py
+++ b/lib/cartopy/tests/mpl/test_contour.py
@@ -54,6 +54,24 @@ def test_contour_doesnt_shrink():
     assert_array_almost_equal(ax.get_extent(), expected)
 
 
+@pytest.mark.parametrize('func', ['contour', 'contourf'])
+def test_plot_after_contour_doesnt_shrink(func):
+    xglobal = np.linspace(-180, 180)
+    yglobal = np.linspace(-90, 90.00001)
+
+    data = np.hypot(*np.meshgrid(xglobal, yglobal))
+
+    target_proj = ccrs.PlateCarree(central_longitude=200)
+    source_proj = ccrs.PlateCarree()
+
+    ax = plt.axes(projection=target_proj)
+    test_func = getattr(ax, func)
+    test_func(xglobal, yglobal, data, transform=source_proj)
+    ax.plot([10, 20], [20, 30], transform=source_proj)
+    expected = np.array([xglobal[0], xglobal[-1], yglobal[0], 90])
+    assert_array_almost_equal(ax.get_extent(), expected)
+
+
 def test_contour_linear_ring():
     """Test contourf with a section that only has 3 points."""
     ax = plt.axes([0.01, 0.05, 0.898, 0.85], projection=ccrs.Mercator(),


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Fixes #2128.

We already have the `ignore=False` within `update_from_data_xy` so that the contour call itself doesn't shrink the extent.  The equivalent line for `plot` is

https://github.com/matplotlib/matplotlib/blob/d731d48b2431da0cf8d7edaa687f997857b112af/lib/matplotlib/axes/_base.py#L2366-L2368

which relies on `ax.ignore_existing_data_limits` to decide whether to shrink.  Under normal circumstances, this flag is set within [update_datalim](https://github.com/matplotlib/matplotlib/blob/d731d48b2431da0cf8d7edaa687f997857b112af/lib/matplotlib/axes/_base.py#L2485-L2508), which is called by Matplotlib's `contour`.  However, for the combination of transform and invalid latitude in the linked issue, the `xys` that gets passed to `update_datalim` is all nans.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
