### PR TITLE
CI: skip xfail output

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -76,7 +76,7 @@ jobs:
           # It should also be available as a script
           cartopy_feature_download gshhs physical --dry-run
           CARTOPY_GIT_DIR=$PWD
-          pytest -ra -n 4 \
+          pytest -rfEsX -n 4 \
               --color=yes \
               --mpl --mpl-generate-summary=html \
               --mpl-results-path="cartopy_test_output-${{ matrix.os }}-${{ matrix.python-version }}" \


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->


## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Since pytest v8 the [tracebacks for any xfailed tests appear in the test output if you run with `-rx`](https://docs.pytest.org/en/8.0.x/changelog.html#improvements).  This makes it harder to find the "real" failure tracebacks in CI output.  Following https://github.com/matplotlib/matplotlib/pull/27807, this PR removes the extra info flag for xfails.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
We no longer get the reasons for the xfails in the short summary information.  It does not seem to be possible to get that without the tracebacks at the moment.

<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
