### PR TITLE
Bump pyshp min version to v2.3

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -33,7 +33,7 @@ jobs:
         if: matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
         id: minimum-packages
         run: |
-          pip install cython==0.29.24 matplotlib==3.5.3 numpy==1.21 owslib==0.24.1 pyproj==3.1 scipy==1.6.3 shapely==1.7.1
+          pip install cython==0.29.24 matplotlib==3.5.3 numpy==1.21 owslib==0.24.1 pyproj==3.1 scipy==1.6.3 shapely==1.7.1 pyshp==2.3.1
 
       - name: Coverage packages
         id: coverage

--- a/INSTALL
+++ b/INSTALL
@@ -69,7 +69,7 @@ Further information about the required dependencies can be found here:
 **Shapely** 1.7.1 or later (https://github.com/shapely/shapely)
     Python package for the manipulation and analysis of planar geometric objects.
 
-**pyshp** 2.1 or later (https://pypi.python.org/pypi/pyshp)
+**pyshp** 2.3 or later (https://pypi.python.org/pypi/pyshp)
     Pure Python read/write support for ESRI Shapefile format.
 
 **pyproj** 3.1.0 or later (https://github.com/pyproj4/pyproj/)

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - cython>=0.29.24
   - numpy>=1.21
   - shapely>=1.7.1
-  - pyshp>=2.1
+  - pyshp>=2.3
   - pyproj>=3.1.0
   # The testing label has the proper version of freetype included
   - conda-forge/label/testing::matplotlib-base>=3.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "matplotlib>=3.5",
     "shapely>=1.7",
     "packaging>=20",
-    "pyshp>=2.1",
+    "pyshp>=2.3",
     "pyproj>=3.1.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Closes #2284 and also replaces so closes #2239.  Cartopy passes path objects to `pyshp` but this is only possibly from v2.3.  Earlier versions fail with an unhelpful error message as shown in #2284.

Should `pyshp` also be pinned in the minimum versions CI test?

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

-->
