### PR TITLE
Input filename for shapefile.Reader() should be a string

### DIFF
--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -133,7 +133,7 @@ class BasicReader:
 
     def __init__(self, filename, bbox=None):
         # Validate the filename/shapefile
-        self._reader = reader = shapefile.Reader(filename)
+        self._reader = reader = shapefile.Reader(str(filename))
         if reader.shp is None or reader.shx is None or reader.dbf is None:
             raise ValueError("Incomplete shapefile definition "
                              "in '%s'." % filename)


### PR DESCRIPTION


## Rationale

The input full path name for the function "shapefile.Reader()" should be a string. However, the file name get from e.g. natural_earth() is a pathlib.Path object. This causes an error when reading the data file. 

Change 
        self._reader = reader = shapefile.Reader(filename)
to
        self._reader = reader = shapefile.Reader(str(filename))
on line 136 in io/shapereader.py.
