### PR TITLE
Update nightshade.py to allow user-defined sub-solar coordinates

### DIFF
--- a/lib/cartopy/feature/nightshade.py
+++ b/lib/cartopy/feature/nightshade.py
@@ -14,7 +14,7 @@ from . import ShapelyFeature
 
 class Nightshade(ShapelyFeature):
     def __init__(self, date=None, delta=0.1, refraction=-0.83,
-                 color="k", alpha=0.5, **kwargs):
+                 color="k", alpha=0.5, sub_solar_coords=None, **kwargs):
         """
         Shade the darkside of the Earth, accounting for refraction.
 
@@ -47,8 +47,12 @@ class Nightshade(ShapelyFeature):
 
         # Returns the Greenwich hour angle,
         # need longitude (opposite direction)
-        lat, lon = _solar_position(date)
+        if sub_solar_coords is None:        #if not specified proceed as usual
+            lat, lon = _solar_position(date)
+        else:
+            lat, lon = sub_solar_coords     #if specified, use given coordinates
         pole_lon = lon
+                     
         if lat > 0:
             pole_lat = -90 + lat
             central_lon = 180


### PR DESCRIPTION
This allows for the specification of the sub solar coordinates directly, rather than calculating them using the date. This increases the usefulness of nightshade to those of us using cartopy for non-Earth bodies.

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Currently Nightshade produces the shade based off the sub-solar point at a defined time, based on the Earth. As cartopy is used for modelling other solar-system bodies, such as the Moon, which will have differing sub-solar points at a given time, the current use case for Nightshade is exclusive to the Earth. By allowing for user-defined sub-solar coordinates, this use case is extended to any sphere. 

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
Nightshade is now also useable for Non-Earth bodies

<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
