### PR TITLE
TST: Update Lambert Conformal test tolerances

### DIFF
--- a/lib/cartopy/tests/crs/test_lambert_conformal.py
+++ b/lib/cartopy/tests/crs/test_lambert_conformal.py
@@ -5,6 +5,7 @@
 # licensing details.
 
 from numpy.testing import assert_array_almost_equal
+import pyproj
 import pytest
 
 import cartopy.crs as ccrs
@@ -68,18 +69,29 @@ class Test_LambertConformal_standard_parallels:
 
     def test_single_spole(self):
         s_pole_crs = ccrs.LambertConformal(standard_parallels=[-1.])
+        expected_x = (-19939660, 19939660)
+        expected_y = (-735590302, -8183795)
+        if pyproj.__proj_version__ >= '9.2.0':
+            expected_x = (-19840440, 19840440)
+            expected_y = (-370239953, -8191953)
+        print(s_pole_crs.x_limits)
         assert_array_almost_equal(s_pole_crs.x_limits,
-                                  (-19939660, 19939660),
+                                  expected_x,
                                   decimal=0)
         assert_array_almost_equal(s_pole_crs.y_limits,
-                                  (-735590302, -8183795),
+                                  expected_y,
                                   decimal=0)
 
     def test_single_npole(self):
         n_pole_crs = ccrs.LambertConformal(standard_parallels=[1.])
+        expected_x = (-20130569, 20130569)
+        expected_y = (-8170229, 726200683)
+        if pyproj.__proj_version__ >= '9.2.0':
+            expected_x = (-20222156, 20222156)
+            expected_y = (-8164817, 360848719)
         assert_array_almost_equal(n_pole_crs.x_limits,
-                                  (-20130569, 20130569),
+                                  expected_x,
                                   decimal=0)
         assert_array_almost_equal(n_pole_crs.y_limits,
-                                  (-8170229, 726200683),
+                                  expected_y,
                                   decimal=0)


### PR DESCRIPTION
PROJ 9.2+ has changed some of the Lambert Conformal test values as well. We got some of these in #2145 but LambertConformal also needed to be updated. The lower y-bound does seem a bit extreme here, but I think it is really pretty minimal in practice and just a matter of the x-boundary locations changing slightly and thus this value also changes now.

closes #2193