### PR TITLE
DOC: Remove expected NASA failing images because they work now

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,11 +92,12 @@ subsection_order = ExplicitOrder(['../../examples/lines_and_polygons',
 sphinx_gallery_conf = {
     'capture_repr': (),
     'examples_dirs': ['../../examples'],
-    # NASA wmts servers are returning bad content metadata
     "expected_failing_examples": [
-        '../../examples/web_services/reprojected_wmts.py',
-        '../../examples/web_services/wmts.py',
-        '../../examples/web_services/wmts_time.py',
+        # NASA wmts servers frequently return bad content metadata
+        # uncomment these to fix the doc build failures
+        # '../../examples/web_services/reprojected_wmts.py',
+        # '../../examples/web_services/wmts.py',
+        # '../../examples/web_services/wmts_time.py',
         # OSGeo WMS has been shut off
         # https://discourse.osgeo.org/t/map-tile-loading-pin-location-issues/6910/2
         '../../examples/web_services/wms.py'


### PR DESCRIPTION
In the title, try to get circleCI builds working again. Ii chose to leave the comment in there rather than removing it altogether because they are bound to fail again and it is easier to just comment/uncomment those lines of code.