### PR TITLE
DOC: Skip failing WMTS time example again due to flaky servers

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,6 +96,7 @@ sphinx_gallery_conf = {
     "expected_failing_examples": [
         '../../examples/web_services/reprojected_wmts.py',
         '../../examples/web_services/wmts.py',
+        '../../examples/web_services/wmts_time.py',
     ],
     'filename_pattern': '^((?!sgskip).)*$',
     'gallery_dirs': ['gallery'],


### PR DESCRIPTION
We should try and avoid NASA servers it seems like... If people have more reliable servers we could point to it would be great to switch these examples over.