### PR TITLE
CI: Fix image upload path to remove shapely-dev

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -88,7 +88,7 @@ jobs:
           pytest -rfEsX -n 4 \
               --color=yes \
               --mpl --mpl-generate-summary=html \
-              --mpl-results-path="cartopy_test_output-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.shapely-dev }}" \
+              --mpl-results-path="cartopy_test_output-${{ matrix.os }}-${{ matrix.python-version }}" \
               --pyargs cartopy ${EXTRA_TEST_ARGS}
 
       - name: No Network Tests


### PR DESCRIPTION
There was an extra "-" added at the end of our CI uploads that prevented artifacts from being uploaded. We don't use shapely-dev anymore, so that can be removed here.