### PR TITLE
DOC: Pin Sphinx less than version 6

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx<6
 sphinx-gallery
 beautifulsoup4
 pydata-sphinx-theme


### PR DESCRIPTION
Version 6 removed the logo, which sphinx-gallery is currently incompatible with. We should pin less than 6 until an updated release is out.
https://github.com/pydata/pydata-sphinx-theme/issues/1094

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
