### PR TITLE
CI: add scheduled testing against nightlies

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -1,6 +1,12 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    # 10th of each month
+    - cron: "0 0 10 * *"
+  workflow_dispatch:
 
 jobs:
   build:
@@ -12,13 +18,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.9, '3.10', '3.11', '3.12']
-        shapely-dev: [false]
         use-network: [true]
         include:
-          - os: ubuntu-latest
-            python-version: '3.11'
-            shapely-dev: true
-            use-network: true
           - os: ubuntu-latest
             python-version: '3.11'
             use-network: false
@@ -35,28 +36,30 @@ jobs:
           cache: 'pip'
 
       - name: Minimum packages
-        if: matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
+        if: |
+          matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' &&
+          (github.event_name == 'push' || github.event_name == 'pull_request')
         id: minimum-packages
         run: |
           pip install cython==0.29.24 matplotlib==3.5.3 numpy==1.21 owslib==0.24.1 pyproj==3.3.1 scipy==1.6.3 shapely==1.7.1 pyshp==2.3.1
 
       - name: Coverage packages
         id: coverage
-        # only want the coverage to be run on the latest ubuntu
-        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
+        # only want the coverage to be run on the latest ubuntu and for code changes i.e. push and pr
+        if: |
+          matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' &&
+          (github.event_name == 'push' || github.event_name == 'pull_request')
         run: |
           echo "CYTHON_COVERAGE=1" >> $GITHUB_ENV
           # Also add doctest here to avoid windows runners which expect a different path separator
           echo "EXTRA_TEST_ARGS=--cov=cartopy -ra --doctest-modules" >> $GITHUB_ENV
           pip install cython
 
-      - name: Install Shapely dev
-        if: matrix.shapely-dev
+      - name: Install Nightlies
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
-          # Install Shapely from source on ubuntu
-          sudo apt-get update
-          sudo apt-get install -yy libgeos-dev
-          pip install git+https://github.com/shapely/shapely.git@main
+          # Install Nightly builds from Scientific Python
+          python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib scipy shapely
 
       - name: Install Cartopy
         id: install
@@ -108,5 +111,30 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: image-failures-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.shapely-dev }}
-          path: cartopy_test_output-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.shapely-dev }}
+          name: image-failures-${{ matrix.os }}-${{ matrix.python-version }}
+          path: cartopy_test_output-${{ matrix.os }}-${{ matrix.python-version }}
+
+  # Separate dependent job to only upload one issue from the matrix of jobs
+  create-issue:
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    needs: [build]
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    name: Create issue on failure
+
+    steps:
+      - name: Create issue on failure
+        uses: imjohnbo/issue-bot@v3
+        with:
+          title: "[TST] Upcoming dependency test failures"
+          body: |
+            The build with nightly wheels from matplotlib, scipy, shapely and their
+            dependencies has failed. Check the logs for any updates that need to be
+            made in cartopy.
+            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+
+          pinned: false
+          close-previous: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
This PR removes `shapely-dev` from the CI test matrix and instead introduces monthly testing against the Shapely, SciPy and Matplotlib nightly builds (note Numpy and ContourPy nightlies are automatically pulled in with Matplotlib).

The [guidance from Scientific Python](https://scientific-python.org/specs/spec-0004/#test-with-nightly-wheels) recommends a weekly job for this.  At https://github.com/SciTools/cartopy/pull/2371#discussion_r1564037949, @greglucas suggested a monthly job.  I also lean towards monthly just because Cartopy doesn't have a lot of resource so with a more frequent run we probably would end up closing lots of duplicate issues that we didn't get around to looking at yet.  The choice of 10th of the month is pretty arbitrary but it seems good to move it away from the beginning of the month so we aren't bothered by it on New Year's Day! I also added a `workflow-dispatch` trigger so we can run it if and when we have any reason to worry about recent updates in any package.

For the approach I roughly followed [Matplotlib's workflow](https://github.com/matplotlib/matplotlib/blob/main/.github/workflows/tests.yml).  It feels a little excessive to run the whole matrix but I couldn't find a neat way to restrict it for just these workflow triggers.  I took the command to install the nightlies from the [Scientific Python page](https://scientific-python.org/specs/spec-0004/#test-with-nightly-wheels).  It's a little different from what Matplotlib does, and what's recommended in [Matplotlib's installation documentation](https://matplotlib.org/stable/users/installing/index.html#install-a-nightly-build) but I don't know the reason for the difference or how to choose between them.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
