### PR TITLE
Fix incorrect internal use of PlateCarree

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1790,7 +1790,7 @@ class LambertConformal(Projection):
             lons[1:-1] = np.linspace(central_longitude - 180 + 0.001,
                                      central_longitude + 180 - 0.001, n)
 
-        points = self.transform_points(PlateCarree(globe=globe), lons, lats)
+        points = self.transform_points(self.as_geodetic(), lons, lats)
 
         self._boundary = sgeom.LinearRing(points)
         mins = np.min(points, axis=0)
@@ -1866,7 +1866,7 @@ class LambertAzimuthalEqualArea(Projection):
         lon = central_longitude + 180
         sign = np.sign(central_latitude) or 1
         lat = -central_latitude + sign * 0.01
-        x, max_y = self.transform_point(lon, lat, PlateCarree(globe=globe))
+        x, max_y = self.transform_point(lon, lat, self.as_geodetic())
 
         coords = _ellipse_boundary(a * 1.9999, max_y - false_northing,
                                    false_easting, false_northing, 61)

--- a/lib/cartopy/tests/crs/test_lambert_conformal.py
+++ b/lib/cartopy/tests/crs/test_lambert_conformal.py
@@ -3,6 +3,7 @@
 # This file is part of Cartopy and is released under the BSD 3-clause license.
 # See LICENSE in the root of the repository for full licensing details.
 
+import numpy as np
 from numpy.testing import assert_array_almost_equal
 import pyproj
 import pytest
@@ -36,6 +37,17 @@ def test_default_with_cutoff():
 
     assert_array_almost_equal(crs.y_limits,
                               (-49788019.81831982, 30793476.08487709))
+
+
+def test_sphere():
+    """Test LambertConformal with spherical globe. (#2377)"""
+    globe = ccrs.Globe(ellipse='sphere')
+
+    # This would error creating a boundary
+    crs = ccrs.LambertConformal(globe=globe)
+
+    assert np.all(np.isfinite(crs.x_limits))
+    assert np.all(np.isfinite(crs.y_limits))
 
 
 def test_specific_lambert():


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->

## Rationale

This replaces a couple of internal uses of PlateCarree() for lon/lat coords with more proper geodetic CRS's on the same ellipse, which avoids some precision problems. In the case of LambertConformal, this was resulting in a traceback when creating a boundary on a spherical Earth datum.

This also fixes another case doing the same thing, seemingly without problem, but it seems better to avoid `PlateCarree()` here too.

Fixes #2377.
<!-- Please provide detail as to *why* you are making this change. -->


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
