### PR TITLE
Preset Stamen tile file extension, opacity

### DIFF
--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -374,10 +374,10 @@ class Stamen(GoogleWTS):
         # use optional desired_tile_form input if available
         # otherwise, use preset value based on the layer name
         if desired_tile_form is None:
-            if not layer_info['opaque']:
-                desired_tile_form = 'RGBA'
-            else:
+            if layer_info['opaque']:
                 desired_tile_form = 'RGB'
+            else:
+                desired_tile_form = 'RGBA'
 
         super().__init__(desired_tile_form=desired_tile_form,
                          cache=cache)

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -350,7 +350,7 @@ class Stamen(GoogleWTS):
     """
 
     def __init__(self, style='toner',
-                 desired_tile_form='RGB', cache=False):
+                 desired_tile_form=None, cache=False):
 
         # preset layer configuration
         layer_config = {
@@ -367,13 +367,17 @@ class Stamen(GoogleWTS):
           'watercolor':         {'extension': 'jpg', 'opaque': True},
         }
 
-        # get layer information from dict if known, else use defaults
+        # get layer information from dict
         layer_info = layer_config.get(
             style, {'extension': '.png', 'opaque': True})
 
-        # allow background transparency
-        if not layer_info['opaque']:
-            desired_tile_form = 'RGBA'
+        # use optional desired_tile_form input if available
+        # otherwise, use preset value based on the layer name
+        if desired_tile_form is None:
+            if not layer_info['opaque']:
+                desired_tile_form = 'RGBA'
+            else:
+                desired_tile_form = 'RGB'
 
         super().__init__(desired_tile_form=desired_tile_form,
                          cache=cache)

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -351,13 +351,39 @@ class Stamen(GoogleWTS):
 
     def __init__(self, style='toner',
                  desired_tile_form='RGB', cache=False):
+
+        # preset layer configuration
+        layer_config = {
+          'terrain':            {'extension': 'png', 'opaque': True},
+          'terrain-background': {'extension': 'png', 'opaque': True},
+          'terrain-labels':     {'extension': 'png', 'opaque': False},
+          'terrain-lines':      {'extension': 'png', 'opaque': False},
+          'toner-background':   {'extension': 'png', 'opaque': True},
+          'toner':              {'extension': 'png', 'opaque': True},
+          'toner-hybrid':       {'extension': 'png', 'opaque': False},
+          'toner-labels':       {'extension': 'png', 'opaque': False},
+          'toner-lines':        {'extension': 'png', 'opaque': False},
+          'toner-lite':         {'extension': 'png', 'opaque': True},
+          'watercolor':         {'extension': 'jpg', 'opaque': True},
+        }
+
+        # get layer information from dict if known, else use defaults
+        layer_info = layer_config.get(
+            style, {'extension': '.png', 'opaque': True})
+
+        # allow background transparency
+        if not layer_info['opaque']:
+            desired_tile_form = 'RGBA'
+
         super().__init__(desired_tile_form=desired_tile_form,
                          cache=cache)
         self.style = style
+        self.extension = layer_info['extension']
 
     def _image_url(self, tile):
         x, y, z = tile
-        return f'http://tile.stamen.com/{self.style}/{z}/{x}/{y}.png'
+        return 'http://tile.stamen.com/' + \
+            f'{self.style}/{z}/{x}/{y}.{self.extension}'
 
 
 class MapboxTiles(GoogleWTS):


### PR DESCRIPTION
## Rationale

In issue #2198 it was pointed out the Stamen watercolor tiles can not be downloaded currently as png. Right now, all the layers are downloaded as png and also default to RGB mode. This PR creates a dictionary to set the file extension automatically (specifically using jpg for watercolor) and desired_tile_form to RGBA for known layers which should have a transparent background (like terrain-lines).

## Implications

Stamen watercolor feature should be working again, and behavior of behavior of non-opaque layers improved. By explicitly listing the known Stamen layers in a dict, this also may help the user be aware of the available options.
