### PR TITLE
pre-commit: adopt codespell hook

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # style: start of pre-commit and whitespace fixes
 16aba40dd09fb95c85fac1a0bee0f795b9f8b5fe
+
+# format: spell checking (#2153)
+eb1dd508e087396948de5a3d20c5791500743ddf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,19 @@ ci:
   autoupdate_schedule: 'quarterly'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: "v4.0.1"
     hooks:
       - id: check-added-large-files
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: "3.9.2"
     hooks:
       - id: flake8
+  - repo: https://github.com/codespell-project/codespell
+    rev: "v2.2.2"
+    hooks:
+    - id: codespell
+      types_or: [python, markdown, rst]
+      additional_dependencies: [tomli]

--- a/INSTALL
+++ b/INSTALL
@@ -160,7 +160,7 @@ These packages are required for the full Cartopy test suite to run.
     Python package for software testing.
 
 **pytest-mpl** 0.11 or later (https://github.com/matplotlib/pytest-mpl)
-    Pytest plugin to faciliate image comparison for Matplotlib figures
+    Pytest plugin to facilitate image comparison for Matplotlib figures
 
 **pep8** 1.3.3 or later (https://pypi.python.org/pypi/pep8)
     Python package for software testing.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -331,7 +331,7 @@ epub_copyright = '2012, Philip Elson, Richard Hattersley'
 # The format is a list of tuples containing the path and title.
 # epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 # epub_post_files = []
 

--- a/docs/source/whatsnew/v0.21.rst
+++ b/docs/source/whatsnew/v0.21.rst
@@ -86,7 +86,7 @@ Features
 
         # set up coordinates in map projection space
         map_coords = map_projection.transform_point(-175, -35, platecarree)
-        # Dont specifiy any args, default xycoords='data', transform=map projection
+        # Don't specify any args, default xycoords='data', transform=map projection
         ax.annotate('default crs', map_coords, size=5)
 
         # data in map projection using default transform, with

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -246,7 +246,7 @@ class _ViewClippedPathPatch(mpatches.PathPatch):
     def _adjust_location(self):
         if self.stale:
             self.set_path(self._original_path.clip_to_bbox(self.axes.viewLim))
-            # Some places in matplotlib's tranform stack cache the actual
+            # Some places in matplotlib's transform stack cache the actual
             # path so we trigger an update by invalidating the transform.
             self._trans_wrap.invalidate()
 

--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -238,7 +238,7 @@ class LatitudeFormatter(_PlateCarreeFormatter):
             suitable for most use cases. To control the appearance of
             tick labels use the *number_format* keyword.
         dms: bool, optional
-            Wether or not formatting as degrees-minutes-seconds and not
+            Whether or not formatting as degrees-minutes-seconds and not
             as decimal degrees.
         minute_symbol: str, optional
             The character(s) used to represent the minute symbol.
@@ -371,7 +371,7 @@ class LongitudeFormatter(_PlateCarreeFormatter):
             suitable for most use cases. To control the appearance of
             tick labels use the *number_format* keyword.
         dms: bool, optional
-            Wether or not formatting as degrees-minutes-seconds and not
+            Whether or not formatting as degrees-minutes-seconds and not
             as decimal degrees.
         minute_symbol: str, optional
             The character(s) used to represent the minute symbol.

--- a/lib/cartopy/tests/mpl/test_feature_artist.py
+++ b/lib/cartopy/tests/mpl/test_feature_artist.py
@@ -51,7 +51,7 @@ def mocked_axes(extent, projection=ccrs.PlateCarree()):
         figure=mock.sentinel.figure)
 
 
-# Need to initialize private renderer properties on the sentinal
+# Need to initialize private renderer properties on the sentinel
 mock.sentinel.renderer._raster_depth = 0
 mock.sentinel.renderer._rasterizing = False
 

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -870,7 +870,7 @@ def test_streamplot():
 @pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare()
 def test_annotate():
-    """ test a variety of annotate options on mulitple projections
+    """ test a variety of annotate options on multiple projections
 
     Annotate defaults to coords passed as if they're in map projection space.
     `transform` or `xycoords` & `textcoords` control the marker and text offset
@@ -905,7 +905,7 @@ def test_annotate():
 
     # set up coordinates in map projection space
     map_coords = map_projection.transform_point(-175, -35, platecarree)
-    # Dont specifiy any args, default xycoords='data', transform=map projection
+    # Don't specify any args, default xycoords='data', transform=map projection
     ax.annotate('default crs', map_coords, size=5)
 
     # data in map projection using default transform, with

--- a/lib/cartopy/tests/test_polygon.py
+++ b/lib/cartopy/tests/test_polygon.py
@@ -341,7 +341,7 @@ class PolygonTests:
 
 class TestWrap(PolygonTests):
     # Test that Plate Carree projection "does the right thing"(tm) with
-    # source data tha extends outside the [-180, 180] range.
+    # source data that extends outside the [-180, 180] range.
     def test_plate_carree_no_wrap(self):
         proj = ccrs.PlateCarree()
         poly = sgeom.box(0, 0, 10, 10)

--- a/lib/cartopy/tests/test_vector_transform.py
+++ b/lib/cartopy/tests/test_vector_transform.py
@@ -193,7 +193,7 @@ class Test_vector_scalar_to_grid:
 
     def test_with_scalar_field_non_ndarray_data(self):
         # Transform and regrid vector (with no projection transform) with an
-        # additional scalar field wich is not a ndarray.
+        # additional scalar field which is not a ndarray.
         expected_x_grid = np.array([[-10., -5., 0., 5., 10.],
                                     [-10., -5., 0., 5., 10.],
                                     [-10., -5., 0., 5., 10.]])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,7 @@ requires = [
     "setuptools_scm >= 7.0.0",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.codespell]
+ignore-words-list = "damon,koordinates,linz,slippy,subtiles,tring"
+skip = "./.git,./docs/build,./docs/source/gallery,./docs/source/reference,*.cpp,*.css,*.examples,*.js,*.html,*.ipynb,*.pdf,*.rst.txt"


### PR DESCRIPTION
This PR adds support for the [codespell](https://github.com/codespell-project/codespell) pre-commit git hook to enforce spell checking throughout the code-base.

Reference: https://github.com/SciTools/cartopy/pull/1934