### PR TITLE
DOC: Remove mentions of Travis CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,17 +5,10 @@
 [run]
 branch = True
 omit =
-    lib/cartopy/examples/*
-    lib/cartopy/sphinxext/*
     lib/cartopy/tests/*
     lib/cartopy/_version.py
     *.pxd
 plugins = Cython.Coverage
-
-[paths]
-source =
-    lib/cartopy
-    /home/travis/miniconda/envs/test-environment/lib/python?.?/site-packages/cartopy
 
 [report]
 exclude_lines =

--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@
 <a href="https://github.com/SciTools/cartopy/graphs/contributors">
 <img src="https://img.shields.io/github/contributors/SciTools/cartopy.svg"
  alt="# contributors" /></a>
-<a href="https://travis-ci.org/SciTools/cartopy/branches">
-<img src="https://api.travis-ci.org/repositories/SciTools/cartopy.svg?branch=main"
- alt="Travis-CI" /></a>
 <a href="https://zenodo.org/badge/latestdoi/5282596">
 <img src="https://zenodo.org/badge/5282596.svg"
  alt="zenodo" /></a>


### PR DESCRIPTION
Noticed that the link was broken in the README. We don't use Travis anymore, so just remove it. Also removed a few paths that are no longer there (examples, sphinxext) in `.coveragerc`