### PR TITLE
Add xfails to current owslib failures

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,6 +93,12 @@ subsection_order = ExplicitOrder(['../../examples/lines_and_polygons',
 sphinx_gallery_conf = {
     'capture_repr': (),
     'examples_dirs': ['../../examples'],
+    # NASA wmts servers are returning bad content metadata
+    "expected_failing_examples": [
+        '../../examples/web_services/reprojected_wmts.py',
+        '../../examples/web_services/wmts.py',
+        '../../examples/web_services/wmts_time.py',
+    ],
     'filename_pattern': '^((?!sgskip).)*$',
     'gallery_dirs': ['gallery'],
     'within_subsection_order': ExampleTitleSortKey,

--- a/examples/miscellanea/eccentric_ellipse.py
+++ b/examples/miscellanea/eccentric_ellipse.py
@@ -37,7 +37,7 @@ def vesta_image():
         the ``img_proj`` coordinate system.
 
     """
-    url = 'https://www.nasa.gov/sites/default/files/pia17037.jpg'
+    url = 'https://photojournal.jpl.nasa.gov/jpeg/PIA17037.jpg'
     img_handle = BytesIO(urlopen(url).read())
     raw_image = Image.open(img_handle)
     # The image is extremely high-resolution, which takes a long time to

--- a/lib/cartopy/tests/io/test_ogc_clients.py
+++ b/lib/cartopy/tests/io/test_ogc_clients.py
@@ -129,6 +129,7 @@ class TestWMSRasterSource:
 @pytest.mark.filterwarnings("ignore:TileMatrixLimits")
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
+@pytest.mark.xfail(reason='NASA servers are returning bad content metadata')
 class TestWMTSRasterSource:
     URI = 'https://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi'
     layer_name = 'VIIRS_CityLights_2012'

--- a/lib/cartopy/tests/mpl/test_caching.py
+++ b/lib/cartopy/tests/mpl/test_caching.py
@@ -150,6 +150,7 @@ def test_contourf_transform_path_counting():
 @pytest.mark.filterwarnings("ignore:TileMatrixLimits")
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
+@pytest.mark.xfail(reason='NASA servers are returning bad content metadata')
 def test_wmts_tile_caching():
     image_cache = WMTSRasterSource._shared_image_cache
     image_cache.clear()

--- a/lib/cartopy/tests/mpl/test_web_services.py
+++ b/lib/cartopy/tests/mpl/test_web_services.py
@@ -15,6 +15,7 @@ from cartopy.io.ogc_clients import _OWSLIB_AVAILABLE
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
 @pytest.mark.mpl_image_compare(filename='wmts.png', tolerance=0.03)
+@pytest.mark.xfail(reason='NASA servers are returning bad content metadata')
 def test_wmts():
     ax = plt.axes(projection=ccrs.PlateCarree())
     url = 'https://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi'


### PR DESCRIPTION
This adds xfails to all of the 10 current failures in the test suite. It also adds the failing documentation examples to the expected failures there as well.

In addition, running the examples locally I noticed that there is now a 404 from the Vesta image example, so another commit to change the URL for that example.