### PR TITLE
fix identification of native_srs for wms services

### DIFF
--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -254,7 +254,7 @@ class WMSRasterSource(RasterSource):
             return None
         else:
             # If the native_srs was identified, check if it is provided
-            # by the service. If not return None to continue checking 
+            # by the service. If not return None to continue checking
             # for available fallback srs
             contents = self.service.contents
             native_OK = all(

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -247,7 +247,25 @@ class WMSRasterSource(RasterSource):
     def _native_srs(self, projection):
         # Return the SRS which corresponds to the given projection when
         # known, otherwise return None.
-        return _CRS_TO_OGC_SRS.get(projection)
+        native_srs = _CRS_TO_OGC_SRS.get(projection)
+
+        # If the native_srs could not be identified, return None
+        if native_srs is None:
+            return None
+        else:
+            # If the native_srs was identified, check if it is provided
+            # by the service. If not return None to continue checking 
+            # for available fallback srs
+            contents = self.service.contents
+            native_OK = all(
+                native_srs in contents[layer].crsOptions
+                for layer in self.layers
+            )
+
+            if native_OK:
+                return native_srs
+            else:
+                return None
 
     def _fallback_proj_and_srs(self):
         """


### PR DESCRIPTION
## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

While testing several WMS services for [EOmaps](https://github.com/raphaelquast/EOmaps) I realized that there is a flaw in the logic for identifying the "native_srs" of a WMS service:

Current logic:
- `native_srs = axes projection` if found in hardcoded `_CRS_TO_OGC_SRS` dict

Problem:
- In case the axes projection is found in `_CRS_TO_OGC_SRS` but the service **does not provide the used srs**, no search for fallback-srs is attempted and adding the wms will fail even if a fallback srs would have been available

Solution:
- If the axes projection is valid, only use it if it is actually provided by the service and otherwise continue checking for fallback srs


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

WMS services that do **not** provide the currently used axes projection will now attempt to reproject from available fallback projections even if the axes projection was provided in `_CRS_TO_OGC_SRS`.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
