### PR TITLE
Update release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,31 @@ jobs:
       - name: Create sdist
         run: python setup.py build_ext sdist
 
+      - name: Save built packages as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages-${{ runner.os }}-${{ matrix.python-version }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 5
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    environment:
+      name: PyPI
+      url: https://pypi.org/project/cartopy
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Download packages
+        uses: actions/download-artifact@v3
+
+      - name: Consolidate packages for upload
+        run: |
+          mkdir dist
+          cp packages-*/* dist/
+
       - name: Publish Package
         uses: pypa/gh-action-pypi-publish@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           cp packages-*/* dist/
 
       - name: Publish Package
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1.8.5
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 name: Build and upload to PyPI
 
-# Only build on tagged releases
+# Only build on published releases
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types:
+      - published
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
     environment:
       name: PyPI
       url: https://pypi.org/project/cartopy
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     runs-on: ubuntu-18.04
 
     steps:
@@ -59,6 +61,3 @@ jobs:
 
       - name: Publish Package
         uses: pypa/gh-action-pypi-publish@v1.8.5
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
A few changes to update the GitHub release workflow
* Swap the event from "pushing a tag" to "release publication". This restricts what events trigger it and more directly tie the generation of PyPI products to the process we follow
* Pin to the 1.8.5 version of the PyPA PyPI publication action; it's always better not to just be blindly using GitHub HEAD.
* Separate the workflow into two separate jobs: build and publish. This reduces the code that has access to the private tokens/permissions needed to publish. It also is a small (needed) step towards having a build matrix (for e.g. wheels) that then get uploaded together in one single step to PyPI.
* Use PyPI ["trusted publisher"](https://docs.pypi.org/trusted-publishers/) instead of an API token (see below)

The last one is a new feature just released to general availability by PyPI. Instead of using a fixed API token (which is tied to one user's account--currently mine), you configure the *project* on PyPI to accept publication from a particular GitHub workflow and (optionally) environment. Transparently (using the PyPA GitHub Action we're already using) GitHub and PyPI exchange the needed tokens to allow publication to PyPI. The use of an environment additionally allows some gatekeeping like wait timers, restrict certain branches for "deployment", and manual approval for "deployment", if we were so inclined.

Assuming we want to go this way, the additional items that need to take place outside the PR merger:
* [x] Add the [PyPI environment](https://github.com/SciTools/cartopy/settings/environments) to the repo (which can have no custom configuration)
* [x] Remove the current PyPI API token from the [repo's secrets](https://github.com/SciTools/cartopy/settings/secrets/actions)
* [x] Delete the token from my account
* [x] Configure the cartopy PyPI project to [accept the github workflow](https://pypi.org/manage/project/cartopy/settings/publishing/) as a trusted publisher