### PR TITLE
Make renderer parameter optional in GeoAxes.get_tightbbox

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -466,7 +466,7 @@ class GeoAxes(matplotlib.axes.Axes):
                                self.get_autoscaley_on())
             yield
 
-    def _draw_preprocess(self, renderer):
+    def _draw_preprocess(self):
         """
         Perform pre-processing steps shared between :func:`GeoAxes.draw`
         and :func:`GeoAxes.get_tightbbox`.
@@ -484,7 +484,7 @@ class GeoAxes(matplotlib.axes.Axes):
         # by `draw` or `get_tightbbox` are positioned and clipped correctly.
         self.patch._adjust_location()
 
-    def get_tightbbox(self, renderer, *args, **kwargs):
+    def get_tightbbox(self, renderer=None, *args, **kwargs):
         """
         Extend the standard behaviour of
         :func:`matplotlib.axes.Axes.get_tightbbox`.
@@ -493,7 +493,7 @@ class GeoAxes(matplotlib.axes.Axes):
         calculating the tight bounding box.
         """
         # Shared processing steps
-        self._draw_preprocess(renderer)
+        self._draw_preprocess()
 
         return super().get_tightbbox(renderer, *args, **kwargs)
 
@@ -506,7 +506,7 @@ class GeoAxes(matplotlib.axes.Axes):
         A global range is used if no limits have yet been set.
         """
         # Shared processing steps
-        self._draw_preprocess(renderer)
+        self._draw_preprocess()
 
         # XXX This interface needs a tidy up:
         #       image drawing on pan/zoom;

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -488,7 +488,7 @@ def test_gridliner_count_draws():
     gl = ax.gridlines()
 
     with mock.patch.object(gl, '_draw_gridliner', return_value=None) as mocked:
-        ax.get_tightbbox(renderer=None)
+        ax.get_tightbbox()
         mocked.assert_called_once()
 
     with mock.patch.object(gl, '_draw_gridliner', return_value=None) as mocked:


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Small quality of life improvement.  The _renderer_ parameter is optional in all of Matplotlib's `get_tightbbox` methods, so should be here as well.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
