### PR TITLE
FIX: imshow arguments should be popped before passing upstream

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1282,6 +1282,11 @@ class GeoAxes(matplotlib.axes.Axes):
 
         if (transform is None or transform == self.transData or
                 same_projection and inside_bounds):
+            if "regrid_shape" in kwargs:
+                warnings.warn("ignoring regrid_shape because it doesn't do anything "
+                              "when working in the same projection. To avoid this "
+                              "warning, remove the 'regrid_shape' keyword argument.")
+                kwargs.pop("regrid_shape")
             result = super().imshow(img, *args, **kwargs)
         else:
             extent = kwargs.pop('extent', None)

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -139,6 +139,16 @@ def test_imshow_wrapping():
     assert ax.get_xlim() == (-180, 180)
 
 
+def test_imshow_arguments():
+    """Smoke test for imshow argument passing in the fast-path"""
+    ax = plt.axes(projection=ccrs.PlateCarree())
+    # Set the regrid_shape parameter to ensure it isn't passed to Axes.imshow()
+    # in the fast-path call to super()
+    with pytest.warns(UserWarning, match="ignoring regrid_shape"):
+        ax.imshow(np.random.random((10, 10)), transform=ccrs.PlateCarree(),
+              extent=(-180, 180, -90, 90), regrid_shape=500)
+
+
 def test_imshow_rgba():
     # tests that the alpha of a RGBA array passed to imshow is set to 0
     # instead of masked


### PR DESCRIPTION
We have extra keyword arguments in Cartopy that can't be passed upstream to Matplotlib, so remove them from the keyword arguments before going into any possible methods.

closes #2415