### PR TITLE
CI: Ruff linter settings warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,9 +94,9 @@ python_files = ["test_*.py"]
 
 [tool.ruff]
 target-version = "py39"
-select = ["E", "F", "I", "W"]
+lint.select = ["E", "F", "I", "W"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 force-sort-within-sections = true
 known-first-party = ["cartopy"]
 lines-after-imports = 2


### PR DESCRIPTION
## Rationale

Running ruff check gives the following warning:
```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'select' -> 'lint.select'
  - 'isort' -> 'lint.isort'
```

## Implications
pyproject.toml is modified accordingly to avoid the warning.