### PR TITLE
MNT: Move cartopy feature download script into the package

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -72,7 +72,9 @@ jobs:
         shell: bash
         run: |
           # Check that the downloader tool at least knows where to get the data from (but don't actually download it)
-          python tools/cartopy_feature_download.py gshhs physical --dry-run
+          python -m cartopy.feature.download gshhs physical --dry-run
+          # It should also be available as a script
+          cartopy_feature_download gshhs physical --dry-run
           CARTOPY_GIT_DIR=$PWD
           pytest -ra -n 4 \
               --color=yes \

--- a/lib/cartopy/feature/download/__main__.py
+++ b/lib/cartopy/feature/download/__main__.py
@@ -10,7 +10,7 @@ the data used by various Feature instances.
 
 For detail on how to use this tool, execute it with the `-h` option:
 
-    python cartopy_feature_download.py -h
+    python -m cartopy.feature.download -h
 
 """
 
@@ -107,7 +107,7 @@ def download_features(group_names, dry_run=True):
                               ''.format(category, name, scale, len(geoms)))
 
 
-if __name__ == '__main__':
+def main():
     parser = argparse.ArgumentParser(description='Download feature datasets.')
     parser.add_argument('group_names', nargs='+',
                         choices=FEATURE_DEFN_GROUPS,
@@ -146,3 +146,7 @@ if __name__ == '__main__':
     config['downloaders'][SHP_NE_SPEC].url_template = URL_TEMPLATE
 
     download_features(args.group_names, dry_run=args.dry_run)
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ plotting = ["pillow>=6.1.0", "scipy>=1.3.1"]
 test = ["pytest>=5.1.2", "pytest-mpl>=0.11", "pytest-xdist", "pytest-cov", "coveralls"]
 
 [project.scripts]
-feature_download = "tools.cartopy_feature_download.py:__main__"
+cartopy_feature_download = "cartopy.feature.download.__main__:main"
 
 [project.urls]
 documentation='https://scitools.org.uk/cartopy/docs/latest/'


### PR DESCRIPTION
Move it from the tools directory into the feature module and make it an executable module by calling it __main__.py

It can be invoked with `python -m cartopy.feature.download` now.

Does this location make sense? This adds a new download module so that the execution has download in the name which I think helps with discoverability/readability (`python -m cartopy.feature -h` isn't as readable IMO if we put `__main__.py` in the top-level), I'm open to other suggestions as well.

closes #2227

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

-->
