### PR TITLE
FIX: Handle invalid geometries for rectangular projections

### DIFF
--- a/lib/cartopy/tests/test_line_string.py
+++ b/lib/cartopy/tests/test_line_string.py
@@ -194,6 +194,15 @@ class TestBisect:
                 assert not any(np.isnan(coord)), \
                     'Unexpected NaN in projected coords.'
 
+    def test_nan_rectangular(self):
+        # Make sure rectangular projections can handle invalid geometries
+        projection = ccrs.Robinson()
+        line_string = sgeom.LineString([(0, 0), (1, 1), (np.nan, np.nan),
+                                        (2, 2), (3, 3)])
+        multi_line_string = projection.project_geometry(line_string,
+                                                        ccrs.PlateCarree())
+        assert len(multi_line_string.geoms) == 2
+
 
 class TestMisc:
     def test_misc(self):

--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -582,7 +582,10 @@ def project_linear(geometry not None, src_crs not None,
     cdef bool geom_fully_inside = False
     if isinstance(dest_projection, (ccrs._RectangularProjection, ccrs._WarpedRectangularProjection)):
         dest_line = sgeom.LineString([(x[0], x[1]) for x in dest_coords])
-        geom_fully_inside = gp_domain.covers(dest_line)
+        if dest_line.is_valid:
+            # We can only check for covers with valid geometries
+            # some have nans/infs at this point still
+            geom_fully_inside = gp_domain.covers(dest_line)
 
     lines = LineAccumulator()
     for src_idx in range(1, src_size):


### PR DESCRIPTION
Rectangular projections have an extra fast-path check to see if points can be transformed faster. This check requires valid geometries though, so ignore this case when dealing with invalid geometries.

closes #2260