### PR TITLE
Added add_cyclic to API reference and What's new Version 0.21

### DIFF
--- a/docs/source/reference/transformations.rst
+++ b/docs/source/reference/transformations.rst
@@ -34,6 +34,8 @@ Longitude wrapping
    :toctree: generated/
 
     util.add_cyclic_point
+    util.add_cyclic
+
 
 LinearRing/LineString projection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/whatsnew/v0.21.rst
+++ b/docs/source/whatsnew/v0.21.rst
@@ -114,6 +114,11 @@ Features
 
         plt.show()
 
+* Matthias Cuntz added a new convenience utility function
+  :func:~cartopy.util.add_cyclic. This is an extension of
+  :func:~cartopy.util.add_cyclic_point for 2-dimensional coordinates lat and
+  lon. (:pull:1753)
+
 Deprecations
 ------------
 

--- a/lib/cartopy/util.py
+++ b/lib/cartopy/util.py
@@ -269,6 +269,7 @@ def add_cyclic(data, x=None, y=None, axis=-1,
     --------
     Adding a cyclic point to a data array, where the cyclic dimension is
     the right-most dimension.
+
     >>> import numpy as np
     >>> data = np.ones([5, 6]) * np.arange(6)
     >>> cyclic_data = add_cyclic(data)
@@ -280,6 +281,7 @@ def add_cyclic(data, x=None, y=None, axis=-1,
      [0. 1. 2. 3. 4. 5. 0.]]
 
     Adding a cyclic point to a data array and an associated x-coordinate.
+
     >>> lons = np.arange(0, 360, 60)
     >>> cyclic_data, cyclic_lons = add_cyclic(data, x=lons)
     >>> print(cyclic_data)  # doctest: +NORMALIZE_WHITESPACE
@@ -293,6 +295,7 @@ def add_cyclic(data, x=None, y=None, axis=-1,
 
     Adding a cyclic point to a data array and an associated 2-dimensional
     x-coordinate.
+
     >>> lons = np.arange(0, 360, 60)
     >>> lats = np.arange(-90, 90, 180/5)
     >>> lon2d, lat2d = np.meshgrid(lons, lats)
@@ -312,6 +315,7 @@ def add_cyclic(data, x=None, y=None, axis=-1,
 
     Adding a cyclic point to a data array and the associated 2-dimensional
     x- and y-coordinates.
+
     >>> lons = np.arange(0, 360, 60)
     >>> lats = np.arange(-90, 90, 180/5)
     >>> lon2d, lat2d = np.meshgrid(lons, lats)
@@ -337,6 +341,7 @@ def add_cyclic(data, x=None, y=None, axis=-1,
      [ 54.  54.  54.  54.  54.  54.  54.]]
 
     Not adding a cyclic point if cyclic point detected in x.
+
     >>> lons = np.arange(0, 361, 72)
     >>> lats = np.arange(-90, 90, 180/5)
     >>> lon2d, lat2d = np.meshgrid(lons, lats)


### PR DESCRIPTION
## Rationale

I had added the convenience utility function add_cyclic in 2021. It was merged in Nov 5, 2021 by @greglucas.
We had apparently forgotten to add it to the API reference in the docs. It also did not make it into What's new Version 0.21 nor into the milestones on Github.
So I added util.add_cyclic in the transformations.rst in the documentation.
Because the PR 1753 was not included in the milestones of v0.21, I added it into the What's New v0.21.rst.

## Implications

It will just be easier to find the functionality. Otherwise one could only find it in the gallery example.

## Notes

Unrelated to this PR are two remarks:
1. One of the tests fails on my machine:    lib/cartopy/tests/mpl/test_features.py::test_natural_earth   The only differences between Expected and Actual images are some dashed country boundaries. I would recommend to make the coutry boundaries in solid lines to avoid this problem between matplotlib versions.
2. Building the documentation also fails on   examples/miscellanea/tube_stations.py   I have not investigated the problem. It actual fails in pyproj.

My system: macOS 13.4, Python 3.10.9 and in cartopy directory
```
python -m pip install --upgrade pyshp
python -m pip install "shapely<2" --no-binary shapely
python -m pip install cython numpy geos pyproj matplotlib owslib pillow scipy packaging pytest pytest-mpl pytest-xdist beautifulsoup4 pydata-sphinx-theme sphinx sphinx-gallery flake8 pre-commit pykdtree setuptools_scm fiona pep8
pip install -e .

```