### PR TITLE
FIX/MNT: Simplify project geometry handling

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -918,10 +918,7 @@ class Projection(CRS, metaclass=ABCMeta):
         geoms = []
         for geom in geometry.geoms:
             geoms.append(self._project_point(geom, src_crs))
-        if geoms:
-            return sgeom.MultiPoint(geoms)
-        else:
-            return sgeom.MultiPoint()
+        return sgeom.MultiPoint(geoms)
 
     def _project_multiline(self, geometry, src_crs):
         geoms = []
@@ -929,10 +926,7 @@ class Projection(CRS, metaclass=ABCMeta):
             r = self._project_line_string(geom, src_crs)
             if r:
                 geoms.extend(r.geoms)
-        if geoms:
-            return sgeom.MultiLineString(geoms)
-        else:
-            return []
+        return sgeom.MultiLineString(geoms)
 
     def _project_multipolygon(self, geometry, src_crs):
         geoms = []
@@ -940,11 +934,7 @@ class Projection(CRS, metaclass=ABCMeta):
             r = self._project_polygon(geom, src_crs)
             if r:
                 geoms.extend(r.geoms)
-        if geoms:
-            result = sgeom.MultiPolygon(geoms)
-        else:
-            result = sgeom.MultiPolygon()
-        return result
+        return sgeom.MultiPolygon(geoms)
 
     def _project_polygon(self, polygon, src_crs):
         """

--- a/lib/cartopy/tests/test_line_string.py
+++ b/lib/cartopy/tests/test_line_string.py
@@ -8,6 +8,7 @@ import time
 
 import numpy as np
 import pytest
+import shapely
 import shapely.geometry as sgeom
 
 import cartopy.crs as ccrs
@@ -72,6 +73,15 @@ class TestLineString:
         cutoff_time = time.time() + 1
         tgt_proj.project_geometry(line_string, src_proj)
         assert time.time() < cutoff_time, 'Projection took too long'
+
+    @pytest.mark.skipif(shapely.__version__ < "2",
+                        reason="Shapely <2 has an incorrect geom_type ")
+    def test_multi_linestring_return_type(self):
+        # Check that the return type of project_geometry is a MultiLineString
+        # and not an empty list
+        multi_line_string = ccrs.Mercator().project_geometry(
+            sgeom.MultiLineString(), ccrs.PlateCarree())
+        assert isinstance(multi_line_string, sgeom.MultiLineString)
 
 
 class FakeProjection(ccrs.PlateCarree):


### PR DESCRIPTION
The MultiLineString return type was a plain list, but it should be an empty MultiLineString to be consistent with the other return types. Additionally, all geometry constructors take empty lists, so just use that rather than special-casing the returns.

Closes #2406 