### PR TITLE
MNT: xfail deprecated Google Image Tile API

### DIFF
--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -34,6 +34,11 @@ KNOWN_EXTENTS = {(0, 0, 0): (-20037508.342789244, 20037508.342789244,
 
 
 def GOOGLE_IMAGE_URL_REPLACEMENT(self, tile):
+    # TODO: This is a hack to replace the Google image URL with a static image.
+    #       This service has been deprecated by Google, so we need to replace it
+    #       See https://developers.google.com/chart/image for the notice
+    pytest.xfail(reason="Google has deprecated the tile API used in this test")
+
     x, y, z = tile
     return (f'https://chart.googleapis.com/chart?chst=d_text_outline&'
             f'chs=256x256&chf=bg,s,00000055&chld=FFFFFF|16|h|000000|b||||'


### PR DESCRIPTION
We need to find a replacement for these tests or find a different way to generate these images. The service is currently intermittent and turned off for longer periods of time it sounds like. https://developers.google.com/chart/image

xfail all tests that use this API for now (they are flaky, not necessarily always failing). This is so we can get the test suite passing to make a release now and not wait on the replacement.