### PR TITLE
precompute finite value mask for kdtree query

### DIFF
--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -13,11 +13,11 @@ import numpy as np
 
 
 try:
-    from pykdtree.kdtree import KDTree as _kdtree_handle
+    from pykdtree.kdtree import KDTree as _kdtreeClass
     _is_pykdtree = True
 except ImportError:
     try:
-        from scipy.spatial import cKDTree as _kdtree_handle
+        from scipy.spatial import cKDTree as _kdtreeClass
     except ImportError as e:
         raise ImportError("Using image transforms requires either "
                           "pykdtree or scipy.") from e
@@ -274,7 +274,7 @@ def regrid(array, source_x_coords, source_y_coords, source_proj, target_proj,
     finite_xyz = np.all(np.isfinite(target_xyz), axis=-1)
 
     if _is_pykdtree:
-        kdtree = _kdtree_handle(xyz)
+        kdtree = _kdtreeClass(xyz)
         # Use sqr_dists=True because we don't care about distances,
         # and it saves a sqrt.
         _, indices[finite_xyz] = kdtree.query(target_xyz[finite_xyz, :],
@@ -283,7 +283,7 @@ def regrid(array, source_x_coords, source_y_coords, source_proj, target_proj,
     else:
         # Versions of scipy >= v0.16 added the balanced_tree argument,
         # which caused the KDTree to hang with this input.
-        kdtree = _kdtree_handle(xyz, balanced_tree=False)
+        kdtree = _kdtreeClass(xyz, balanced_tree=False)
         _, indices[finite_xyz] = kdtree.query(target_xyz[finite_xyz, :], k=1)
 
     mask = ~finite_xyz | (indices >= len(xyz))

--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -286,7 +286,7 @@ def regrid(array, source_x_coords, source_y_coords, source_proj, target_proj,
         kdtree = scipy.spatial.cKDTree(xyz, balanced_tree=False)
         _, indices[finite_xyz] = kdtree.query(target_xyz[finite_xyz, :], k=1)
 
-    mask = indices >= len(xyz)
+    mask = ~finite_xyz | (indices >= len(xyz))
     indices[mask] = 0
 
     desired_ny, desired_nx = target_x_points.shape

--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -13,11 +13,11 @@ import numpy as np
 
 
 try:
-    import pykdtree.kdtree
+    from pykdtree.kdtree import KDTree as _kdtree_handle
     _is_pykdtree = True
 except ImportError:
     try:
-        import scipy.spatial
+        from scipy.spatial import cKDTree as _kdtree_handle
     except ImportError as e:
         raise ImportError("Using image transforms requires either "
                           "pykdtree or scipy.") from e
@@ -274,7 +274,7 @@ def regrid(array, source_x_coords, source_y_coords, source_proj, target_proj,
     finite_xyz = np.all(np.isfinite(target_xyz), axis=-1)
 
     if _is_pykdtree:
-        kdtree = pykdtree.kdtree.KDTree(xyz)
+        kdtree = _kdtree_handle(xyz)
         # Use sqr_dists=True because we don't care about distances,
         # and it saves a sqrt.
         _, indices[finite_xyz] = kdtree.query(target_xyz[finite_xyz, :],
@@ -283,7 +283,7 @@ def regrid(array, source_x_coords, source_y_coords, source_proj, target_proj,
     else:
         # Versions of scipy >= v0.16 added the balanced_tree argument,
         # which caused the KDTree to hang with this input.
-        kdtree = scipy.spatial.cKDTree(xyz, balanced_tree=False)
+        kdtree = _kdtree_handle(xyz, balanced_tree=False)
         _, indices[finite_xyz] = kdtree.query(target_xyz[finite_xyz, :], k=1)
 
     mask = ~finite_xyz | (indices >= len(xyz))

--- a/lib/cartopy/tests/test_img_transform.py
+++ b/lib/cartopy/tests/test_img_transform.py
@@ -108,3 +108,20 @@ def test_gridding_data_outside_projection():
     assert_array_equal([-180, 180, -90, 90], extent)
     assert_array_equal(expected, image)
     assert_array_equal(expected_mask, image.mask)
+
+
+@pytest.mark.parametrize("target_prj", (ccrs.Mollweide(), ccrs.LambertAzimuthalEqualArea()))
+def test_invalid_regridding_with_invalid_extent(target_prj):
+    # tests that when a valid extent results in invalid points in the
+    # transformed coordinates, the regridding does not error.
+
+    # create 3 data points
+    lats = np.array([65, 10, -45])
+    lons = np.array([-170, 10, 170])
+    data = np.array([1, 2, 3])
+    data_trans = ccrs.Geodetic()
+
+    target_x, target_y, extent = img_trans.mesh_projection(target_prj, 8, 4)
+    
+    _ = img_trans.regrid(data, lons, lats, data_trans, target_prj,
+                             target_x, target_y)

--- a/lib/cartopy/tests/test_img_transform.py
+++ b/lib/cartopy/tests/test_img_transform.py
@@ -110,7 +110,8 @@ def test_gridding_data_outside_projection():
     assert_array_equal(expected_mask, image.mask)
 
 
-@pytest.mark.parametrize("target_prj", (ccrs.Mollweide(), ccrs.LambertAzimuthalEqualArea()))
+@pytest.mark.parametrize("target_prj",
+                         (ccrs.Mollweide(), ccrs.Orthographic()))
 def test_invalid_regridding_with_invalid_extent(target_prj):
     # tests that when a valid extent results in invalid points in the
     # transformed coordinates, the regridding does not error.
@@ -122,6 +123,6 @@ def test_invalid_regridding_with_invalid_extent(target_prj):
     data_trans = ccrs.Geodetic()
 
     target_x, target_y, extent = img_trans.mesh_projection(target_prj, 8, 4)
-    
+
     _ = img_trans.regrid(data, lons, lats, data_trans, target_prj,
-                             target_x, target_y)
+                         target_x, target_y)

--- a/lib/cartopy/tests/test_img_transform.py
+++ b/lib/cartopy/tests/test_img_transform.py
@@ -128,9 +128,6 @@ def test_regridding_with_invalid_extent(target_prj, use_scipy, monkeypatch):
 
     if use_scipy:
         monkeypatch.setattr(img_trans, "_is_pykdtree", False)
-        monkeypatch.setattr(img_trans, "_kdtree_handle", scipy.spatial.cKDTree)
-        _ = img_trans.regrid(data, lons, lats, data_trans, target_prj,
-                             target_x, target_y)
-    else:
-        _ = img_trans.regrid(data, lons, lats, data_trans, target_prj,
-                             target_x, target_y)
+        monkeypatch.setattr(img_trans, "_kdtreeClass", scipy.spatial.cKDTree)
+    _ = img_trans.regrid(data, lons, lats, data_trans, target_prj,
+                         target_x, target_y)

--- a/lib/cartopy/tests/test_img_transform.py
+++ b/lib/cartopy/tests/test_img_transform.py
@@ -114,7 +114,7 @@ def test_gridding_data_outside_projection():
 @pytest.mark.parametrize("target_prj",
                          (ccrs.Mollweide(), ccrs.Orthographic()))
 @pytest.mark.parametrize("use_scipy", (True, False))
-def test_invalid_regridding_with_invalid_extent(target_prj, use_scipy, monkeypatch):
+def test_regridding_with_invalid_extent(target_prj, use_scipy, monkeypatch):
     # tests that when a valid extent results in invalid points in the
     # transformed coordinates, the regridding does not error.
 

--- a/lib/cartopy/tests/test_img_transform.py
+++ b/lib/cartopy/tests/test_img_transform.py
@@ -7,11 +7,11 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
+import scipy.spatial
 
 import cartopy.crs as ccrs
 import cartopy.img_transform as img_trans
 
-import scipy.spatial
 
 @pytest.mark.parametrize('xmin, xmax', [
     (-90, 0), (-90, 90), (-90, None),
@@ -134,5 +134,3 @@ def test_invalid_regridding_with_invalid_extent(target_prj, use_scipy, monkeypat
     else:
         _ = img_trans.regrid(data, lons, lats, data_trans, target_prj,
                              target_x, target_y)
-
-


### PR DESCRIPTION
## Rationale

scipy>=1.11 now raises an error when querying a kdtree object with coordinate arrays that contain `nan` or `inf` values. This PR adds a mask for finite values before that query occurs. 


## Implications

Closes #2199 




