### PR TITLE
Create ocean bathymetry example

### DIFF
--- a/examples/lines_and_polygons/ocean_bathymetry.py
+++ b/examples/lines_and_polygons/ocean_bathymetry.py
@@ -2,7 +2,13 @@
 Ocean bathymetry
 ----------------
 
-Produces a map of ocean seafloor depth.
+Produces a map of ocean seafloor depth, demonstrating the
+:class:`cartopy.io.shapereader.Reader` interface. The data is a series
+of 10m resolution nested polygons obtained from Natural Earth, and derived
+from the NASA SRTM Plus product. Since the dataset contains a zipfile with
+multiple shapefiles representing different depths, the example demonstrates
+manually downloading and reading them with the general shapereader interface,
+instead of the specialized `cartopy.feature.NaturalEarthFeature` interface.
 
 """
 from glob import glob
@@ -81,6 +87,7 @@ if __name__ == "__main__":
                                      norm=norm,
                                      boundaries=depths.astype(int)[::-1],
                                      spacing='proportional',
+                                     extend='min',
                                      ticks=depths.astype(int),
                                      label='Depth (m)')
 

--- a/examples/scalar_data/ocean_bathymetry.py
+++ b/examples/scalar_data/ocean_bathymetry.py
@@ -1,0 +1,88 @@
+"""
+Ocean bathymetry
+----------------
+
+Produces a map of ocean seafloor depth.
+
+"""
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+import cartopy as cart
+import cartopy.crs as ccrs
+from glob import glob
+
+
+def load_bathymetry(zip_file_url):
+    """Read zip file from Natural Earth containing bathymetry shapefiles"""
+    # Download and extract shapefiles
+    import requests
+    import zipfile
+    import io
+    r = requests.get(zip_file_url)
+    z = zipfile.ZipFile(io.BytesIO(r.content))
+    z.extractall("ne_10m_bathymetry_all/")
+
+    # Read shapefiles, sorted by depth
+    shp_dict = {}
+    files = glob('ne_10m_bathymetry_all/*.shp')
+    assert len(files) > 0
+    files.sort()
+    depths = []
+    for f in files:
+        depth = '-' + f.split('_')[-1].split('.')[0]  # depth from file name
+        depths.append(depth)
+        bbox = (90, -15, 160, 60)  # (x0, y0, x1, y1)
+        nei = cart.io.shapereader.Reader(f, bbox=bbox)
+        shp_dict[depth] = nei
+    depths = np.array(depths)[::-1]  # sort from surface to bottom
+    return depths, shp_dict
+
+
+if __name__ == "__main__":
+    # Load data (14.8 MB file)
+    depths, shp_dict = load_bathymetry(
+        'https://naturalearth.s3.amazonaws.com/' +
+        '10m_physical/ne_10m_bathymetry_all.zip')
+
+    # Construct colormap:
+    # Depth levels in the colorbar are spaced as in the data
+    norm = matplotlib.colors.Normalize(vmin=-10000, vmax=0)  # in meters
+    depth_fraction = depths.astype(float) / depths.astype(float).min()
+    tmp = matplotlib.colormaps['Blues']  # to quantize: use .resampled(10)
+    colors_depths = tmp(depth_fraction)  # color values at fractional depths
+
+    # Set up plot
+    subplot_kw = {'projection': ccrs.LambertCylindrical()}
+    fig, ax = plt.subplots(subplot_kw=subplot_kw, figsize=(9, 7))
+    ax.set_extent([90, 160, -15, 60], crs=ccrs.PlateCarree())  # x0, x1, y0, y1
+
+    # Iterate and plot feature for each depth level
+    for i, depth in enumerate(depths):
+        ax.add_geometries(shp_dict[depth].geometries(),
+                          crs=ccrs.PlateCarree(),
+                          color=colors_depths[i])
+
+    # Add standard features
+    land_feature = cart.feature.NaturalEarthFeature(category='physical',
+                                                    name='LAND',
+                                                    scale='110m')
+    ax.add_feature(land_feature, color='grey')
+    ax.coastlines(lw=1, resolution='110m')
+    ax.gridlines(draw_labels=False)
+    ax.set_position([0.03, 0.05, 0.8, 0.9])
+
+    # Add custom colorbar
+    axi = fig.add_axes([0.85, 0.1, 0.025, 0.8])
+    ax.add_feature(cart.feature.BORDERS, linestyle=':')
+    matplotlib.colorbar.ColorbarBase(ax=axi,
+                                     cmap=tmp.reversed(),
+                                     norm=norm,
+                                     boundaries=depths.astype(int)[::-1],
+                                     spacing='proportional',
+                                     ticks=depths.astype(int),
+                                     label='Depth (m)')
+
+    # Convert vector bathymetries to raster (saves a lot of disk space)
+    # while leaving labels as vectors
+    ax.set_rasterized(True)

--- a/examples/scalar_data/ocean_bathymetry.py
+++ b/examples/scalar_data/ocean_bathymetry.py
@@ -5,20 +5,23 @@ Ocean bathymetry
 Produces a map of ocean seafloor depth.
 
 """
-import numpy as np
+from glob import glob
+
 import matplotlib
 import matplotlib.pyplot as plt
+import numpy as np
+
 import cartopy as cart
 import cartopy.crs as ccrs
-from glob import glob
 
 
 def load_bathymetry(zip_file_url):
     """Read zip file from Natural Earth containing bathymetry shapefiles"""
     # Download and extract shapefiles
-    import requests
-    import zipfile
     import io
+    import zipfile
+
+    import requests
     r = requests.get(zip_file_url)
     z = zipfile.ZipFile(io.BytesIO(r.content))
     z.extractall("ne_10m_bathymetry_all/")

--- a/examples/scalar_data/ocean_bathymetry.py
+++ b/examples/scalar_data/ocean_bathymetry.py
@@ -11,8 +11,9 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
-import cartopy as cart
 import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+import cartopy.io.shapereader as shpreader
 
 
 def load_bathymetry(zip_file_url):
@@ -36,7 +37,7 @@ def load_bathymetry(zip_file_url):
         depth = '-' + f.split('_')[-1].split('.')[0]  # depth from file name
         depths.append(depth)
         bbox = (90, -15, 160, 60)  # (x0, y0, x1, y1)
-        nei = cart.io.shapereader.Reader(f, bbox=bbox)
+        nei = shpreader.Reader(f, bbox=bbox)
         shp_dict[depth] = nei
     depths = np.array(depths)[::-1]  # sort from surface to bottom
     return depths, shp_dict
@@ -67,17 +68,14 @@ if __name__ == "__main__":
                           color=colors_depths[i])
 
     # Add standard features
-    land_feature = cart.feature.NaturalEarthFeature(category='physical',
-                                                    name='LAND',
-                                                    scale='110m')
-    ax.add_feature(land_feature, color='grey')
+    ax.add_feature(cfeature.LAND, color='grey')
     ax.coastlines(lw=1, resolution='110m')
     ax.gridlines(draw_labels=False)
     ax.set_position([0.03, 0.05, 0.8, 0.9])
 
     # Add custom colorbar
     axi = fig.add_axes([0.85, 0.1, 0.025, 0.8])
-    ax.add_feature(cart.feature.BORDERS, linestyle=':')
+    ax.add_feature(cfeature.BORDERS, linestyle=':')
     matplotlib.colorbar.ColorbarBase(ax=axi,
                                      cmap=tmp.reversed(),
                                      norm=norm,

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -130,7 +130,7 @@ class BasicReader:
 
     """
 
-    def __init__(self, filename):
+    def __init__(self, filename, bbox=None):
         # Validate the filename/shapefile
         self._reader = reader = shapefile.Reader(filename)
         if reader.shp is None or reader.shx is None or reader.dbf is None:


### PR DESCRIPTION
## Rationale

In a previous pull request (#1916) @mattphysics created a notebook for plotting ocean bathymetry using Natural Earth data, but it was not finished. I have here converted it to converted it to a script, reduced the length in some places, and propose adding it to the example gallery.
[](url)

## Implications

The shapereader.natural_earth interface does not work on this particular file, since the .zip contains multiple shapefiles corresponding to different depths. I think it is a nice example using cartopy's shapereader.Reader interface. The axis extent is set to [90, 160, -15, 60] to help speed up the script versus plotting the whole world.
![test](https://github.com/SciTools/cartopy/assets/30876419/a6b0c980-2925-45d1-9f9d-81c117f73807)
