### PR TITLE
MNT: Remove wmts-time from expected doc failures

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,7 +96,6 @@ sphinx_gallery_conf = {
     "expected_failing_examples": [
         '../../examples/web_services/reprojected_wmts.py',
         '../../examples/web_services/wmts.py',
-        '../../examples/web_services/wmts_time.py',
     ],
     'filename_pattern': '^((?!sgskip).)*$',
     'gallery_dirs': ['gallery'],


### PR DESCRIPTION
It is working again. Docs should be green after this 🤞 
