### PR TITLE
MNT: remove deprecated Gridliner properties

### DIFF
--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -443,54 +443,6 @@ class Gridliner(matplotlib.artist.Artist):
         self._drawn = False
         self._auto_update = auto_update
 
-    @property
-    def xlabels_top(self):
-        warnings.warn('The .xlabels_top attribute is deprecated. Please '
-                      'use .top_labels to toggle visibility instead.')
-        return self.top_labels
-
-    @xlabels_top.setter
-    def xlabels_top(self, value):
-        warnings.warn('The .xlabels_top attribute is deprecated. Please '
-                      'use .top_labels to toggle visibility instead.')
-        self.top_labels = value
-
-    @property
-    def xlabels_bottom(self):
-        warnings.warn('The .xlabels_bottom attribute is deprecated. Please '
-                      'use .bottom_labels to toggle visibility instead.')
-        return self.bottom_labels
-
-    @xlabels_bottom.setter
-    def xlabels_bottom(self, value):
-        warnings.warn('The .xlabels_bottom attribute is deprecated. Please '
-                      'use .bottom_labels to toggle visibility instead.')
-        self.bottom_labels = value
-
-    @property
-    def ylabels_left(self):
-        warnings.warn('The .ylabels_left attribute is deprecated. Please '
-                      'use .left_labels to toggle visibility instead.')
-        return self.left_labels
-
-    @ylabels_left.setter
-    def ylabels_left(self, value):
-        warnings.warn('The .ylabels_left attribute is deprecated. Please '
-                      'use .left_labels to toggle visibility instead.')
-        self.left_labels = value
-
-    @property
-    def ylabels_right(self):
-        warnings.warn('The .ylabels_right attribute is deprecated. Please '
-                      'use .right_labels to toggle visibility instead.')
-        return self.right_labels
-
-    @ylabels_right.setter
-    def ylabels_right(self, value):
-        warnings.warn('The .ylabels_right attribute is deprecated. Please '
-                      'use .right_labels to toggle visibility instead.')
-        self.right_labels = value
-
     def has_labels(self):
         return len(self._labels) != 0
 


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
These properties were first deprecated in v0.18 (#1507), which [came out three and a half years ago](https://github.com/SciTools/cartopy/releases/tag/v0.18.0).

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

-->
