### PR TITLE
Allow GSHHS levels 5 and 6 for Antarctica.

### DIFF
--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -365,7 +365,7 @@ class GSHHSFeature(Feature):
         if levels is None:
             levels = [1]
         self._levels = set(levels)
-        unknown_levels = self._levels.difference([1, 2, 3, 4])
+        unknown_levels = self._levels.difference([1, 2, 3, 4, 5, 6])
         if unknown_levels:
             raise ValueError(f"Unknown GSHHS levels {unknown_levels!r}.")
 


### PR DESCRIPTION
## Rationale

The [documentation for `GSHHSFeature`](https://scitools.org.uk/cartopy/docs/latest/reference/generated/cartopy.feature.GSHHSFeature.html) already states that levels 1 through 6 are allowed but the code so far only allowed 1 through 4.

As per https://www.ngdc.noaa.gov/mgg/shorelines/data/gshhg/readme.txt levels 5 and 6 were introduced in GSHHS version 2.3.0 in February 2014 to distinguish the Antarctic ice-front (L5) and grounding lines (L6).

Importantly, this also means that L1 does not contain any coastlines for Antarctica, so allowing only L1-L4 is insufficient.

See also https://www.soest.hawaii.edu/pwessel/gshhg/.


## Implications

 * Antarctica coastlines are supported.
 * Users have to manually choose L5 or L6 or both.


Side note: there are no existing tests I could piggyback on but "it works on my machine"... Let me know if you have a more structured way to make sure this works for everyone.
