### PR TITLE
CI: Update CircleCI conda python version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,8 @@ env-run: &env-setup
     conda config \
         --set always_yes yes \
         --set changeps1 no \
-        --set show_channel_urls yes
+        --set show_channel_urls yes \
+        --set auto_activate_base false
     conda config --add channels conda-forge
     conda create -n test-environment python=$PYTHON_VERSION
 
@@ -79,7 +80,7 @@ jobs:
       - run:
           <<: *env-setup
           environment:
-            PYTHON_VERSION: 3
+            PYTHON_VERSION: 3.11
       - run: *deps-install
       - run: *cp-install
 


### PR DESCRIPTION
## Rationale

It seems like CircleCI is trying to create a Pypy environment rather than a CPython environment, so try to explicitly set some more options.

https://app.circleci.com/pipelines/github/SciTools/cartopy/1225/workflows/5ee8fa8f-c6d9-4aea-be22-60c85b7af577/jobs/3227

```
The following packages will be DOWNGRADED:

  python                          3.11.0-he550d4f_1_cpython --> 3.9.16-0_73_pypy
```