### PR TITLE
Matplotlib 3.8 test warning

### DIFF
--- a/lib/cartopy/tests/mpl/conftest.py
+++ b/lib/cartopy/tests/mpl/conftest.py
@@ -20,6 +20,7 @@ def mpl_test_cleanup(request):
         plt.switch_backend('Agg')
         stack.enter_context(plt.rc_context())
         yield
+        plt.close('all')
 
 
 def pytest_itemcollected(item):

--- a/lib/cartopy/tests/mpl/conftest.py
+++ b/lib/cartopy/tests/mpl/conftest.py
@@ -15,12 +15,12 @@ def mpl_test_cleanup(request):
     with ExitStack() as stack:
         # At exit, close all open figures and switch backend back to original.
         stack.callback(plt.switch_backend, plt.get_backend())
+        stack.callback(plt.close, 'all')
 
         # Run each test in a context manager so that state does not leak out
         plt.switch_backend('Agg')
         stack.enter_context(plt.rc_context())
         yield
-        plt.close('all')
 
 
 def pytest_itemcollected(item):


### PR DESCRIPTION
## Rationale

tests\mpl\conftest.py gives the following warning:  "MatplotlibDeprecationWarning: Auto-close()ing of figures upon backend switching is deprecated since 3.8 and will be removed two minor releases later. To suppress this warning, explicitly call plt.close('all') first."

## Implications

The warning is addressed.
