### PR TITLE
Make Gridliner deprecation warning show up

### DIFF
--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -448,6 +448,7 @@ class Gridliner(matplotlib.artist.Artist):
         if auto_update is None:
             auto_update = True
         else:
+            # Note #2394 should be addressed before this deprecation expires.
             calling_module = inspect.stack()[1].filename
             warnings.warn(
                 "The auto_update parameter was deprecated at Cartopy 0.23.  In future "

--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -9,6 +9,7 @@ location information to the plots.
 
 """
 
+import inspect
 import itertools
 import operator
 import warnings
@@ -447,10 +448,13 @@ class Gridliner(matplotlib.artist.Artist):
         if auto_update is None:
             auto_update = True
         else:
+            calling_module = inspect.stack()[1].filename
             warnings.warn(
                 "The auto_update parameter was deprecated at Cartopy 0.23.  In future "
                 "the gridlines and labels will always be updated.",
-                DeprecationWarning)
+                DeprecationWarning,
+                stacklevel=(3 if calling_module.endswith('cartopy/mpl/geoaxes.py')
+                            else 2))
         self._auto_update = auto_update
 
     def has_labels(self):


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Follow up to #2330.  The deprecation warning is currently not showing for normal use.  I thought I had checked but perhaps I only looked in test output.  I've now set the stacklevel to 3 for when `Gridliner` is created via `ax.gridlines`, and to 2 for the possible (but unlikely?) cases where a `Gridliner` is created directly.

I have checked locally that this now gives the desired results
```python
In [1]: import matplotlib.pyplot as plt
   ...: import cartopy.crs as ccrs
   ...: fig = plt.figure()
   ...: ax = fig.add_subplot(projection=ccrs.PlateCarree())
   ...: ax.coastlines()
Out[1]: <cartopy.mpl.feature_artist.FeatureArtist at 0x756842d2d1c0>

In [2]: ax.gridlines(draw_labels=True, auto_update=True)
<ipython-input-2-499091cee3ba>:1: DeprecationWarning: The auto_update parameter was deprecated at Cartopy 0.23.  In future the gridlines and labels will always be updated.
  ax.gridlines(draw_labels=True, auto_update=True)
Out[2]: <cartopy.mpl.gridliner.Gridliner at 0x75688bcc5790>

In [3]: from cartopy.mpl.gridliner import Gridliner

In [4]: test = Gridliner(ax, ccrs.PlateCarree(), auto_update=True)
<ipython-input-4-422209944b61>:1: DeprecationWarning: The auto_update parameter was deprecated at Cartopy 0.23.  In future the gridlines and labels will always be updated.
  test = Gridliner(ax, ccrs.PlateCarree(), auto_update=True)
```

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
