### PR TITLE
FIX: contour sticky edges match dataLim

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1594,8 +1594,8 @@ class GeoAxes(matplotlib.axes.Axes):
         """
         result = super().contour(*args, **kwargs)
 
-        # We need to compute the dataLim correctly for contours.
         if not _MPL_38:
+            # We need to compute the dataLim correctly for contours.
             bboxes = [col.get_datalim(self.transData)
                       for col in result.collections
                       if col.get_paths()]
@@ -1603,7 +1603,12 @@ class GeoAxes(matplotlib.axes.Axes):
                 extent = mtransforms.Bbox.union(bboxes)
                 self.update_datalim(extent.get_points())
         else:
-            self.update_datalim(result.get_datalim(self.transData))
+            # We need to compute the dataLim correctly for contours and set the
+            # artist's sticky edges to match.
+            datalim = result.get_datalim(self.transData)
+            self.update_datalim(datalim)
+            result.sticky_edges.x[:] = datalim.xmin, datalim.xmax
+            result.sticky_edges.y[:] = datalim.ymin, datalim.ymax
 
         self.autoscale_view()
 
@@ -1635,8 +1640,8 @@ class GeoAxes(matplotlib.axes.Axes):
         """
         result = super().contourf(*args, **kwargs)
 
-        # We need to compute the dataLim correctly for contours.
         if not _MPL_38:
+            # We need to compute the dataLim correctly for contours.
             bboxes = [col.get_datalim(self.transData)
                       for col in result.collections
                       if col.get_paths()]
@@ -1644,7 +1649,12 @@ class GeoAxes(matplotlib.axes.Axes):
                 extent = mtransforms.Bbox.union(bboxes)
                 self.update_datalim(extent.get_points())
         else:
-            self.update_datalim(result.get_datalim(self.transData))
+            # We need to compute the dataLim correctly for contours and set the
+            # artist's sticky edges to match.
+            datalim = result.get_datalim(self.transData)
+            self.update_datalim(datalim)
+            result.sticky_edges.x[:] = datalim.xmin, datalim.xmax
+            result.sticky_edges.y[:] = datalim.ymin, datalim.ymax
 
         self.autoscale_view()
 


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Fixes #2413.  The problem seems to be that we have a very small mismatch between the artist's sticky edges and the axes dataLim.  Within Matplotlib's contour code, [these are set equal](https://github.com/matplotlib/matplotlib/blob/6b7b99927458de5980f8d5590073dd81e44e4cc5/lib/matplotlib/contour.py#L890-L892).

I have tested locally with both mpl nightly and mpl 3.8.4.  Note that https://github.com/matplotlib/matplotlib/pull/28393 was included in mpl 3.9.1 so our CI should already use the new version.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
