### PR TITLE
TST/FIX: Test for instance rather than string in class representation

### DIFF
--- a/lib/cartopy/tests/mpl/test_axes.py
+++ b/lib/cartopy/tests/mpl/test_axes.py
@@ -13,7 +13,8 @@ import pytest
 
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
-from cartopy.mpl.geoaxes import InterProjectionTransform, GeoAxes
+from cartopy.mpl.geoaxes import (
+    InterProjectionTransform, GeoAxes, GeoAxesSubplot)
 
 
 class TestNoSpherical:
@@ -119,7 +120,7 @@ class Test_Axes_add_geometries:
 
 def test_geoaxes_subplot():
     ax = plt.subplot(1, 1, 1, projection=ccrs.PlateCarree())
-    assert str(ax.__class__) == "<class 'cartopy.mpl.geoaxes.GeoAxesSubplot'>"
+    assert isinstance(ax, GeoAxesSubplot)
 
 
 @pytest.mark.mpl_image_compare(filename='geoaxes_subslice.png')


### PR DESCRIPTION
Testing with the pre-release MPL 3.7 wheel has added one new test failure.

Matplotlib has merged SubplotBase into AxesBase now, which makes the class string representation here GeoAxes now, even though we are still an _instance_ of `GeoAxesSubplot`.

xref: https://github.com/matplotlib/matplotlib/pull/23573

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
