### PR TITLE
retire stickler-ci

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,3 +1,0 @@
-linters:
-    flake8:
-        python: 3

--- a/docs/source/reference/projections.rst
+++ b/docs/source/reference/projections.rst
@@ -615,5 +615,3 @@ SouthPolarStereo
     ax = plt.axes(projection=ccrs.SouthPolarStereo())
     ax.coastlines(resolution='110m')
     ax.gridlines()
-
-


### PR DESCRIPTION
This PR removes the `stickler-ci` service configuration, which isn't needed now that #1934 has landed and the [pre-commit-ci](https://results.pre-commit.ci/repo/github/5282596) is enabled.

For context, see this [comment](https://github.com/SciTools/cartopy/pull/2148#issuecomment-1465250382).

Once/If this PR is merged, I can disable the `stickler-ci` service... or do it pre-merge if we're happy to bank this PR change.