### PR TITLE
MNT: deprecate the style module

### DIFF
--- a/lib/cartopy/mpl/style.py
+++ b/lib/cartopy/mpl/style.py
@@ -11,6 +11,10 @@ Handles matplotlib styling in a single consistent place.
 import warnings
 
 
+warnings.warn('The style module is deprecated and will be removed in a future release.',
+              DeprecationWarning, stacklevel=2)
+
+
 # Define the matplotlib style aliases that cartopy can expand.
 # Note: This should not contain the plural aliases
 # (e.g. linewidths -> linewidth).

--- a/lib/cartopy/tests/mpl/test_style.py
+++ b/lib/cartopy/tests/mpl/test_style.py
@@ -3,9 +3,14 @@
 # This file is part of Cartopy and is released under the BSD 3-clause license.
 # See LICENSE in the root of the repository for full licensing details.
 
+import warnings
+
 import pytest
 
-from cartopy.mpl import style
+
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', DeprecationWarning)
+    from cartopy.mpl import style
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
#2323 and #2333 removed our internal use of this module.

This module does 2 things
* Merges dictionaries of styles taking account of a hard-coded subset of Matplotlib aliases (specifically not plural aliases like _facecolors_).  If this was intended for general use I think it should handle all aliases, maybe making use of [ArtistInspector.get_aliases](https://matplotlib.org/stable/api/_as_gen/matplotlib.artist.ArtistInspector.html#matplotlib.artist.ArtistInspector.get_aliases) so it could be artist specific.  However a utility function for that probably belongs in Matplotlib (if anywhere) rather than here.
* Handles the Cartopy-specific `facecolor="never"`, but there is some discussion of removing that completely at https://github.com/SciTools/cartopy/pull/2323#discussion_r1493368803.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
One less module to maintain.

<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
