### PR TITLE
TST: Pin pytest-mpl less than 0.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ speedups = ["pykdtree", "fiona"]
 ows = ["OWSLib>=0.20.0", "pillow>=6.1.0"]
 plotting = ["pillow>=6.1.0", "scipy>=1.3.1"]
 srtm = ["beautifulsoup4"]
-test = ["pytest>=5.1.2", "pytest-mpl>=0.11", "pytest-xdist", "pytest-cov", "coveralls"]
+test = ["pytest>=5.1.2", "pytest-mpl>=0.11,<0.17", "pytest-xdist", "pytest-cov", "coveralls"]
 
 [project.scripts]
 cartopy_feature_download = "cartopy.feature.download.__main__:main"


### PR DESCRIPTION
v0.17 of pytest-mpl might be producing flaky results on CI, so pin it to the old version for now until a new fix comes out.

This is a WIP to see if it is actually the culprit or not. This is just an educated guess based on their release date in February and images failing that don't require external resources.
Possibly related to: https://github.com/matplotlib/pytest-mpl/issues/225