### PR TITLE
FIX: use compound paths to draw transformed geometries

### DIFF
--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -585,7 +585,7 @@ def test_pcolormesh_set_clim_with_mask():
 
 @pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(filename='pcolormesh_limited_area_wrap.png',
-                               tolerance=1.82)
+                               tolerance=1.83)
 def test_pcolormesh_limited_area_wrap():
     # make up some realistic data with bounds (such as data from the UM's North
     # Atlantic Europe model)


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
When a geometry gets transformed to a different crs, it can become multiple geometries.  Currently we plot these as separate paths which could be problematic if the user passes a list of e.g. facecolors.

```python
import matplotlib.pyplot as plt
import cartopy.crs as ccrs
import shapely.geometry as sgeom

square1 = sgeom.Polygon([(-10, -10), (10, -10), (10, 10), (-10, 10), (-10, 10) ])
square2 = sgeom.Polygon([(30, 0), (50, 0), (50, 20), (30, 20), (30, 0)])

fig = plt.figure(figsize=(4, 5))

ax1 = fig.add_subplot(211, projection=ccrs.PlateCarree())
ax2 = fig.add_subplot(212, projection=ccrs.PlateCarree(central_longitude=180))

for ax in ax1, ax2:
    ax.coastlines()
    ax.add_geometries([square1, square2], crs=ccrs.PlateCarree(),
                      facecolors=['r', 'b'])

plt.show()
```
Before:
![image](https://github.com/SciTools/cartopy/assets/10599679/dfdc629e-b556-4a99-8e21-0364c9c9a810)

After:
![image](https://github.com/SciTools/cartopy/assets/10599679/fa6ae622-0eb4-448e-9b90-ef3c5b88efc6)


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

-->
