### PR TITLE
Reduce sphinx warnings

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,4 +1,4 @@
-sphinx<6
+sphinx
 sphinx-gallery
 beautifulsoup4
 pydata-sphinx-theme

--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -1,0 +1,9 @@
+{{ fullname }}
+{{ underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+    :members:
+    :inherited-members:
+

--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -6,4 +6,3 @@
 .. autoclass:: {{ objname }}
     :members:
     :inherited-members:
-

--- a/docs/source/reference/crs.rst
+++ b/docs/source/reference/crs.rst
@@ -1,9 +1,9 @@
 .. _api.crs:
 
-.. currentmodule:: cartopy
-
 Coordinate reference systems (CRS)
 ----------------------------------
+
+.. module:: cartopy.crs
 
 The :class:`cartopy.crs.CRS` class is the very core of cartopy, all coordinate reference systems
 in cartopy have :class:`~cartopy.crs.CRS` as a parent class.
@@ -15,18 +15,20 @@ Base CRS's
    :toctree: generated/
    :template: autosummary/class_without_inherited.rst
 
-   crs.CRS
-   crs.Globe
-   crs.Projection
-   crs.Geodetic
-   crs.Geocentric
-   crs.RotatedGeodetic
-   crs.epsg
+   CRS
+   Globe
+   Projection
+   Geodetic
+   Geocentric
+   RotatedGeodetic
+   epsg
 
 .. _api.geodesic:
 
 Geodesic calculations
 ~~~~~~~~~~~~~~~~~~~~~
+
+.. module:: cartopy.geodesic
 
 The :mod:`cartopy.geodesic` module defines the :class:`cartopy.geodesic.Geodesic` class which can interface with the Proj
 geodesic functions. See the `Proj geodesic page`_ for more background
@@ -37,7 +39,7 @@ information.
 .. autosummary::
    :toctree: generated/
 
-   geodesic.Geodesic
+   Geodesic
 
 List of projections
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -6,7 +6,7 @@ API reference
 :Release: |version|
 :Date: |today|
 
-.. module:: cartopy
+.. currentmodule:: cartopy
 
 This is a detailed reference manual for functions, modules,
 and objects in cartopy. For initially learning how to use cartopy,

--- a/docs/source/reference/io.rst
+++ b/docs/source/reference/io.rst
@@ -1,7 +1,5 @@
 .. _api.io:
 
-.. module:: cartopy.io
-
 Input/output capabilities (cartopy.io)
 --------------------------------------
 
@@ -14,67 +12,77 @@ data formats.
 Shapefiles
 ~~~~~~~~~~
 
-Cartopy provides a basic interface for accessing shapefiles.
+.. module:: cartopy.io.shapereader
+
+:mod:`cartopy.io.shapereader` provides a basic interface for accessing shapefiles.
 
 .. autosummary::
     :toctree: generated/
 
-    shapereader.Reader
-    shapereader.BasicReader
-    shapereader.Record
-    shapereader.natural_earth
-    shapereader.NEShpDownloader
-    shapereader.gshhs
-    shapereader.GSHHSShpDownloader
-
+    Reader
+    BasicReader
+    FionaReader
+    Record
+    FionaRecord
+    natural_earth
+    NEShpDownloader
+    gshhs
+    GSHHSShpDownloader
 
 Image collections
 ~~~~~~~~~~~~~~~~~
 
+.. module:: cartopy.io.img_nest
+
+:mod:`cartopy.io.img_nest` provides an interface for representing images.
+
 .. autosummary::
     :toctree: generated/
 
-    img_nest.Img
-    img_nest.ImageCollection
-    img_nest.NestedImageCollection
-
+    Img
+    ImageCollection
+    NestedImageCollection
 
 Image tiles
 ~~~~~~~~~~~
 
-These classes provide an interface to the respective tile resources to
+.. module:: cartopy.io.img_tiles
+
+Classes in :mod:`cartopy.io.img_tiles` provide an interface to the respective tile resources to
 automatically load the proper tile and resolution depending on the desired domain.
 
 .. autosummary::
     :toctree: generated/
 
-    img_tiles.OSM
-    img_tiles.GoogleTiles
-    img_tiles.GoogleWTS
-    img_tiles.MapQuestOSM
-    img_tiles.MapQuestOpenAerial
-    img_tiles.MapboxStyleTiles
-    img_tiles.MapboxTiles
-    img_tiles.OrdnanceSurvey
-    img_tiles.QuadtreeTiles
-    img_tiles.Stamen
-
+    OSM
+    GoogleTiles
+    GoogleWTS
+    MapQuestOSM
+    MapQuestOpenAerial
+    MapboxStyleTiles
+    MapboxTiles
+    OrdnanceSurvey
+    QuadtreeTiles
+    Stamen
 
 Open Geospatial Consortium (OGC)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are several classes to enable interfacing with OGC clients.
+.. module:: cartopy.io.ogc_clients
+
+:mod:`cartopy.io.ogc_clients` contains several classes to enable interfacing with OGC clients.
 
 .. autosummary::
     :toctree: generated/
 
-    ogc_clients.WFSGeometrySource
-    ogc_clients.WMSRasterSource
-    ogc_clients.WMTSRasterSource
-
+    WFSGeometrySource
+    WMSRasterSource
+    WMTSRasterSource
 
 Shuttle Radar Topography Mission (SRTM)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. module:: cartopy.io.srtm
 
 The SRTM data can be accessed through the :mod:`cartopy.io.srtm` module
 using classes and functions defined below.
@@ -83,20 +91,21 @@ using classes and functions defined below.
     :toctree: generated/
     :recursive:
 
-    srtm.SRTM1Source
-    srtm.SRTM3Source
-    srtm.SRTMDownloader
-    srtm.read_SRTM
-    srtm.read_SRTM1
-    srtm.read_SRTM3
-    srtm.add_shading
-
+    SRTM1Source
+    SRTM3Source
+    SRTMDownloader
+    read_SRTM
+    read_SRTM1
+    read_SRTM3
+    add_shading
 
 Base classes and functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-These are the base classes that new resources can leverage
+These are the base classes in :mod:`cartopy.io` that new resources can leverage
 to implement a new reader or tile client.
+
+.. module:: cartopy.io
 
 .. autosummary::
     :toctree: generated/

--- a/docs/source/reference/matplotlib.rst
+++ b/docs/source/reference/matplotlib.rst
@@ -11,6 +11,8 @@ projections, such as non-rectangular axes and spines.
 Geoaxes
 ~~~~~~~
 
+.. module:: cartopy.mpl.geoaxes
+
 The most primitive extension is the :class:`cartopy.mpl.geoaxes.GeoAxes` class, which
 extends a Matplotlib Axes and adds a `transform` keyword
 argument to many plotting methods to enable geographic projections and boundary wrapping
@@ -20,16 +22,16 @@ to occur on the axes.
     :toctree: generated/
     :template: autosummary/class_without_inherited.rst
 
-    geoaxes.GeoAxes
-    geoaxes.GeoAxesSubplot
-    geoaxes.GeoSpine
-    geoaxes.InterProjectionTransform
+    GeoAxes
+    GeoAxesSubplot
+    GeoSpine
+    InterProjectionTransform
 
-
-.. currentmodule:: cartopy.mpl
 
 Gridlines and ticks
 ~~~~~~~~~~~~~~~~~~~
+
+.. module:: cartopy.mpl.gridliner
 
 Cartopy can produce gridlines and ticks in any projection and add
 them to the current geoaxes projection, providing a way to add detailed
@@ -39,14 +41,23 @@ location information to the plots.
     :toctree: generated/
     :template: autosummary/class_without_inherited.rst
 
-    gridliner.Gridliner
-    ticker.LongitudeFormatter
-    ticker.LatitudeFormatter
-    ticker.LongitudeLocator
-    ticker.LatitudeLocator
+    Gridliner
+
+.. module:: cartopy.mpl.ticker
+
+.. autosummary::
+    :toctree: generated/
+    :template: autosummary/class_without_inherited.rst
+
+    LongitudeFormatter
+    LatitudeFormatter
+    LongitudeLocator
+    LatitudeLocator
 
 Artist extensions
 ~~~~~~~~~~~~~~~~~
+
+.. module:: cartopy.mpl.feature_artist
 
 Features and images can be added to a :class:`cartopy.mpl.geoaxes.GeoAxes` through
 an extension of the Matplotlib Artist interfaces.
@@ -55,13 +66,21 @@ an extension of the Matplotlib Artist interfaces.
     :toctree: generated/
     :template: autosummary/class_without_inherited.rst
 
-    feature_artist.FeatureArtist
-    slippy_image_artist.SlippyImageArtist
+    FeatureArtist
 
-.. currentmodule:: cartopy.mpl
+.. module:: cartopy.mpl.slippy_image_artist
+
+.. autosummary::
+    :toctree: generated/
+    :template: autosummary/class_without_inherited.rst
+
+    SlippyImageArtist
+
 
 Additional extensions
 ~~~~~~~~~~~~~~~~~~~~~
+
+.. module:: cartopy.mpl.patch
 
 Extra functionality that is primarily intended for developers. They describe
 some of the capabilities for transforming
@@ -70,6 +89,6 @@ between GEOS, Shapely, and Matplotlib paths.
 .. autosummary::
     :toctree: generated/
 
-    patch.geos_to_path
-    patch.path_segments
-    patch.path_to_geos
+    geos_to_path
+    path_segments
+    path_to_geos

--- a/docs/source/reference/transformations.rst
+++ b/docs/source/reference/transformations.rst
@@ -1,7 +1,5 @@
 .. _api.transformations:
 
-.. currentmodule:: cartopy
-
 Image and vector transformations
 --------------------------------
 
@@ -11,40 +9,56 @@ and reshape data when going from one projection to another.
 Image transformations
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. autosummary::
-   :toctree: generated/
+.. module:: cartopy.img_transform
 
-    img_transform.mesh_projection
-    img_transform.regrid
-    img_transform.warp_array
-    img_transform.warp_img
+:mod:`cartopy.img_transform` contains:
+
+.. autosummary::
+    :toctree: generated/
+
+    mesh_projection
+    regrid
+    warp_array
+    warp_img
 
 Vector transformations
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. autosummary::
-   :toctree: generated/
+.. module:: cartopy.vector_transform
 
-    vector_transform.vector_scalar_to_grid
+:mod:`cartopy.vector_transform` contains:
+
+.. autosummary::
+    :toctree: generated/
+
+    vector_scalar_to_grid
 
 Longitude wrapping
 ~~~~~~~~~~~~~~~~~~
 
-.. autosummary::
-   :toctree: generated/
+.. module:: cartopy.util
 
-    util.add_cyclic_point
-    util.add_cyclic
+:mod:`cartopy.util` contains:
+
+.. autosummary::
+    :toctree: generated/
+
+    add_cyclic_point
+    add_cyclic
 
 
 LinearRing/LineString projection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autosummary::
-   :toctree: generated/
+.. module:: cartopy.trace
 
-   trace.project_linear
-   trace.Interpolator
-   trace.CartesianInterpolator
-   trace.SphericalInterpolator
-   trace.LineAccumulator
+:mod:`cartopy.trace` contains:
+
+.. autosummary::
+    :toctree: generated/
+
+    project_linear
+    Interpolator
+    CartesianInterpolator
+    SphericalInterpolator
+    LineAccumulator

--- a/docs/source/whatsnew/v0.14.rst
+++ b/docs/source/whatsnew/v0.14.rst
@@ -23,7 +23,7 @@ Features
 * The SRTM3 data source has been changed to the `LP DAAC Data Pool
   <https://lpdaac.usgs.gov/data_access/data_pool>`_. The Data Pool is more
   consistent, fixing several missing tiles, and the data is void-filled.
-  Consequently, the :func:`cartopy.srtm.fill_gaps` function has been deprecated
+  Consequently, the ``cartopy.srtm.fill_gaps`` function has been deprecated
   as it has no purpose within the STRM context. The
   SRTM example has also been updated to skip the void-filling step.
   Additionally, this data source provides SRTM at a higher resolution of

--- a/docs/source/whatsnew/v0.17.rst
+++ b/docs/source/whatsnew/v0.17.rst
@@ -38,7 +38,7 @@ Features
 
 * Greg Lucas contributed functionality to plot day/night across the globe,
   which was turned into a map feature by Phil Elson. The shading can be added
-  to a map with :data:`cartopy.feature.nightshade.Nightshade(datetime)`. For
+  to a map with :meth:`cartopy.feature.nightshade.Nightshade(datetime) <cartopy.feature.nightshade.Nightshade>`. For
   more information, see the
   :ref:`sphx_glr_gallery_lines_and_polygons_nightshade.py` example.
   (:pull:`1135`, :pull:`1181`)

--- a/examples/miscellanea/animate_surface.py
+++ b/examples/miscellanea/animate_surface.py
@@ -3,7 +3,7 @@ Animating a gridded surface
 ---------------------------
 
 This example demonstrates how to animate
-gridded data using `pcolormesh()`.
+gridded data using `~cartopy.mpl.geoaxes.GeoAxes.pcolormesh()`.
 """
 from matplotlib.animation import FuncAnimation
 import matplotlib.pyplot as plt

--- a/examples/miscellanea/axes_grid_basic.py
+++ b/examples/miscellanea/axes_grid_basic.py
@@ -2,12 +2,14 @@
 Using Cartopy and AxesGrid toolkit
 ----------------------------------
 
-This example demonstrates how to use cartopy `GeoAxes` with
-`AxesGrid` from the `mpl_toolkits.axes_grid1`.
-The script constructs an `axes_class` kwarg with Plate Carree projection
-and passes it to the `AxesGrid` instance. The `AxesGrid` built-in
-tick labelling is not used, and instead a standard procedure
-of creating grid lines is used. Then some fake data is plotted.
+This example demonstrates how to use cartopy `~cartopy.mpl.geoaxes.GeoAxes`
+with `~mpl_toolkits.axes_grid1.axes_grid.AxesGrid` from the
+:mod:`mpl_toolkits.axes_grid1`. The script constructs an ``axes_class`` kwarg
+with Plate Carree projection and passes it to the
+`~mpl_toolkits.axes_grid1.axes_grid.AxesGrid` instance. The
+`~mpl_toolkits.axes_grid1.axes_grid.AxesGrid` built-in tick labelling
+is not used, and instead a standard procedure of creating grid lines is used.
+Then some fake data is plotted.
 """
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import AxesGrid

--- a/examples/scalar_data/wrapping_global.py
+++ b/examples/scalar_data/wrapping_global.py
@@ -8,10 +8,11 @@ represented in spherical coordinates. This means that the plotting methods will
 not plot data between the last and the first longitude.
 
 To help with this, the data and longitude/latitude coordinate arrays can be
-expanded with a cyclic point to close this gap. The routine `add_cyclic`
-repeats the last data column. It can also add the first longitude plus the
-cyclic keyword (defaults to 360) to the end of the longitude array so that the
-data values at the ending longitudes will be closed to the wrap point.
+expanded with a cyclic point to close this gap. The routine
+`~cartopy.util.add_cyclic` repeats the last data column. It can also add the
+first longitude plus the cyclic keyword (defaults to 360) to the end of the
+longitude array so that the data values at the ending longitudes will be closed
+to the wrap point.
 
 """
 import matplotlib.pyplot as plt

--- a/lib/cartopy/io/img_nest.py
+++ b/lib/cartopy/io/img_nest.py
@@ -80,9 +80,9 @@ class Img(collections.namedtuple('Img', _img_class_attrs)):
         Determine potential world filename combinations, without checking
         their existence.
 
-        For example, a '*.tif' file may have one of the following
-        popular conventions for world file extensions '*.tifw',
-        '*.tfw', '*.TIFW' or '*.TFW'.
+        For example, a ``'*.tif'`` file may have one of the following
+        popular conventions for world file extensions ``'*.tifw'``,
+        ``'*.tfw'``, ``'*.TIFW'`` or ``'*.TFW'``.
 
         Given the possible world file extensions, the upper case basename
         combinations are also generated. For example, the file 'map.tif'
@@ -205,7 +205,7 @@ class ImageCollection:
             The directory path to search for image files.
         glob_pattern: optional
             The image filename glob pattern to search with.
-            Defaults to '*.tif'.
+            Defaults to ``'*.tif'``.
         img_class: optional
             The class used to construct each image in the Collection.
 
@@ -497,7 +497,8 @@ class NestedImageCollection:
         name_dir_pairs
             A list of image collection name and directory path pairs.
         glob_pattern: optional
-            The image collection filename glob pattern. Defaults to '*.tif'.
+            The image collection filename glob pattern. Defaults
+            to ``'*.tif'``.
         img_class: optional
             The class of images created in the image collection.
 

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -125,8 +125,9 @@ class BasicReader:
     """
     Provide an interface for accessing the contents of a shapefile.
 
-    The primary methods used on a Reader instance are
-    :meth:`~Reader.records` and :meth:`~Reader.geometries`.
+    The primary methods used on a BasicReader instance are
+    :meth:`~cartopy.io.shapereader.BasicReader.records` and
+    :meth:`~cartopy.io.shapereader.BasicReader.geometries`.
 
     """
 
@@ -152,7 +153,7 @@ class BasicReader:
         This interface is useful for accessing the geometries of the
         shapefile where knowledge of the associated metadata is not necessary.
         In the case where further metadata is needed use the
-        :meth:`~Reader.records`
+        :meth:`~cartopy.io.shapereader.BasicReader.records`
         interface instead, extracting the geometry from the record with the
         :meth:`~Record.geometry` method.
 
@@ -179,8 +180,9 @@ class FionaReader:
     Provides an interface for accessing the contents of a shapefile
     with the fiona library, which has a much faster reader than pyshp.
 
-    The primary methods used on a Reader instance are
-    :meth:`~Reader.records` and :meth:`~Reader.geometries`.
+    The primary methods used on a FionaReader instance are
+    :meth:`~cartopy.io.shapereader.FionaReader.records` and
+    :meth:`~cartopy.io.shapereader.FionaReader.geometries`.
 
     """
 
@@ -232,9 +234,9 @@ class FionaReader:
         This interface is useful for accessing the geometries of the
         shapefile where knowledge of the associated metadata is desired.
         In the case where further metadata is needed use the
-        :meth:`~Reader.records`
+        :meth:`~cartopy.io.shapereader.FionaReader.records`
         interface instead, extracting the geometry from the record with the
-        :meth:`~Record.geometry` method.
+        :meth:`~cartopy.io.shapereader.FionaRecord.geometry` method.
 
         """
         for item in self._data:
@@ -242,7 +244,7 @@ class FionaReader:
 
     def records(self):
         """
-        Returns an iterator of :class:`~Record` instances.
+        Returns an iterator of :class:`~FionaRecord` instances.
 
         """
         for item in self._data:

--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -133,7 +133,7 @@ class FeatureArtist(matplotlib.artist.Artist):
     def draw(self, renderer, *args, **kwargs):
         """
         Draw the geometries of the feature that intersect with the extent of
-        the :class:`cartopy.mpl.GeoAxes` instance to which this
+        the :class:`cartopy.mpl.geoaxes.GeoAxes` instance to which this
         object has been added.
 
         """

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -288,6 +288,7 @@ class GeoSpine(mspines.Spine):
         return ret
 
     def set_position(self, position):
+        """GeoSpine does not support changing its position."""
         raise NotImplementedError(
             'GeoSpine does not support changing its position.')
 
@@ -434,7 +435,7 @@ class GeoAxes(matplotlib.axes.Axes):
             Currently an image "factory" is just an object with
             an ``image_for_domain`` method. Examples of image factories
             are :class:`cartopy.io.img_nest.NestedImageCollection` and
-            :class:`cartopy.io.image_tiles.GoogleTiles`.
+            :class:`cartopy.io.img_tiles.GoogleTiles`.
 
         """
         if hasattr(factory, 'image_for_domain'):


### PR DESCRIPTION
## Rationale

As @greglucas  pointed out in #2220, the CI server shows some warnings while building the docs. Running on a newer version of sphinx (v7.0.1), there is also a warning in GeoSpine.set_position from a link in the inherited docstring. These are addressed here. Some more broken cross-references were also found/cleaned up by looking at the output of sphinx in nitpicky mode.

## Notes
1. This adds the :module: tag to all modules (including sub-modules), so they can be cross-referenced. Previously I had only changed this for the main the top-level modules, which is why there was still a warning about not finding the SRTM modules.

2. A class.rst template is created, which is used by default. Without this, the methods within a class were not generating HTML anchors that can be linked to, other than in the matplotlib and crs modules where a template was already explicitly used.

3. Sphinx version <6 needed to be pinned in docs/doc-requirements.txt (#2131), but I think this not needed now due to pydata/pydata-sphinx-theme#1132

## Implications

Improved cross-referencing throughout the docs.