### PR TITLE
Add encoding support for shapereader

### DIFF
--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -131,9 +131,9 @@ class BasicReader:
 
     """
 
-    def __init__(self, filename, bbox=None):
+    def __init__(self, filename, bbox=None, encoding='utf-8'):
         # Validate the filename/shapefile
-        self._reader = reader = shapefile.Reader(filename)
+        self._reader = reader = shapefile.Reader(filename, encoding=encoding)
         if reader.shp is None or reader.shx is None or reader.dbf is None:
             raise ValueError("Incomplete shapefile definition "
                              "in '%s'." % filename)
@@ -186,10 +186,10 @@ class FionaReader:
 
     """
 
-    def __init__(self, filename, bbox=None):
+    def __init__(self, filename, bbox=None, encoding=None):
         self._data = []
 
-        with fiona.open(filename) as f:
+        with fiona.open(filename, encoding=encoding) as f:
             if bbox is not None:
                 assert len(bbox) == 4
                 features = f.filter(bbox=bbox)


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale
Based on the discussion of #2041, `shapereader` should support `encoding` in order to read shape files with non-default encoding. 

Currently, for a shape file with GBK encoding `aomen.shp` (containing the polygon for Macau)

```python
import cartopy.io.shapereader as shpreader
shp = shpreader.Reader('aomen.shp')
list(shp.records())
```
will produce error 

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc1 in position 0: invalid start byte
```
After this PR, the `encoding` can be specified

```python
import cartopy.io.shapereader as shpreader
shp = shpreader.Reader('aomen.shp', encoding='gbk')
list(shp.records())
```
and the results are

```
[<Record: <POLYGON ((113.55 22.217, 113.55 22.214, 113.555 22.206, 113.559 22.206, 113...>, 
{'BIANMA': 820000, 'NAME': '澳门特别行政区', 'ENAME': 'Aomen Tebianxingzhengqu'}, <fields>>]
```


<!-- Please provide detail as to *why* you are making this change. -->


## Implications
None as far as I know

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

-->
