### PR TITLE
Gridliner: don't destroy and recreate artists

### DIFF
--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -520,3 +520,29 @@ def test_gridliner_title_noadjust():
     ax.set_extent([-180, 180, -60, 60])
     fig.draw_without_rendering()
     assert ax.title.get_position() == pos
+
+
+def test_gridliner_labels_zoom():
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
+
+    # Start with a global map.
+    ax.set_global()
+    gl = ax.gridlines(draw_labels=True, auto_update=True)
+
+    fig.draw_without_rendering()  # Generate child artists
+    labels = [a.get_text() for a in gl.bottom_label_artists if a.get_visible()]
+    assert labels == ['180°', '120°W', '60°W', '0°', '60°E', '120°E', '180°']
+    # For first draw, active labels should be all of the labels.
+    assert len(gl._all_labels) == 24
+    assert gl._labels == gl._all_labels
+
+    # Zoom in.
+    ax.set_extent([-20, 10.0, 45.0, 70.0])
+
+    fig.draw_without_rendering()  # Update child artists
+    labels = [a.get_text() for a in gl.bottom_label_artists if a.get_visible()]
+    assert labels == ['15°W', '10°W', '5°W', '0°', '5°E']
+    # After zoom, we may not be using all the available labels.
+    assert len(gl._all_labels) == 24
+    assert gl._labels == gl._all_labels[:20]


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
@greglucas has asked for this at least twice!

When re-drawing the `GridLiner`, update its existing `LineCollection` and `Text` objects rather than creating new ones.  This was trivial for the `LineCollection`s but a bit more complicated for the labels since we might have different numbers of them e.g. after zooming.  Clearly Matplotlib's `Axis` has already solved that problem so I got my inspiration from [there](https://github.com/matplotlib/matplotlib/blob/e3a5cee92bf10f07608f9e638f8d586ba81f16c7/lib/matplotlib/axis.py#L1620-L1626).  We now keep two lists of labels: `_all_labels` is the list of labels that have been drawn at some point.  `_labels` is the list that were used at the most recent draw (and still gets cleared out and repopulated each time).

Goes on top of #2249.  ~Only the third commit is new.~

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

-->
