### PR TITLE
Fix failing gouraud shading mask creation in pccolormesh

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1893,7 +1893,7 @@ class GeoAxes(matplotlib.axes.Axes):
                           "It is recommended to remove the wrap manually "
                           "before calling pcolormesh.")
             # With gouraud shading, we actually want an (Ny, Nx) shaped mask
-            gmask = np.zeros(data_shape, dtype=bool)
+            gmask = np.zeros((data_shape[0], data_shape[1]), dtype=bool)
             # If any of the cells were wrapped, apply it to all 4 corners
             gmask[:-1, :-1] |= mask
             gmask[1:, :-1] |= mask

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -654,6 +654,17 @@ def test_pcolormesh_single_column_wrap():
     return fig
 
 
+def test_pcolormesh_wrap_gouraud_shading_failing_mask_creation():
+    x_range = np.linspace(-180, 180, 50)
+    y_range = np.linspace(90, -90, 50)
+    x, y = np.meshgrid(x_range, y_range)
+    data = ((np.sin(np.deg2rad(x))) / 10. + np.exp(np.cos(np.deg2rad(y))))
+
+    fig = plt.figure(figsize=(10, 6))
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.Mercator())
+    ax.pcolormesh(x, y, data, transform=ccrs.PlateCarree(), shading='gouraud')
+
+
 def test_pcolormesh_diagonal_wrap():
     # Check that a cell with the top edge on one side of the domain
     # and the bottom edge on the other gets wrapped properly


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

Using pccolormesh with gouraud shading fails on wrap around mask creation, since numpy array mask is created with negative dimension. 

Details: Fails here https://github.com/SciTools/cartopy/blob/main/lib/cartopy/mpl/geoaxes.py#L1896 because 
data_shape equals (Nx, Ny, -1) or (Ny - 1, Nx - 1, -1). 

<!-- Please provide detail as to *why* you are making this change. -->

## Implications

As far as I can see there are no implications of the proposed change.

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
