### PR TITLE
DOC: fix LAND zorder in feature example

### DIFF
--- a/examples/lines_and_polygons/feature_creation.py
+++ b/examples/lines_and_polygons/feature_creation.py
@@ -28,7 +28,7 @@ def main():
     # Put a background image on for nice sea rendering.
     ax.stock_img()
 
-    # Create a feature for States/Admin 1 regions at 1:50m from Natural Earth
+    # Create a feature for States/Admin 1 regions at 1:50m from Natural Earth.
     states_provinces = cfeature.NaturalEarthFeature(
         category='cultural',
         name='admin_1_states_provinces_lines',
@@ -38,9 +38,11 @@ def main():
     SOURCE = 'Natural Earth'
     LICENSE = 'public domain'
 
-    ax.add_feature(cfeature.LAND)
-    ax.add_feature(cfeature.COASTLINE)
+    # Add our states feature.
     ax.add_feature(states_provinces, edgecolor='gray')
+    # Add land feature, overriding the default negative zorder so it shows
+    # above the background image.
+    ax.add_feature(cfeature.LAND, zorder=1, edgecolor='k')
 
     # Add a text annotation for the license information to the
     # the bottom right corner.


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Closes #1350.

I think the [v0.15 docs](https://scitools.org.uk/cartopy/docs/v0.15/examples/feature_creation.html) show the original intent was to have the land above the background image.  #916 changed the default zorder for `cfeature.LAND`.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

-->
