### PR TITLE
REL: Include sdist in PyPI release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: sdist
-          path: dist/
+          path: dist
 
       - uses: pypa/cibuildwheel@f21bb8376a051ffb6cb5604b28ccaef7b90e8ab7 # v2.14.1
         with:
@@ -116,10 +116,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Download packages
+      - name: Download wheels
         uses: actions/download-artifact@v3
         with:
           name: artifact
+          path: dist
+
+      - name: Download sdist
+        uses: actions/download-artifact@v3
+        with:
+          name: sdist
           path: dist
 
       - name: Publish Package


### PR DESCRIPTION
It looks like we didn't upload the sdist to PyPI. We need to explicitly download that artifact since it is produced and named separately from the wheels.

closes #2228 