### PR TITLE
FIX: Remove force_path_ccw of contours

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -171,12 +171,7 @@ class InterProjectionTransform(mtransforms.Transform):
             return mpath.Path(self.transform(src_path.vertices))
 
         transformed_geoms = []
-        # Check whether this transform has the "force_path_ccw" attribute set.
-        # This is a cartopy extension to the Transform API to allow finer
-        # control of Path orientation handling (Path ordering is not important
-        # in matplotlib, but is in Cartopy).
-        geoms = cpatch.path_to_geos(src_path,
-                                    getattr(self, 'force_path_ccw', False))
+        geoms = cpatch.path_to_geos(src_path)
 
         for geom in geoms:
             proj_geom = self.target_projection.project_geometry(
@@ -1639,16 +1634,6 @@ class GeoAxes(matplotlib.axes.Axes):
             arguments X and Y must be provided and be 2-dimensional.
             The default is False, to compute the contours in data-space.
         """
-        t = kwargs.get('transform')
-        if isinstance(t, ccrs.Projection):
-            kwargs['transform'] = t = t._as_mpl_transform(self)
-        # Set flag to indicate correcting orientation of paths if not ccw
-        if isinstance(t, mtransforms.Transform):
-            for sub_trans, _ in t._iter_break_from_left_to_right():
-                if isinstance(sub_trans, InterProjectionTransform):
-                    if not hasattr(sub_trans, 'force_path_ccw'):
-                        sub_trans.force_path_ccw = True
-
         result = super().contourf(*args, **kwargs)
 
         # We need to compute the dataLim correctly for contours.


### PR DESCRIPTION
This was added to fix previously unoriented paths from Matplotlib's contouring code. This has seemingly been fixed upstream somewhere in the past and there is no test/reproducer in Cartopy, so we can remove this for now because the polygons are oriented as Shapely expects from Matplotlib.

closes #2288

If anyone has ideas for good test cases, it would be nice to add some, but I haven't really given much thought to what produces the bad geometries. An example of what I think would be nice to test below with some minimal values.
1. Contour with a hole in middle of projection
2. Contour with a hole wrapped around the edge of the globe (set `central_longitude=180` in the `proj_map` call)
3. Others...?

```python
import numpy as np
import matplotlib.pyplot as plt
from cartopy import crs as ccrs


proj_data = ccrs.PlateCarree()
proj_map = ccrs.Robinson()

xx, yy = np.meshgrid([-20, 0, 20], [-20, 0, 20])
levels = (10, 50)
zz = np.abs(xx) + np.abs(yy)

ax = plt.figure().add_subplot(projection=proj_map)

cset = ax.contourf(xx, yy, zz, transform=proj_data, levels=levels)
ax.coastlines()

plt.show()
```