### PR TITLE
TST/FIX: Do difference ourselves rather than numpy to avoid datatype cast

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1372,7 +1372,7 @@ class PlateCarree(_CylindricalProjection):
         bbox = [[lon_lower_bound_0, lon_lower_bound_1],
                 [lon_lower_bound_1, lon_lower_bound_0]]
 
-        bbox[1][1] += np.diff(self.x_limits)[0]
+        bbox[1][1] += self.x_limits[1] - self.x_limits[0]
 
         return bbox, lon_0_offset
 


### PR DESCRIPTION
The docstring test was failing because `np.diff()` returns `np.int64` for the datatype. It is simple enough to just do the difference ourselves and stick with Python types to fix the failure.