### PR TITLE
ENH: enable passing RGB(A) to polormesh

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1796,7 +1796,7 @@ class GeoAxes(matplotlib.axes.Axes):
         kwargs['shading'] = 'flat'
         X = np.asanyarray(args[0])
         Y = np.asanyarray(args[1])
-        nrows, ncols = np.asanyarray(args[2]).shape
+        nrows, ncols = np.asanyarray(args[2]).shape[:2]
         Nx = X.shape[-1]
         Ny = Y.shape[0]
         if X.ndim != 2 or X.shape[0] == 1:
@@ -1843,12 +1843,13 @@ class GeoAxes(matplotlib.axes.Axes):
         Ny, Nx, _ = coords.shape
         if kwargs.get('shading') == 'gouraud':
             # Gouraud shading has the same shape for coords and data
-            data_shape = Ny, Nx
+            data_shape = Ny, Nx, -1
         else:
-            data_shape = Ny - 1, Nx - 1
+            data_shape = Ny - 1, Nx - 1, -1
         # data array
         C = collection.get_array().reshape(data_shape)
-
+        if C.shape[-1] == 1:
+            C = C.squeeze(axis=-1)
         transformed_pts = self.projection.transform_points(
             t, coords[..., 0], coords[..., 1])
 

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -45,7 +45,8 @@ import cartopy.mpl.patch as cpatch
 from cartopy.mpl.slippy_image_artist import SlippyImageArtist
 
 
-assert packaging.version.parse(mpl.__version__).release[:2] >= (3, 4), \
+_MPL_VERSION = packaging.version.parse(mpl.__version__)
+assert _MPL_VERSION.release >= (3, 4), \
     'Cartopy is only supported with Matplotlib 3.4 or greater.'
 
 # A nested mapping from path, source CRS, and target projection to the
@@ -1922,13 +1923,12 @@ class GeoAxes(matplotlib.axes.Axes):
                           "map it must be fully transparent.",
                           stacklevel=3)
 
-        # The original data mask (regardless of wrapped cells)
-        C_mask = getattr(C, 'mask', None)
+        # Get hold of masked versions of the array to be passed to set_array
+        # methods of QuadMesh and PolyQuadMesh
+        pcolormesh_data, pcolor_data, pcolor_mask = \
+            cartopy.mpl.geocollection._split_wrapped_mesh_data(C, mask)
 
-        # create the masked array to be used with this pcolormesh
-        full_mask = mask if C_mask is None else mask | C_mask
-        pcolormesh_data = np.ma.array(C, mask=full_mask)
-        collection.set_array(pcolormesh_data.ravel())
+        collection.set_array(pcolormesh_data)
 
         # plot with slightly lower zorder to avoid odd issue
         # where the main plot is obscured
@@ -1944,25 +1944,32 @@ class GeoAxes(matplotlib.axes.Axes):
         # `pcolor` only draws polygons where the data is not
         # masked, so this will only draw a limited subset of
         # polygons that were actually wrapped.
-        # We will add the original data mask in later to
-        # make sure that set_array can work in future
-        # calls on the proper sized array inputs.
-        # NOTE: we don't use C.data here because C.data could
-        #       contain nan's which would be masked in the
-        #       pcolor routines, which we don't want. We will
-        #       fill in the proper data later with set_array()
-        #       calls.
-        pcolor_data = np.ma.array(np.zeros(C.shape),
-                                  mask=~mask)
-        pcolor_col = self.pcolor(coords[..., 0], coords[..., 1],
-                                 pcolor_data, zorder=zorder,
-                                 **kwargs)
-        # Now add back in the masked data if there was any
-        full_mask = ~mask if C_mask is None else ~mask | C_mask
-        pcolor_data = np.ma.array(C, mask=full_mask)
-        # The pcolor_col is now possibly shorter than the
-        # actual collection, so grab the masked cells
-        pcolor_col.set_array(pcolor_data[mask].ravel())
+
+        if _MPL_VERSION.release[:2] < (3, 8):
+            # We will add the original data mask in later to
+            # make sure that set_array can work in future
+            # calls on the proper sized array inputs.
+            # NOTE: we don't use C.data here because C.data could
+            #       contain nan's which would be masked in the
+            #       pcolor routines, which we don't want. We will
+            #       fill in the proper data later with set_array()
+            #       calls.
+            pcolor_zeros = np.ma.array(np.zeros(C.shape), mask=pcolor_mask)
+            pcolor_col = self.pcolor(coords[..., 0], coords[..., 1],
+                                     pcolor_zeros, zorder=zorder,
+                                     **kwargs)
+
+            # The pcolor_col is now possibly shorter than the
+            # actual collection, so grab the masked cells
+            pcolor_col.set_array(pcolor_data[mask].ravel())
+        else:
+            pcolor_col = self.pcolor(coords[..., 0], coords[..., 1],
+                                     pcolor_data, zorder=zorder,
+                                     **kwargs)
+            # Currently pcolor_col.get_array() will return a compressed array
+            # and warn unless we explicitly set the 2D array.  This should be
+            # unnecessary with future matplotlib versions.
+            pcolor_col.set_array(pcolor_data)
 
         pcolor_col.set_cmap(cmap)
         pcolor_col.set_norm(norm)
@@ -1973,7 +1980,7 @@ class GeoAxes(matplotlib.axes.Axes):
         # put the pcolor_col and mask on the pcolormesh
         # collection so that users can do things post
         # this method
-        collection._wrapped_mask = mask.ravel()
+        collection._wrapped_mask = mask
         collection._wrapped_collection_fix = pcolor_col
 
         return collection

--- a/lib/cartopy/mpl/geocollection.py
+++ b/lib/cartopy/mpl/geocollection.py
@@ -61,6 +61,8 @@ class GeoQuadMesh(QuadMesh):
             if _MPL_VERSION.release[:2] < (3, 8):
                 A[mask] = pcolor_data
             else:
+                if A.ndim == 3:  # RGB(A) data.  Need to broadcast mask.
+                    mask = mask[:, :, np.newaxis]
                 # np.copyto is not implemented for masked arrays so handle the
                 # mask explicitly
                 np.copyto(A.mask, pcolor_data.mask, where=mask)

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -310,7 +310,12 @@ def test_pcolormesh_get_array_with_mask():
 
     result = c.get_array()
     assert not np.ma.is_masked(result)
-    assert np.array_equal(data2.ravel(), result), \
+
+    expected = data2
+    if MPL_VERSION.release[:2] < (3, 8):
+        expected = expected.ravel()
+
+    assert np.array_equal(expected, result), \
         'Data supplied does not match data retrieved in unwrapped case'
 
 


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Since Matplotlib v3.7.0, `pcolormesh` accepts RGBA arrays
https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.7.0.html#pcolormesh-accepts-rgb-a-colors

Cartopy just needs a small tweak to be able to pass these down, and we can adapt [this StackOverflow question](https://stackoverflow.com/questions/70541279/how-to-pcolormesh-rgba-array-with-2d-x-and-y/75950850#75950850) to give

```python
import cartopy.crs as ccrs
import matplotlib.pyplot as plt
import numpy as np

np.random.seed(100)

x = np.arange(10, 20)
y = np.arange(0, 10)
x, y = np.meshgrid(x, y)

img = np.random.randint(low=0, high=255, size=(10, 10, 4)) / 255

projection = ccrs.Mollweide()
transform = ccrs.PlateCarree()
ax = plt.axes(projection=projection)
ax.set_global()
ax.coastlines()

ax.pcolormesh(np.linspace(0, 120, 11), np.linspace(0, 80, 11), img, transform=transform)

plt.show()
```
![test](https://user-images.githubusercontent.com/10599679/230419512-399fcac2-dd6a-4675-a76b-4db083bdbd6a.png)

Closes #2156 and I think also resolves #2045 and resolves #2171, as the request for `set_array` to handle `None` seems to be a workaround that is not needed since mpl 3.7.  I also note that the `None` handling [is not actually documented in `QuadMesh.set_array`](https://matplotlib.org/devdocs/api/collections_api.html#matplotlib.collections.QuadMesh.set_array).

This also adds test coverage for and fixes #2208.

~I'm not sure of the best way to test this.  Does it just need a smoke test of a `pcolormesh` plot with suitable data?~

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

-->
