### PR TITLE
add pre-commit.ci badge

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 ci:
+  autofix_prs: false
   autoupdate_schedule: 'quarterly'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
 ci:
-  autofix_prs: false
   autoupdate_schedule: 'quarterly'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@
  alt="zenodo" /></a>
 <a href="https://gitter.im/SciTools/cartopy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge">
 <img src="https://badges.gitter.im/SciTools/cartopy.svg" alt="Gitter Chat" /></a>
+<a href="https://results.pre-commit.ci/latest/github/SciTools/cartopy/main">
+<img src="https://results.pre-commit.ci/badge/github/SciTools/cartopy/main.svg"
+ alt="pre-commit.ci" /></a>
 </p>
 <br>
 

--- a/docs/source/reference/projections.rst
+++ b/docs/source/reference/projections.rst
@@ -615,5 +615,3 @@ SouthPolarStereo
     ax = plt.axes(projection=ccrs.SouthPolarStereo())
     ax.coastlines(resolution='110m')
     ax.gridlines()
-
-


### PR DESCRIPTION
This PR adds the `pre-commit.ci` badge to the `README.md` as a follow on to #1934 

Controversially, I've also removed the `autofix_prs` disable in the `.pre-commit-config.yaml` - totally happy to encourage debate on this choice.

Personally, the `pre-commit.ci` autofix does save the exact situation that we're initially in, where we banked a PR that wasn't compliant for all the git-hooks (#2146 - my bad, I should have rebased to include #1934 and the git hooks would have detected non-compliance locally).

Naively, I trust the hooks to do the "right thing" and auto-fix as part of the `pre-commit.ci` workflow. I'd love to hear the flip argument as to why we shouldn't adopt that pattern.