### PR TITLE
CI: Change pip install pin for releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install cibuildwheel
-        run: pipx install cibuildwheel==f21bb8376a051ffb6cb5604b28ccaef7b90e8ab7 # v2.14.1
+        run: pipx install cibuildwheel==2.14.1
       - id: set-matrix
         run: |
           MATRIX=$(


### PR DESCRIPTION
I messed up when updating the wheels matrix generation to use a hash instead of the version.
https://github.com/SciTools/cartopy/pull/2197#discussion_r1280033976

This is just for generating the wheels matrix of jobs and really shouldn't matter what specific version to use. So, rather than installing via a hash through github, lets just reference the pypi release version. This portion is less critical than below in actually building the wheels where we are able to reference the commit hash through the GitHub Actions specific utility.

I verified this on my fork: https://github.com/greglucas/cartopy/actions/runs/5766395153

After this is merged I will delete the old release from GitHub and make a new one with the same content and move the tag, which will trigger the release process again (since it failed last time).