### PR TITLE
Add api-token for CircleCI redirector action

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -8,5 +8,6 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLECI_TOKEN }}
           artifact-path: 0/docs/build/html/index.html
           circleci-jobs: docs-python3


### PR DESCRIPTION
As [requested by @QuLogic](https://github.com/SciTools/cartopy/pull/2183#issuecomment-1577873467).

Created a CircleCI Personal API Token and added it to the repo GHA secrets as the `CIRCLECI_TOKEN` variable.

Hopefully, this can now be used with the [larsoner/circleci-artifacts-redirector-action](https://github.com/larsoner/circleci-artifacts-redirector-action) GHA.