### PR TITLE
CI: Put release build conditional in the first job to avoid building every time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,17 @@ on:
 
 jobs:
   build_sdist:
+    if: |
+      github.event_name == 'release' ||
+      (github.event_name == 'pull_request' && (
+        (
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'CI: build wheels'
+        ) ||
+        contains(github.event.pull_request.labels.*.name,
+                'CI: build wheels')
+        )
+      )
     name: Build source distribution
     runs-on: ubuntu-latest
     outputs:
@@ -57,18 +68,8 @@ jobs:
           if-no-files-found: error
 
   generate-wheels-matrix:
-    if: |
-      github.event_name == 'release' ||
-      (github.event_name == 'pull_request' && (
-        (
-          github.event.action == 'labeled' &&
-          github.event.label.name == 'CI: build wheels'
-        ) ||
-        contains(github.event.pull_request.labels.*.name,
-                'CI: build wheels')
-        )
-      )
     name: Generate wheels matrix
+    needs: [build_sdist]
     runs-on: ubuntu-latest
     outputs:
       include: ${{ steps.set-matrix.outputs.include }}


### PR DESCRIPTION
I noticed that we are building the sdist on every PR within the release workflow.
https://github.com/SciTools/cartopy/actions/workflows/release.yml
This didn't have the conditional expression associated with it to check for the specific label or release. We don't need to waste CI resources with this build, so move the conditional up and make the matrix job build dependent on it.