### PR TITLE
BLD: Use numpy2.0.0rc1 to build the package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,13 @@ requires = [
     "wheel",
     "setuptools >= 40.6.0",
     "Cython >= 0.29.24",
-    "oldest-supported-numpy",
+    # numpy requirement for wheel builds for distribution on PyPI - building
+    # against 2.x yields wheels that are also compatible with numpy 1.x at
+    # runtime.
+    # Note that building against numpy 1.x works fine too - users and
+    # redistributors can do this by installing the numpy version they like and
+    # disabling build isolation.
+    "numpy>=2.0.0rc1",
     "setuptools_scm >= 7.0.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This will still work with older numpy versions when running Cartopy built from a wheel with this build requirement.

This is what scipy has done to build their wheels.
https://github.com/scipy/scipy/blob/e2e39f691c048b8ad6dd5e7d4eb5a396a81f8dd3/pyproject.toml#L25-L31

I have tested this with numpy 1.25, and also the latest shapely and matplotlib nightlies and all tests passed locally.
`pip install --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple shapely matplotlib`