### PR TITLE
MNT: Use ruff for formatting checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,10 +25,6 @@ repos:
       - id: no-commit-to-branch
         # Trims trailing whitespace
       - id: trailing-whitespace
-  - repo: https://github.com/pycqa/flake8
-    rev: "6.1.0"
-    hooks:
-      - id: flake8
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.2.6"
     hooks:
@@ -40,9 +36,8 @@ repos:
     hooks:
       - id: sort-all
         types: [file, python]
-  - repo: https://github.com/PyCQA/isort
-    rev: "5.12.0"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 'v0.1.5'
     hooks:
-      - id: isort
-        types: [file, python]
-        args: [--filter-files]
+    - id: ruff
+      args: [--fix]

--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
   - sphinx
   - sphinx-gallery
   # Extras
-  - flake8
   - pre-commit
   - pykdtree
+  - ruff
   - setuptools_scm

--- a/examples/miscellanea/eccentric_ellipse.py
+++ b/examples/miscellanea/eccentric_ellipse.py
@@ -13,9 +13,9 @@ matching eccentricity.
 from io import BytesIO
 from urllib.request import urlopen
 
-from PIL import Image
 import matplotlib.pyplot as plt
 import numpy as np
+from PIL import Image
 
 import cartopy.crs as ccrs
 

--- a/lib/cartopy/feature/nightshade.py
+++ b/lib/cartopy/feature/nightshade.py
@@ -9,8 +9,8 @@ import datetime
 import numpy as np
 import shapely.geometry as sgeom
 
-from . import ShapelyFeature
 from .. import crs as ccrs
+from . import ShapelyFeature
 
 
 class Nightshade(ShapelyFeature):

--- a/lib/cartopy/io/img_nest.py
+++ b/lib/cartopy/io/img_nest.py
@@ -8,8 +8,8 @@
 import collections
 from pathlib import Path
 
-from PIL import Image
 import numpy as np
+from PIL import Image
 import shapely.geometry as sgeom
 
 

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -23,8 +23,8 @@ import io
 from pathlib import Path
 import warnings
 
-from PIL import Image
 import numpy as np
+from PIL import Image
 import shapely.geometry as sgeom
 
 import cartopy
@@ -751,12 +751,12 @@ class AzureMapsTiles(GoogleWTS):
             A valid Azure Maps subscription key.
         tileset_id
             A tileset ID for a map. See
-            https://docs.microsoft.com/en-us/rest/api/maps/renderv2/getmaptilepreview#tilesetid  # noqa: E501
+            https://docs.microsoft.com/en-us/rest/api/maps/renderv2/getmaptilepreview#tilesetid
             for details.
         api_version
             API version to use. Defaults to 2.0 as recommended by Microsoft.
 
-        """
+        """  # noqa: E501
         super().__init__(desired_tile_form=desired_tile_form, cache=cache)
         self.subscription_key = subscription_key
         self.tileset_id = tileset_id

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -24,8 +24,8 @@ import warnings
 import weakref
 from xml.etree import ElementTree
 
-from PIL import Image
 import numpy as np
+from PIL import Image
 import shapely.geometry as sgeom
 
 

--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -19,8 +19,12 @@ import shapely.geometry as sgeom
 
 import cartopy
 from cartopy.crs import PlateCarree, Projection, _RectangularProjection
-from cartopy.mpl.ticker import (LatitudeFormatter, LatitudeLocator, LongitudeFormatter,
-                                LongitudeLocator)
+from cartopy.mpl.ticker import (
+    LatitudeFormatter,
+    LatitudeLocator,
+    LongitudeFormatter,
+    LongitudeLocator,
+)
 
 
 degree_locator = mticker.MaxNLocator(nbins=9, steps=[1, 1.5, 1.8, 2, 3, 6, 10])

--- a/lib/cartopy/tests/io/test_ogc_clients.py
+++ b/lib/cartopy/tests/io/test_ogc_clients.py
@@ -21,8 +21,8 @@ except ImportError:
 import pytest
 
 import cartopy.crs as ccrs
-import cartopy.io.ogc_clients as ogc
 from cartopy.io.ogc_clients import _OWSLIB_AVAILABLE
+import cartopy.io.ogc_clients as ogc
 
 
 RESOLUTION = (30, 30)

--- a/lib/cartopy/tests/io/test_srtm.py
+++ b/lib/cartopy/tests/io/test_srtm.py
@@ -31,8 +31,12 @@ def srtm_login_or_skip(monkeypatch):
         pytest.skip('SRTM_PASSWORD environment variable is unset.')
 
     from http.cookiejar import CookieJar
-    from urllib.request import (HTTPBasicAuthHandler, HTTPCookieProcessor,
-                                HTTPPasswordMgrWithDefaultRealm, build_opener)
+    from urllib.request import (
+        HTTPBasicAuthHandler,
+        HTTPCookieProcessor,
+        HTTPPasswordMgrWithDefaultRealm,
+        build_opener,
+    )
 
     password_manager = HTTPPasswordMgrWithDefaultRealm()
     password_manager.add_password(

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -17,8 +17,13 @@ from shapely.geos import geos_version
 import cartopy.crs as ccrs
 from cartopy.mpl import _MPL_36
 from cartopy.mpl.geoaxes import GeoAxes
-from cartopy.mpl.gridliner import (LATITUDE_FORMATTER, LONGITUDE_FORMATTER, Gridliner,
-                                   classic_formatter, classic_locator)
+from cartopy.mpl.gridliner import (
+    LATITUDE_FORMATTER,
+    LONGITUDE_FORMATTER,
+    Gridliner,
+    classic_formatter,
+    classic_locator,
+)
 from cartopy.mpl.ticker import LongitudeFormatter, LongitudeLocator
 
 

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -6,10 +6,10 @@
 
 import types
 
-from PIL import Image
 import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 import numpy as np
+from PIL import Image
 import pytest
 import shapely.geometry as sgeom
 

--- a/lib/cartopy/tests/mpl/test_ticker.py
+++ b/lib/cartopy/tests/mpl/test_ticker.py
@@ -12,8 +12,12 @@ import pytest
 
 import cartopy.crs as ccrs
 from cartopy.mpl.geoaxes import GeoAxes
-from cartopy.mpl.ticker import (LatitudeFormatter, LatitudeLocator, LongitudeFormatter,
-                                LongitudeLocator)
+from cartopy.mpl.ticker import (
+    LatitudeFormatter,
+    LatitudeLocator,
+    LongitudeFormatter,
+    LongitudeLocator,
+)
 
 
 ONE_MIN = 1 / 60.

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -12,9 +12,8 @@ import pickle
 import warnings
 
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_array_equal
 from numpy.testing import assert_array_almost_equal as assert_arr_almost_eq
-from numpy.testing import assert_array_equal
 import pyproj
 import pytest
 import shapely.geometry as sgeom

--- a/lib/cartopy/tests/test_img_nest.py
+++ b/lib/cartopy/tests/test_img_nest.py
@@ -11,9 +11,9 @@ import shutil
 import sys
 import warnings
 
-from PIL import Image
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
+from PIL import Image
 import pytest
 import shapely.geometry as sgeom
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,16 +87,17 @@ ignore = [
     "lib/cartopy/trace.cpp",
 ]
 
-[tool.isort]
-force_sort_within_sections = true
-known_first_party = "cartopy"
-lines_after_imports = 2
-line_length = 88
-no_lines_before = "LOCALFOLDER"
-skip_gitignore = true
-verbose = false
-
 [tool.pytest.ini_options]
 addopts = "--mpl"
 testpaths = ["lib"]
 python_files = ["test_*.py"]
+
+[tool.ruff]
+target-version = "py39"
+select = ["E", "F", "I", "W"]
+
+[tool.ruff.isort]
+force-sort-within-sections = true
+known-first-party = ["cartopy"]
+lines-after-imports = 2
+no-lines-before = ["local-folder"]


### PR DESCRIPTION
Moves from flake8 and isort to ruff for the formatting checks. Also updates some of the sorted and formatted imports that were flagged by ruff. Ruff is significantly faster than flake8 / isort and we can also start adding additional checks later if we want. I looked at adding "D", but that is quite intimidating to update the docstrings right now with ~500-1k failures depending on which checks we want.