### PR TITLE
pre-commit: adopt sort-all hook

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@
 
 # format: spell checking (#2153)
 eb1dd508e087396948de5a3d20c5791500743ddf
+
+# style: sort __all__ statements (#2151)
+c00e0adae1b1e8695e173f4482369face82206ee

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,8 @@ repos:
     - id: codespell
       types_or: [python, markdown, rst]
       additional_dependencies: [tomli]
+  - repo: https://github.com/aio-libs/sort-all
+    rev: "v1.2.0"
+    hooks:
+      - id: sort-all
+        types: [file, python]

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -44,7 +44,7 @@ try:
 except ImportError:
     pass
 
-__all__ = ['Reader', 'Record']
+__all__ = ["Reader", "Record"]
 
 
 class Record:


### PR DESCRIPTION
This PR adds support for the [sort-all](https://github.com/aio-libs/sort-all) pre-commit git hook to enforce an opinionated sort order of `__all__` statements throughout the code-base.

Reference: https://github.com/SciTools/cartopy/pull/1934