### PR TITLE
update and add new pre-commit git-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,27 @@ ci:
   autoupdate_schedule: 'quarterly'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.0.1"
+    rev: "v4.4.0"
     hooks:
+        # Prevent giant files from being committed
       - id: check-added-large-files
+        # Check whether files parse as valid Python
+      - id: check-ast
+        # Check for files that contain merge conflict strings
+      - id: check-merge-conflict
+        # Attempts to load all TOML files to verify syntax
+      - id: check-toml
+        # Attempts to load all yaml files to verify syntax
+      - id: check-yaml
+        # Check for debugger imports and py37+ breakpoint() calls in python source
+      - id: debug-statements
+        # Makes sure files end in a newline and only a newline
       - id: end-of-file-fixer
+        # Replaces or checks mixed line ending
       - id: mixed-line-ending
+        # Protect specific branches from direct checkins (main)
+      - id: no-commit-to-branch
+        # Trims trailing whitespace
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/flake8
     rev: "3.9.2"


### PR DESCRIPTION
This PR updates the `pre-commit-hooks` version, includes some explanatory comments regarding the purpose of each hook, and adds some more sensible hooks to stop us from shooting ourselves in the foot. 