### PR TITLE
DOC: Change Stamen image tiles over to Google

### DIFF
--- a/examples/lines_and_polygons/effects_of_the_ellipse.py
+++ b/examples/lines_and_polygons/effects_of_the_ellipse.py
@@ -23,7 +23,7 @@ from shapely.ops import transform as geom_transform
 
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
-from cartopy.io.img_tiles import Stamen
+from cartopy.io.img_tiles import GoogleTiles
 
 
 def transform_fn_factory(target_crs, source_crs):
@@ -57,8 +57,8 @@ def main():
                                            name='coastline',
                                            scale='10m')
 
-    # Create a Stamen map tiler instance, and use its CRS for the GeoAxes.
-    tiler = Stamen('terrain-background')
+    # Create an image tiler instance, and use its CRS for the GeoAxes.
+    tiler = GoogleTiles(style="satellite")
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1, projection=tiler.crs)
     ax.set_title('The effect of incorrectly referencing the Solomon Islands')
@@ -69,7 +69,7 @@ def main():
     ax.set_extent(extent, geodetic)
     geoms = list(dataset.intersecting_geometries(extent))
 
-    # Add the Stamen aerial imagery at zoom level 7.
+    # Add the aerial imagery at zoom level 7.
     ax.add_image(tiler, 7)
 
     # Transform the geodetic coordinates of the coastlines into the two

--- a/examples/scalar_data/eyja_volcano.py
+++ b/examples/scalar_data/eyja_volcano.py
@@ -3,7 +3,7 @@ Map tile acquisition
 --------------------
 
 Demonstrates cartopy's ability to draw map tiles which are downloaded on
-demand from the Stamen tile server. Internally these tiles are then combined
+demand from the Google tile server. Internally these tiles are then combined
 into a single image and displayed in the cartopy GeoAxes.
 
 """
@@ -15,19 +15,19 @@ import cartopy.io.img_tiles as cimgt
 
 
 def main():
-    # Create a Stamen terrain background instance.
-    stamen_terrain = cimgt.Stamen('terrain-background')
+    # Create a background image tile.
+    google_terrain = cimgt.GoogleTiles(style="satellite")
 
     fig = plt.figure()
 
     # Create a GeoAxes in the tile's projection.
-    ax = fig.add_subplot(1, 1, 1, projection=stamen_terrain.crs)
+    ax = fig.add_subplot(1, 1, 1, projection=google_terrain.crs)
 
     # Limit the extent of the map to a small longitude/latitude range.
     ax.set_extent([-22, -15, 63, 65], crs=ccrs.Geodetic())
 
-    # Add the Stamen data at zoom level 8.
-    ax.add_image(stamen_terrain, 8)
+    # Add the tile data at zoom level 8.
+    ax.add_image(google_terrain, 8)
 
     # Add a marker for the Eyjafjallajökull volcano.
     ax.plot(-19.613333, 63.62, marker='o', color='red', markersize=12,

--- a/examples/web_services/image_tiles.py
+++ b/examples/web_services/image_tiles.py
@@ -9,11 +9,11 @@ providing web service can be accessed.
 import matplotlib.pyplot as plt
 
 import cartopy.crs as ccrs
-from cartopy.io.img_tiles import Stamen
+from cartopy.io.img_tiles import GoogleTiles
 
 
 def main():
-    tiler = Stamen('terrain-background')
+    tiler = GoogleTiles(style="satellite")
     mercator = tiler.crs
 
     fig = plt.figure()


### PR DESCRIPTION
This changes examples that used Stamen over to Google. The Stamen versions are no longer accessible without an API key, so switching over to a public tile server is the easiest fix for now.