### PR TITLE
Use fewer network tests

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -18,11 +18,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.10', '3.11', '3.12']
-        use-network: [true]
+        use-network: [false]
         include:
           - os: ubuntu-latest
-            python-version: '3.11'
-            use-network: false
+            python-version: '3.10'
+            use-network: true
+          - os: windows-latest
+            python-version: '3.12'
+            use-network: true
 
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +77,7 @@ jobs:
         run: |
           pip install .[ows,plotting,speedups]
 
-      - name: Testing
+      - name: Network Tests
         id: test
         if: matrix.use-network
         # we need to force bash to use line continuations on Windows
@@ -87,17 +90,18 @@ jobs:
           CARTOPY_GIT_DIR=$PWD
           pytest -rfEsX -n 4 \
               --color=yes \
-              --mpl --mpl-generate-summary=html \
-              --mpl-results-path="cartopy_test_output-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.shapely-dev }}" \
-              --pyargs cartopy ${EXTRA_TEST_ARGS}
+              --pyargs cartopy -m "natural_earth or network" ${EXTRA_TEST_ARGS}
 
       - name: No Network Tests
         # Ensure any test that needs network access has been marked as such
         if: ${{ ! matrix.use-network }}
+        shell: bash
         run: |
           pip install pytest-socket
           pytest -rfEsX -n 4 \
               --color=yes \
+              --mpl --mpl-generate-summary=html \
+              --mpl-results-path="cartopy_test_output-${{ matrix.os }}-${{ matrix.python-version }}" \
               --pyargs cartopy -m "not natural_earth and not network" --disable-socket
 
       - name: Coveralls


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

This builds further on the approach from @rcomer in #2371. Now the tests involving network access are only run twice (once on minimum dependencies, and once on latest dependencies. It should be noted, the documentation/gallery also will pick up on some network related issues).
This also removes a shapely-dev remnant.

## Implications

Network and non-network tests are fully separated, making it easier to track problems that come up.

External network usage is reduced since the tests are only run on a subset of the full testing matrix.


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
