### PR TITLE
Broken links in what's new pages

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -3,7 +3,7 @@
 Cartopy configuration
 ---------------------
 
-.. currentmodule:: cartopy
+.. module:: cartopy
 
 The top level cartopy module contains the :attr:`~cartopy.config` dictionary which controls various aspects of cartopy's behaviour.
 
@@ -11,7 +11,7 @@ The top level cartopy module contains the :attr:`~cartopy.config` dictionary whi
     n.b. cartopy.config docstring should be mirrored in lib/cartopy/__init__.py.
 
 
-.. py:data:: cartopy.config
+.. py:data:: config
 
     The config dictionary stores global configuration values for cartopy.
 

--- a/docs/source/reference/feature.rst
+++ b/docs/source/reference/feature.rst
@@ -3,7 +3,7 @@
 Feature interface (cartopy.feature)
 -----------------------------------
 
-.. currentmodule:: cartopy.feature
+.. module:: cartopy.feature
 
 The feature interface can be used and extended to add various "features"
 to geoaxes, such as Shapely objects and Natural Earth Imagery. The default

--- a/docs/source/reference/io.rst
+++ b/docs/source/reference/io.rst
@@ -1,6 +1,6 @@
 .. _api.io:
 
-.. currentmodule:: cartopy.io
+.. module:: cartopy.io
 
 Input/output capabilities (cartopy.io)
 --------------------------------------

--- a/docs/source/reference/matplotlib.rst
+++ b/docs/source/reference/matplotlib.rst
@@ -6,7 +6,7 @@ Matplotlib interface (cartopy.mpl)
 Cartopy extends some Matplotlib capabilities to handle geographic
 projections, such as non-rectangular axes and spines.
 
-.. currentmodule:: cartopy.mpl
+.. module:: cartopy.mpl
 
 Geoaxes
 ~~~~~~~

--- a/docs/source/whatsnew/v0.12.rst
+++ b/docs/source/whatsnew/v0.12.rst
@@ -119,7 +119,7 @@ Deprecations
 * The SRTM module has been re-factored for simplicity and to take advantage
   of the new :ref:`raster source interface <raster-source-interface>`. Some
   methods have therefore been deprecated and will be removed in future
-  releases. The function :func:`cartopy.io.srtm.srtm` has been replaced with
+  releases. The function ``cartopy.io.srtm.srtm`` has been replaced with
   the :meth:`cartopy.io.srtm.SRTM3Source.single_tile` method. Similarly,
   ``cartopy.io.srtm.srtm_composite`` and
   ``cartopy.io.srtm.SRTM3_retrieve`` have been replaced with the

--- a/docs/source/whatsnew/v0.14.rst
+++ b/docs/source/whatsnew/v0.14.rst
@@ -46,7 +46,7 @@ Features
 
 Deprecations
 ------------
-* :data:`cartopy.crs.GOOGLE_MERCATOR` has been moved to :data:`cartopy.crs.Mercator.GOOGLE`.
+* ``cartopy.crs.GOOGLE_MERCATOR`` has been moved to :data:`cartopy.crs.Mercator.GOOGLE`.
 
 
 Incompatible changes

--- a/docs/source/whatsnew/v0.18.rst
+++ b/docs/source/whatsnew/v0.18.rst
@@ -75,8 +75,8 @@ Features
   threads. (:pull:`1232`)
 
 * Elliott Sales de Andrade added a
-  :class:`cartopy.mpl.geoaxes.GeoAxes.GeoSpine` class to replace the
-  :attr:`cartopy.mpl.geoaxes.GeoAxes.outline_patch` that defines the map
+  :class:`cartopy.mpl.geoaxes.GeoSpine` class to replace the
+  ``cartopy.mpl.geoaxes.GeoAxes.outline_patch`` that defines the map
   boundary. (:pull:`1213`)
 
 * Elliott Sales de Andrade improved appearance of plots with tight layout.
@@ -97,20 +97,20 @@ Deprecations
   :func:`cartopy.mpl.geoaxes.GeoAxes.imshow` is now ``'upper'`` to match the
   default in Matplotlib.
 
-* The :attr:`cartopy.mpl.geoaxes.GeoAxes.outline_patch` attribute is
+* The ``cartopy.mpl.geoaxes.GeoAxes.outline_patch`` attribute is
   deprecated. In its place, use Matplotlib's standard options for controlling
   the Axes frame, or access ``GeoAxes.spines['geo']`` directly.
 
-* The :attr:`cartopy.mpl.geoaxes.GeoAxes.background_patch` attribute is
+* The ``cartopy.mpl.geoaxes.GeoAxes.background_patch`` attribute is
   deprecated. In its place, use Matplotlib's standard options for controlling
   the Axes patch, i.e., pass values to the constructor or access
   ``GeoAxes.patch`` directly.
 
 * The gridliner labelling options
-  :attr:`cartopy.mpl.gridliner.Gridliner.xlabels_top`,
-  :attr:`cartopy.mpl.gridliner.Gridliner.xlabels_bottom`,
-  :attr:`cartopy.mpl.gridliner.Gridliner.ylabels_left`, and
-  :attr:`cartopy.mpl.gridliner.Gridliner.ylabels_right` are deprecated.
+  ``cartopy.mpl.gridliner.Gridliner.xlabels_top``,
+  ``cartopy.mpl.gridliner.Gridliner.xlabels_bottom``,
+  ``cartopy.mpl.gridliner.Gridliner.ylabels_left``, and
+  ``cartopy.mpl.gridliner.Gridliner.ylabels_right`` are deprecated.
   Instead, use :attr:`cartopy.mpl.gridliner.Gridliner.top_labels`,
   :attr:`cartopy.mpl.gridliner.Gridliner.bottom_labels`,
   :attr:`cartopy.mpl.gridliner.Gridliner.left_labels`, or

--- a/docs/source/whatsnew/v0.5.rst
+++ b/docs/source/whatsnew/v0.5.rst
@@ -28,5 +28,5 @@ A summary of the main features added with version 0.5:
 Deprecations
 ------------
 * The method ``Axes.natural_earth_shp()`` has been replaced by the
-  method :meth:`Axes.add_feature()` and the :mod:`cartopy.feature`
+  method :meth:`~cartopy.mpl.geoaxes.GeoAxes.add_feature()` and the :mod:`cartopy.feature`
   module.

--- a/docs/source/whatsnew/v0.6.rst
+++ b/docs/source/whatsnew/v0.6.rst
@@ -22,7 +22,7 @@ Features
 
 * Phil Elson added a :py:class:`~cartopy.io.Downloader` class which allows
   automatic downloading of shapefiles (currently from Natural Earth and GSHHS).
-  The extension requires no user action and can be configured via the :py:data:`cartopy.config` dictionary.
+  The extension requires no user action and can be configured via the :data:`cartopy.config` dictionary.
 
 * Development plans for cartopy 0.7 and beyond
 

--- a/docs/source/whatsnew/v0.7.rst
+++ b/docs/source/whatsnew/v0.7.rst
@@ -7,4 +7,4 @@ Version 0.7 (March 21, 2013)
 * Various documentation enhancements have been added. (:pull:`247`, :pull:`244` :pull:`240` and :pull:`242`)
 
 This is a quick release which targets two very specific requirements. The goals outlined in the development plan at
-``v0.6`` still remain the primary target for ``v0.8`` and beyond.
+:doc:`v0.6 <v0.6>` still remain the primary target for :doc:`v0.8 <v0.8>` and beyond.


### PR DESCRIPTION
## Rationale

This fixes several broken links in the what's new pages in the documentation, and uses double backticks around deprecated methods if they weren't already being used.
As a note, in the what's new for v0.5 I found the call to :mod:`cartopy.feature` was not working because of currentmodule being used instead of module in feature.rst. For consistency, this change was then repeated in the .rst file for other modules.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

I think issue #1972 can be closed.
