### PR TITLE
Check for mask in GeoQuadMesh.get_array test

### DIFF
--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -283,7 +283,9 @@ def test_pcolormesh_get_array_with_mask():
     assert c._wrapped_collection_fix is not None, \
         'No pcolormesh wrapping was done when it should have been.'
 
-    assert np.array_equal(data.ravel(), c.get_array()), \
+    result = c.get_array()
+    assert not np.ma.is_masked(result)
+    assert np.array_equal(data.ravel(), result), \
         'Data supplied does not match data retrieved in wrapped case'
 
     ax.coastlines()
@@ -306,7 +308,9 @@ def test_pcolormesh_get_array_with_mask():
     assert getattr(c, "_wrapped_collection_fix", None) is None, \
         'pcolormesh wrapping was done when it should not have been.'
 
-    assert np.array_equal(data2.ravel(), c.get_array()), \
+    result = c.get_array()
+    assert not np.ma.is_masked(result)
+    assert np.array_equal(data2.ravel(), result), \
         'Data supplied does not match data retrieved in unwrapped case'
 
 


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

Currently the tests all pass if the `get_array` method is completely removed from `GeoQuadMesh`.  Unfortunately `np.array_equal` ignores the masks.  Since our reference/input data has no mask, the simplest way to account for this is to check the output is also unmasked.  With this change, if you remove the `get_array` method, the test now fails.

(I tripped over this while messing about with #2166 and https://github.com/matplotlib/matplotlib/pull/25027.)

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

-->
