### PR TITLE
DOC: don't use deprecated collections attribute

### DIFF
--- a/examples/scalar_data/contour_labels.py
+++ b/examples/scalar_data/contour_labels.py
@@ -44,13 +44,10 @@ def main():
     # Add colourful filled contours.
     filled_c = ax.contourf(x, y, z, transform=ccrs.PlateCarree())
 
-    # And black line contours.
+    # And black line contours (or set colors='none' for invisible lines).
     line_c = ax.contour(x, y, z, levels=filled_c.levels,
-                        colors=['black'],
+                        colors='black',
                         transform=ccrs.PlateCarree())
-
-    # Uncomment to make the line contours invisible.
-    # plt.setp(line_c.collections, visible=False)
 
     # Add a colorbar for the filled contour.
     fig.colorbar(filled_c, orientation='horizontal')


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
I just spotted this while grepping for something else.  The `ContourSet.collections` attribute was [deprecated at mpl 3.8](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.8.0.html#contourset-collections).  We could now just call `set_visible` on the `ContourSet` itself, but that will break with older Matplotlib versions.  I have checked that the current suggestion works with Cartopy main and mpl 3.8.2, and also with Cartopy 0.21.1 and mpl 3.6.3.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

-->
