### PR TITLE
FIX: Add xfail for bad test url

### DIFF
--- a/lib/cartopy/tests/mpl/test_features.py
+++ b/lib/cartopy/tests/mpl/test_features.py
@@ -80,7 +80,7 @@ def test_wfs():
 @pytest.mark.network
 @pytest.mark.skipif(not _HAS_PYKDTREE_OR_SCIPY or not _OWSLIB_AVAILABLE,
                     reason='OWSLib and at least one of pykdtree or scipy is required')
-@pytest.mark.xfail(raises=ParseError,
+@pytest.mark.xfail(raises=(ParseError, AttributeError),
                    reason="Bad XML returned from the URL")
 @pytest.mark.mpl_image_compare(filename='wfs_france.png')
 def test_wfs_france():


### PR DESCRIPTION
We are getting a `AttributeError` from the response from the server, trying to call `.find()` on a Nonetype object. So add the `AttributeError` to the xfail conditions as this is out of our control and based on the server.