### PR TITLE
Prepare for Numpy 2.0

### DIFF
--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -53,21 +53,11 @@ _ROTATE_LABEL_PROJS = _POLAR_PROJS + (
 )
 
 
-def _fix_lons(lons):
-    """
-    Fix the given longitudes into the range ``[-180, 180]``.
-
-    """
-    lons = np.array(lons, copy=False, ndmin=1)
-    fixed_lons = ((lons + 180) % 360) - 180
-    # Make the positive 180s positive again.
-    fixed_lons[(fixed_lons == -180) & (lons > 0)] *= -1
-    return fixed_lons
-
-
 def _lon_hemisphere(longitude):
     """Return the hemisphere (E, W or '' for 0) for the given longitude."""
-    longitude = _fix_lons(longitude)
+    # Wrap the longitude to the range -180 to 180, keeping positive 180s
+    lon_wrapped = ((longitude + 180) % 360) - 180
+    longitude = 180 if (longitude > 0 and lon_wrapped == -180) else lon_wrapped
     if longitude > 0:
         hemisphere = 'E'
     elif longitude < 0:

--- a/lib/cartopy/tests/crs/test_oblique_mercator.py
+++ b/lib/cartopy/tests/crs/test_oblique_mercator.py
@@ -187,7 +187,7 @@ def test_equality(oblique_variants):
     "reverse_coord", [False, True], ids=["xy_order", "yx_order"]
 )
 def test_nan(oblique_mercator, plate_carree, reverse_coord):
-    coord = (0.0, np.NaN)
+    coord = (0.0, np.nan)
     if reverse_coord:
         coord = tuple(reversed(coord))
     res = oblique_mercator.transform_point(*coord, src_crs=plate_carree)


### PR DESCRIPTION
I installed the latest pre-release of numpy 2.0 to see if we had any failures appear and these were the only ones that showed up. Pretty simple fixes to all internal/test machinery.

Here is the quick command to help others wanting to test this out by upgrading some local packages as well if wanted.
`python -m pip install numpy matplotlib contourpy --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre --upgrade numpy`