### PR TITLE
MNT: add missing 'needs network' markers

### DIFF
--- a/lib/cartopy/tests/mpl/test_feature_artist.py
+++ b/lib/cartopy/tests/mpl/test_feature_artist.py
@@ -61,6 +61,7 @@ def cached_paths(geom, target_projection):
     return geom_cache.get(target_projection, None)
 
 
+@pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(filename='feature_artist.png')
 def test_feature_artist_draw(feature):
     fig, ax = robinson_map()
@@ -69,6 +70,7 @@ def test_feature_artist_draw(feature):
     return fig
 
 
+@pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(filename='feature_artist.png')
 def test_feature_artist_draw_facecolor_list(feature):
     fig, ax = robinson_map()
@@ -77,6 +79,7 @@ def test_feature_artist_draw_facecolor_list(feature):
     return fig
 
 
+@pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(filename='feature_artist.png')
 def test_feature_artist_draw_cmap(feature):
     fig, ax = robinson_map()
@@ -87,6 +90,7 @@ def test_feature_artist_draw_cmap(feature):
     return fig
 
 
+@pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(filename='feature_artist.png')
 def test_feature_artist_draw_styled_feature(feature):
     geoms = list(feature.geometries())
@@ -98,6 +102,7 @@ def test_feature_artist_draw_styled_feature(feature):
     return fig
 
 
+@pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(filename='feature_artist.png')
 def test_feature_artist_draw_styler(feature):
     geoms = list(feature.geometries())

--- a/lib/cartopy/tests/mpl/test_features.py
+++ b/lib/cartopy/tests/mpl/test_features.py
@@ -46,6 +46,7 @@ def test_natural_earth_custom():
     return ax.figure
 
 
+@pytest.mark.network
 @pytest.mark.skipif(not _HAS_PYKDTREE_OR_SCIPY, reason='pykdtree or scipy is required')
 @pytest.mark.mpl_image_compare(filename='gshhs_coastlines.png', tolerance=0.95)
 def test_gshhs():

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -336,6 +336,7 @@ def test_grid_labels_inline_usa(proj):
     return fig
 
 
+@pytest.mark.natural_earth
 @pytest.mark.skipif(geos_version == (3, 9, 0), reason="GEOS intersection bug")
 @pytest.mark.mpl_image_compare(filename='gridliner_labels_bbox_style.png',
                                tolerance=grid_label_tol)
@@ -496,6 +497,7 @@ def test_gridliner_count_draws():
         mocked.assert_called_once()
 
 
+@pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(
     baseline_dir='baseline_images/mpl/test_mpl_integration',
     filename='simple_global.png')
@@ -522,6 +524,7 @@ def test_gridliner_save_tight_bbox():
     fig.savefig(io.BytesIO(), bbox_inches='tight')
 
 
+@pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(filename='gridliner_labels_title_adjust.png',
                                tolerance=grid_label_tol)
 def test_gridliner_title_adjust():


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Closes #2368 by applying the provided patch with some tweaks.  I think I am responsible for the vast majority of these omissions :sheep: 

Tested locally by disconnecting my laptop from wifi, clearing  out my cartopy data and running with
`pytest -n4 -m "not natural_earth and not network"`

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
