### PR TITLE
MNT: Remove beautifulsoup4 from docs requirements

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,4 +1,3 @@
 sphinx
 sphinx-gallery
-beautifulsoup4
 pydata-sphinx-theme

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,6 @@ dependencies:
   - pytest-mpl
   - pytest-xdist
   # Documentation
-  - beautifulsoup4
   - pydata-sphinx-theme
   - sphinx
   - sphinx-gallery

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,11 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-doc = ["beautifulsoup4", "pydata-sphinx-theme", "sphinx", "sphinx-gallery"]
+doc = ["pydata-sphinx-theme", "sphinx", "sphinx-gallery"]
 speedups = ["pykdtree", "fiona"]
 ows = ["OWSLib>=0.20.0", "pillow>=6.1.0"]
 plotting = ["pillow>=6.1.0", "scipy>=1.3.1"]
+srtm = ["beautifulsoup4"]
 test = ["pytest>=5.1.2", "pytest-mpl>=0.11", "pytest-xdist", "pytest-cov", "coveralls"]
 
 [project.scripts]


### PR DESCRIPTION
beautifulsoup4 was not used in our docs build. It is brought in by pydata-sphinx-theme, but we can leave that dependency resolution there. We do use beautifulsoup4 in SRTM tiles, but that has nothing to do with the docs installation. Not sure if we want to move that into a different category or create a new one altogether `srtm = ["beautifulsoup4"]`?