### PR TITLE
CI: Only run coverage on a single runner

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Coverage packages
         id: coverage
         # only want the coverage to be run on the latest ubuntu
-        if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
+        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
         run: |
           echo "CYTHON_COVERAGE=1" >> $GITHUB_ENV
           # Also add doctest here to avoid windows runners which expect a different path separator


### PR DESCRIPTION
This bumps the coveralls job to Python 3.12 ubuntu-latest so that only one job gets run and submitted. It has been flaky when submitting from two sources. https://github.com/SciTools/cartopy/actions/runs/8218053565/job/22477742731?pr=2322#step:10:16
The Python 3.11 ubuntu-latest has a shapely-dev=true and a shapely-dev=false version, so hopefully this can avoid that if it is truly an issue.