### PR TITLE
Improve matrixing in GHA to work with SciTools/cartopy#2303

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -93,5 +93,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: image-failures-${{ matrix.os }}-${{ matrix.python-version }}
-          path: cartopy_test_output-${{ matrix.os }}-${{ matrix.python-version }}
+          name: image-failures-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.shapely-dev }}
+          path: cartopy_test_output-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.shapely-dev }}

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -79,7 +79,7 @@ jobs:
           pytest -ra -n 4 \
               --color=yes \
               --mpl --mpl-generate-summary=html \
-              --mpl-results-path="cartopy_test_output-${{ matrix.os }}-${{ matrix.python-version }}" \
+              --mpl-results-path="cartopy_test_output-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.shapely-dev }}" \
               --pyargs cartopy ${EXTRA_TEST_ARGS}
 
       - name: Coveralls


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

When a test fails, image results are uploaded. Since `actions/upload-artifact@v4` (#2303), it is the responsibility of the workflow YAML file to avoid name clashes in the artifacts. This PR makes sure that the whole matrix is included in the artifact name and path, avoiding clashes between `matrix.shapely-dev` `true` vs `false`.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

Failures for `ubuntu-latest`, latest python will not result in one of the image uploads failing due to a name clash with the other.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

-->
