### PR TITLE
MNT: bump python versions and dependency minimum versions

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11']
         shapely-dev: [false]
         include:
           - os: ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
       - name: Minimum packages
         # Only run on Linux for now
         # Conda's linux packages don't grab the testing label of matplotlib causing failures due to freetype differences
-        if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'
+        if: matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
         id: minimum-packages
         run: |
           echo "PACKAGES=cython=0.29.15 matplotlib-base=3.2.1 numpy=1.19 owslib=0.20.0 pyproj=3.0 proj=8.0 scipy=1.4.0 shapely=1.6.4" >> $GITHUB_ENV

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -11,11 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
         shapely-dev: [false]
         include:
           - os: ubuntu-latest
-            python-version: '3.10'
+            python-version: '3.11'
             shapely-dev: true
     defaults:
       run:
@@ -50,7 +50,7 @@ jobs:
       - name: Coverage packages
         id: coverage
         # only want the coverage to be run on the latest ubuntu
-        if: matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
+        if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
         run: |
           echo "PACKAGES=$PACKAGES pytest-cov coveralls" >> $GITHUB_ENV
           echo "CYTHON_COVERAGE=1" >> $GITHUB_ENV

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -35,7 +35,7 @@ jobs:
         if: matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
         id: minimum-packages
         run: |
-          echo "PACKAGES=cython=0.29.15 matplotlib-base=3.2.1 numpy=1.19 owslib=0.20.0 pyproj=3.0 proj=8.0 scipy=1.4.0 shapely=1.6.4" >> $GITHUB_ENV
+          echo "PACKAGES=cython=0.29.24 matplotlib-base=3.4 numpy=1.21 owslib=0.24.1 pyproj=3.1 proj=8.0 scipy=1.6.3 shapely=1.7.1" >> $GITHUB_ENV
 
       - name: Latest packages
         if: steps.minimum-packages.conclusion == 'skipped' && !matrix.shapely-dev

--- a/INSTALL
+++ b/INSTALL
@@ -109,7 +109,7 @@ Further information about the required dependencies can be found here:
 **Python** 3.9 or later (https://www.python.org/)
     Python 2 support was removed in v0.19.
 
-**Matplotlib** 3.2 or later (https://matplotlib.org/)
+**Matplotlib** 3.4 or later (https://matplotlib.org/)
     Python package for 2D plotting. Python package required for any
     graphical capabilities.
 
@@ -117,14 +117,14 @@ Further information about the required dependencies can be found here:
     GEOS is an API of spatial predicates and functions for processing geometry
     written in C++.
 
-**Shapely** 1.6.4 or later (https://github.com/Toblerity/Shapely)
+**Shapely** 1.7.1 or later (https://github.com/Toblerity/Shapely)
     Python package for the manipulation and analysis of planar geometric
     objects.
 
 **pyshp** 2.1 or later (https://pypi.python.org/pypi/pyshp)
     Pure Python read/write support for ESRI Shapefile format.
 
-**pyproj** 3.0.0 or later (https://github.com/pyproj4/pyproj/)
+**pyproj** 3.1.0 or later (https://github.com/pyproj4/pyproj/)
     Python interface to PROJ (cartographic projections and coordinate transformations library).
 
 Optional Dependencies
@@ -140,10 +140,10 @@ to install these optional dependencies.
     A fast kd-tree implementation that is used for faster warping
     of images than SciPy.
 
-**SciPy** 1.3.1 or later (https://www.scipy.org/)
+**SciPy** 1.6.3 or later (https://www.scipy.org/)
     A Python package for scientific computing.
 
-**OWSLib** 0.20 or later (https://pypi.python.org/pypi/OWSLib)
+**OWSLib** 0.24.1 or later (https://pypi.python.org/pypi/OWSLib)
      A Python package for client programming with the Open Geospatial
      Consortium (OGC) web service, and which gives access to Cartopy ogc
      clients.

--- a/INSTALL
+++ b/INSTALL
@@ -106,7 +106,7 @@ to the core packages.
 
 Further information about the required dependencies can be found here:
 
-**Python** 3.8 or later (https://www.python.org/)
+**Python** 3.9 or later (https://www.python.org/)
     Python 2 support was removed in v0.19.
 
 **Matplotlib** 3.2 or later (https://matplotlib.org/)

--- a/lib/cartopy/mpl/contour.py
+++ b/lib/cartopy/mpl/contour.py
@@ -40,16 +40,9 @@ class GeoContourSet(QuadContourSet):
             # list in-place (as the contour label code does in mpl).
             paths = col.get_paths()
 
-            # The ax attribute is deprecated in MPL 3.3 in favor of
-            # axes. So, here we test if axes is present and fall back
-            # on the old self.ax to support MPL versions less than 3.3
-            if hasattr(self, "axes"):
-                data_t = self.axes.transData
-            else:
-                data_t = self.ax.transData
-
             # Define the transform that will take us from collection
             # coordinates through to axes projection coordinates.
+            data_t = self.axes.transData
             col_to_data = col.get_transform() - data_t
 
             # Now that we have the transform, project all of this

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -32,6 +32,7 @@ import matplotlib.spines as mspines
 import matplotlib.transforms as mtransforms
 import numpy as np
 import numpy.ma as ma
+import packaging
 import shapely.geometry as sgeom
 
 from cartopy import config
@@ -44,7 +45,7 @@ import cartopy.mpl.patch as cpatch
 from cartopy.mpl.slippy_image_artist import SlippyImageArtist
 
 
-assert mpl.__version__ >= '3.4', \
+assert packaging.version.parse(mpl.__version__).release[:2] >= (3, 4), \
     'Cartopy is only supported with Matplotlib 3.4 or greater.'
 
 # A nested mapping from path, source CRS, and target projection to the

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -44,8 +44,8 @@ import cartopy.mpl.patch as cpatch
 from cartopy.mpl.slippy_image_artist import SlippyImageArtist
 
 
-assert mpl.__version__ >= '3.1', \
-    'Cartopy is only supported with Matplotlib 3.1 or greater.'
+assert mpl.__version__ >= '3.4', \
+    'Cartopy is only supported with Matplotlib 3.4 or greater.'
 
 # A nested mapping from path, source CRS, and target projection to the
 # resulting transformed paths:

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1783,9 +1783,7 @@ class GeoAxes(matplotlib.axes.Axes):
         Handle the interpolation when a wrap could be involved with
         the data coordinates before passing on to Matplotlib.
         """
-        # The shading keyword argument was added in MPL 3.3, so keep
-        # this default updating until we only support MPL>=3.3
-        default_shading = mpl.rcParams.get('pcolor.shading', 'auto')
+        default_shading = mpl.rcParams.get('pcolor.shading')
         if not (kwargs.get('shading', default_shading) in
                 ('nearest', 'auto') and len(args) == 3 and
                 getattr(kwargs.get('transform'), '_wrappable', False)):
@@ -1991,10 +1989,6 @@ class GeoAxes(matplotlib.axes.Axes):
         # Add in an argument checker to handle Matplotlib's potential
         # interpolation when coordinate wraps are involved
         args, kwargs = self._wrap_args(*args, **kwargs)
-        if matplotlib.__version__ < "3.3":
-            # MPL 3.3 introduced the shading option, and it isn't
-            # handled before that for pcolor calls.
-            kwargs.pop('shading', None)
         result = super().pcolor(*args, **kwargs)
 
         # Update the datalim for this pcolor.

--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -10,7 +10,6 @@ import warnings
 
 import matplotlib
 import matplotlib.collections as mcollections
-import matplotlib.path as mpath
 import matplotlib.ticker as mticker
 import matplotlib.transforms as mtrans
 import numpy as np
@@ -757,36 +756,17 @@ class Gridliner:
             specs['coords'] = [
                 getattr(bbox, specs['coord_type'] + idx) for idx in "01"]
 
-        def remove_path_dupes(path):
-            """
-            Remove duplicate points in a path (zero-length segments).
-
-            This is necessary only for Matplotlib 3.1.0 -- 3.1.2, because
-            Path.intersects_path incorrectly returns True for any paths with
-            such segments.
-            """
-            segment_length = np.diff(path.vertices, axis=0)
-            mask = np.logical_or.reduce(segment_length != 0, axis=1)
-            mask = np.append(mask, True)
-            path = mpath.Path(np.compress(mask, path.vertices, axis=0),
-                              np.compress(mask, path.codes, axis=0))
-            return path
-
         def update_artist(artist, renderer):
             artist.update_bbox_position_size(renderer)
             this_patch = artist.get_bbox_patch()
             this_path = this_patch.get_path().transformed(
                 this_patch.get_transform())
-            if '3.1.0' <= matplotlib.__version__ <= '3.1.2':
-                this_path = remove_path_dupes(this_path)
             return this_path
 
         # Get the real map boundaries
         self.axes.spines["geo"].get_window_extent(renderer)  # update coords
         map_boundary_path = self.axes.spines["geo"].get_path().transformed(
             self.axes.spines["geo"].get_transform())
-        if '3.1.0' <= matplotlib.__version__ <= '3.1.2':
-            map_boundary_path = remove_path_dupes(map_boundary_path)
         map_boundary = sgeom.Polygon(map_boundary_path.vertices)
 
         if self.x_inline:

--- a/lib/cartopy/tests/mpl/test_examples.py
+++ b/lib/cartopy/tests/mpl/test_examples.py
@@ -8,7 +8,6 @@ import matplotlib.pyplot as plt
 import pytest
 
 import cartopy.crs as ccrs
-from cartopy.tests.mpl import MPL_VERSION
 
 
 @pytest.mark.natural_earth
@@ -32,10 +31,7 @@ def test_global_map():
 
 
 @pytest.mark.natural_earth
-@pytest.mark.mpl_image_compare(filename='contour_label.png',
-                               tolerance=(9.9
-                                          if MPL_VERSION.release[:2] < (3, 3)
-                                          else 0.5))
+@pytest.mark.mpl_image_compare(filename='contour_label.png', tolerance=0.5)
 def test_contour_label():
     from cartopy.tests.mpl.test_caching import sample_data
     fig = plt.figure()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "wheel",
     "setuptools >= 40.6.0",
-    "Cython >= 0.29.13",
+    "Cython >= 0.29.24",
     "oldest-supported-numpy",
     "setuptools_scm >= 7.0.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -249,6 +249,7 @@ setup(
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: 3 :: Only',
             'Topic :: Scientific/Engineering',
             'Topic :: Scientific/Engineering :: GIS',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ if not IS_SDIST or FORCE_CYTHON:
 try:
     import numpy as np
 except ImportError:
-    raise ImportError('NumPy 1.19+ is required to install cartopy.')
+    raise ImportError('NumPy 1.21+ is required to install cartopy.')
 
 
 # Please keep in sync with INSTALL file.

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,11 @@
 import sys
 
 
-PYTHON_MIN_VERSION = (3, 8)
+PYTHON_MIN_VERSION = (3, 9)
 
 if sys.version_info < PYTHON_MIN_VERSION:
     error = """
-Beginning with Cartopy 0.21, Python {} or above is required.
+Beginning with Cartopy 0.22, Python {} or above is required.
 You are using Python {}.
 
 This may be due to an out of date pip.
@@ -246,7 +246,6 @@ setup(
             'Programming Language :: C++',
             'Programming Language :: Python',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Python 3.8 recently fell off the NEP29 schedule, so this PR removes testing with that and also adds it for python 3.11.
https://numpy.org/neps/nep-0029-deprecation_policy.html

I also bumped versions of other packages used in the minimum versions test as I assume bad things can happen if you bump the python version without doing this!  I wasn't sure exactly which versions to use here but mostly went for the oldest that is newer than 2 years.  For shapely it seemed safer to go with the older 1.7.1 (August 2020) as 1.8.x had many patch releases stretching into last year.  Matplotlib 3.4 is also older than 2 years but 3.5 didn't come out till November 2021.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

-->
