### PR TITLE
MNT: Update gitignore items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,22 +7,13 @@ dist
 
 # cartopy build files
 lib/cartopy/_version.py
-lib/cartopy/trace.cpp
-lib/cartopy/trace.so
-lib/cartopy/trace.*.so
-lib/cartopy/trace.pyd
-lib/cartopy/_crs.c
-lib/cartopy/_crs.so
-lib/cartopy/_crs.*.so
-lib/cartopy/_crs.pyd
-lib/cartopy/geodesic/_geodesic.c
-lib/cartopy/geodesic/_geodesic.so
-lib/cartopy/geodesic/_geodesic.*.so
-lib/cartopy/geodesic/_geodesic.pyd
+*.cpp
+*.so
+*.pyd
+
 docs/build
 lib/cartopy/tests/mpl/output/
 docs/source/cartopy/examples/
-docs/source/cartopy_outline.rst
 docs/source/gallery
 docs/source/matplotlib/coastlines.p??
 docs/source/*/generated/
@@ -33,10 +24,10 @@ lib/cartopy/data/gshhs
 lib/cartopy/data/shapefiles
 
 # some configuration files which aren't part of cartopy repo
-lib/cartopy/tests/.pep8_test_exclude.txt
 lib/cartopy/siteconfig.py
 
-cartopy_test_output
+# Possible local downloads of these files during doc builds
+ne_10m_bathymetry*
 
 
 benchmarks/results/


### PR DESCRIPTION
This removes some old files that are no longer being produced and also ignores some new files that may come in via doc builds. In particular the ne_10m_bathymetry example.
