### PR TITLE
Update Matplotlib min version in pyproject.toml

### DIFF
--- a/lib/cartopy/mpl/__init__.py
+++ b/lib/cartopy/mpl/__init__.py
@@ -9,8 +9,5 @@ import packaging.version
 
 
 _MPL_VERSION = packaging.version.parse(matplotlib.__version__)
-_MPL_35 = _MPL_VERSION.release[:2] >= (3, 5)
 _MPL_36 = _MPL_VERSION.release[:2] >= (3, 6)
 _MPL_38 = _MPL_VERSION.release[:2] >= (3, 8)
-
-assert _MPL_35, 'Cartopy is only supported with Matplotlib 3.5 or greater.'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.21",
-    "matplotlib>=3.4",
+    "matplotlib>=3.5",
     "shapely>=1.7",
     "packaging>=20",
     "pyshp>=2.1",


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
I missed this one at #2258.

Does the fact that this pin is specified in the main dependencies here mean that it is impossible to install Cartopy in an environment with an older Matplotlib and therefore this check is redundant?

https://github.com/SciTools/cartopy/blob/53260b6e8aea3233eba232475332918257ff7b9a/lib/cartopy/mpl/__init__.py#L16

I have a vague memory that Matplotlib was once an optional dependency, which could be why it was written to error on import.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

-->
