### PR TITLE
Add documentation, kwargs for Reader

### DIFF
--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -262,15 +262,15 @@ class FionaReader:
 
 Reader = FionaReader if _HAS_FIONA else BasicReader
 """
-Returns an instance of the default available shapereader interface.
+Alias of the default available shapereader interface.
 
 Will either be :class:`~cartopy.io.shapereader.FionaReader` (if fiona
 installed) or :class:`~cartopy.io.shapereader.BasicReader`
 (based on PyShp). Note that FionaReader has greater speed and additional
 functionality, including attempting to auto-detect source encoding and
 support for different format drivers. Both libraries support the 'encoding'
-and 'bbox' keyword arguments. Note that BasicReader and FionaReader
-instances can also be created directly.
+and 'bbox' keyword arguments. If specific functionality is needed,
+BasicReader and FionaReader instances can also be created directly.
 
 """
 

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -260,23 +260,19 @@ class FionaReader:
                                item.items() if key != 'geometry'})
 
 
-def Reader(filename, bbox=None, **kwargs):
-    """
-    Returns an instance of the default available shapereader interface.
+Reader = FionaReader if _HAS_FIONA else BasicReader
+"""
+Returns an instance of the default available shapereader interface.
 
-    Will either be :class:`~cartopy.io.shapereader.FionaReader` (if fiona
-    installed) or :class:`~cartopy.io.shapereader.BasicReader`
-    (based on PyShp). Note that FionaReader has greater speed and additional
-    functionality, including attempting to auto-detect source encoding and
-    format driver support. Both libraries support the 'encoding'
-    and 'bbox' keyword arguments. Note that BasicReader and FionaReader
-    instances can also be created directly.
+Will either be :class:`~cartopy.io.shapereader.FionaReader` (if fiona
+installed) or :class:`~cartopy.io.shapereader.BasicReader`
+(based on PyShp). Note that FionaReader has greater speed and additional
+functionality, including attempting to auto-detect source encoding and
+support for different format drivers. Both libraries support the 'encoding'
+and 'bbox' keyword arguments. Note that BasicReader and FionaReader
+instances can also be created directly.
 
-    """
-    if _HAS_FIONA:
-        return FionaReader(filename, bbox, **kwargs)
-    else:
-        return BasicReader(filename, bbox, **kwargs)
+"""
 
 
 def natural_earth(resolution='110m', category='physical', name='coastline'):

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -133,9 +133,9 @@ class BasicReader:
 
     """
 
-    def __init__(self, filename, **kwargs):
+    def __init__(self, filename, bbox=None, **kwargs):
         # Validate the filename/shapefile
-        self._reader = reader = shapefile.Reader(filename, **kwargs)
+        self._reader = reader = shapefile.Reader(filename, bbox=bbox, **kwargs)
         if reader.shp is None or reader.shx is None or reader.dbf is None:
             raise ValueError("Incomplete shapefile definition "
                              "in '%s'." % filename)


### PR DESCRIPTION
## Rationale

There was some discussion on how to best implement support for the encoding keyword for the BasicReader and FionaReader interfaces in #2231, and passing it through kwargs was suggested. There is also a generally lack of documentation on 'Reader' that automatically selects between the two (currently the docs just say "alias of FionaReader").

## Implications

Clarifies use of shapereader.Reader and passes kwargs (notably encoding) upstream. bbox is also now passed to PyShp.
