### PR TITLE
Removed dict annotation from GeoAxes.gridlines

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1473,7 +1473,7 @@ class GeoAxes(matplotlib.axes.Axes):
 
         Keyword Parameters
         ------------------
-        **kwargs: dict
+        **kwargs:
             All other keywords control line properties.  These are passed
             through to :class:`matplotlib.collections.Collection`.
 


### PR DESCRIPTION
## Rationale

Just something that had been bothering me for a bit. The `**kwargs` parameter in `GeoAxes.gridlines` is itself a `dict`, but shouldn't be annotated as `dict` because that implies that it accepts only dictionary keyword arguments. For example, the following code is highlighted with a warning:

```python
ax.gridlines(..., linewidth=0.15)  # syntax highlighter expects linewidth to be a dictionary
```

## Implications

Better syntax highlighting. Warning is no longer displayed for code that is correct.
