### PR TITLE
Fix information cut off in crs docs

### DIFF
--- a/docs/source/_templates/autosummary/class_with_inherited.rst
+++ b/docs/source/_templates/autosummary/class_with_inherited.rst
@@ -1,8 +1,0 @@
-{{ fullname }}
-{{ underline }}
-
-.. currentmodule:: {{ module }}
-
-.. autoclass:: {{ objname }}
-    :members:
-    :inherited-members:

--- a/docs/source/_templates/autosummary/class_with_inherited.rst
+++ b/docs/source/_templates/autosummary/class_with_inherited.rst
@@ -5,6 +5,5 @@
 
 .. autoclass:: {{ objname }}
     :members:
-    :no-inherited-members:
-    :show-inheritance:
+    :inherited-members:
     :special-members: __init__

--- a/docs/source/_templates/autosummary/class_with_inherited.rst
+++ b/docs/source/_templates/autosummary/class_with_inherited.rst
@@ -6,4 +6,3 @@
 .. autoclass:: {{ objname }}
     :members:
     :inherited-members:
-    :special-members: __init__

--- a/docs/source/_templates/autosummary/class_without_inherited.rst
+++ b/docs/source/_templates/autosummary/class_without_inherited.rst
@@ -7,4 +7,3 @@
     :members:
     :no-inherited-members:
     :show-inheritance:
-    :special-members: __init__

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -225,6 +225,10 @@ html_show_sphinx = True
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'cartopydoc'
 
+# Show both class-level docstring and __init__ docstring in class
+# documentation
+autoclass_content = 'both'
+
 
 # -- Options for LaTeX output --------------------------------------------------
 

--- a/docs/source/reference/crs.rst
+++ b/docs/source/reference/crs.rst
@@ -13,9 +13,15 @@ Base CRS's
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/class_with_inherited.rst
 
    crs.CRS
    crs.Globe
+   
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/class_without_inherited.rst
+   
    crs.Projection
    crs.Geodetic
    crs.Geocentric

--- a/docs/source/reference/crs.rst
+++ b/docs/source/reference/crs.rst
@@ -17,11 +17,11 @@ Base CRS's
 
    crs.CRS
    crs.Globe
-   
+
 .. autosummary::
    :toctree: generated/
    :template: autosummary/class_without_inherited.rst
-   
+
    crs.Projection
    crs.Geodetic
    crs.Geocentric

--- a/docs/source/reference/crs.rst
+++ b/docs/source/reference/crs.rst
@@ -13,15 +13,10 @@ Base CRS's
 
 .. autosummary::
    :toctree: generated/
-   :template: autosummary/class_with_inherited.rst
+   :template: autosummary/class_without_inherited.rst
 
    crs.CRS
    crs.Globe
-
-.. autosummary::
-   :toctree: generated/
-   :template: autosummary/class_without_inherited.rst
-
    crs.Projection
    crs.Geodetic
    crs.Geocentric


### PR DESCRIPTION
## Rationale
In the core CRS documentation page ([https://scitools.org.uk/cartopy/docs/latest/reference/generated/cartopy.crs.CRS.html#](https://scitools.org.uk/cartopy/docs/latest/reference/generated/cartopy.crs.CRS.html)), there is rather limited information shown since a majority of the notes are simply “New in version 2.2.0.” or in a few cases cut off, e.g. “Make a CRS from:”.

Also, in the mpl docs pages a description of the input parameters are missing in the current 0.21.0 version (see e.g. https://scitools.org.uk/cartopy/docs/latest/reference/generated/cartopy.mpl.gridliner.Gridliner.html).

## Implementation
This is addressed in this PR by creating a new Sphinx template class_with_inherited.rst and directing autosummary to use it in the reference/crs.rst doc page, causing the full docstring to be shown rather than just the first line. To reduce the size of the generated pages for classes that inherit CRS, they are set to use class_without_inherited, which is already being used by reference/matplotlib.rst. That template was modified to show __init__, addressing the missing parameter details.

## Implications
The information identified in cartopy.crs.CRS and cartopy.mpl docs that was missing is now shown
