### PR TITLE
Revert "MNT: xfail owslib tests and documentation that use NASA"

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,12 +93,6 @@ subsection_order = ExplicitOrder(['../../examples/lines_and_polygons',
 sphinx_gallery_conf = {
     'capture_repr': (),
     'examples_dirs': ['../../examples'],
-    # NASA wmts servers are returning bad content metadata
-    "expected_failing_examples": [
-        '../../examples/web_services/reprojected_wmts.py',
-        '../../examples/web_services/wmts.py',
-        '../../examples/web_services/wmts_time.py',
-    ],
     'filename_pattern': '^((?!sgskip).)*$',
     'gallery_dirs': ['gallery'],
     'within_subsection_order': ExampleTitleSortKey,

--- a/lib/cartopy/tests/io/test_ogc_clients.py
+++ b/lib/cartopy/tests/io/test_ogc_clients.py
@@ -129,7 +129,6 @@ class TestWMSRasterSource:
 @pytest.mark.filterwarnings("ignore:TileMatrixLimits")
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
-@pytest.mark.xfail(reason='NASA servers are returning bad content metadata')
 class TestWMTSRasterSource:
     URI = 'https://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi'
     layer_name = 'VIIRS_CityLights_2012'

--- a/lib/cartopy/tests/mpl/test_caching.py
+++ b/lib/cartopy/tests/mpl/test_caching.py
@@ -150,7 +150,6 @@ def test_contourf_transform_path_counting():
 @pytest.mark.filterwarnings("ignore:TileMatrixLimits")
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
-@pytest.mark.xfail(reason='NASA servers are returning bad content metadata')
 def test_wmts_tile_caching():
     image_cache = WMTSRasterSource._shared_image_cache
     image_cache.clear()

--- a/lib/cartopy/tests/mpl/test_web_services.py
+++ b/lib/cartopy/tests/mpl/test_web_services.py
@@ -15,7 +15,6 @@ from cartopy.io.ogc_clients import _OWSLIB_AVAILABLE
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
 @pytest.mark.mpl_image_compare(filename='wmts.png', tolerance=0.03)
-@pytest.mark.xfail(reason='NASA servers are returning bad content metadata')
 def test_wmts():
     ax = plt.axes(projection=ccrs.PlateCarree())
     url = 'https://map1c.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi'


### PR DESCRIPTION
This reverts commit 6c6d93df7a039d25a6d35e36e0b9da2dc927dd26.

Removes the xfails and documentation for the NASA image server failures we were experiencing. @rcomer identified that these are succeeding again now: https://github.com/SciTools/cartopy/pull/2280#issuecomment-1783817044