### PR TITLE
Fix bounds error in shapereader for null records

### DIFF
--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -114,7 +114,11 @@ class FionaRecord(Record):
     def __init__(self, geometry, attributes):
         self._geometry = geometry
         self.attributes = attributes
-        self._bounds = geometry.bounds
+
+        if geometry is not None:
+            self._bounds = geometry.bounds
+        else:
+            self._bounds = None
 
 
 class BasicReader:

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -85,7 +85,7 @@ class Record:
         The bounds of this Record's :meth:`~Record.geometry`.
 
         """
-        if self._bounds is None:
+        if self._bounds is None and self.geometry is not None:
             self._bounds = self.geometry.bounds
         return self._bounds
 


### PR DESCRIPTION
## Rationale

As identified in issue #2087, FionaReader is currently throwing an error when iterating through the records,of the 10m Natural Earth rivers shapefile for North America, due to some entries that have attributes but no geometry. Since geometry is None in those cases, calling geometry.bounds fails. I checked and this is new to version 5.0.0 of the shapefile - the previous 4.1.0 version works without error.

## Implications

The bug should be fixed.
