### PR TITLE
Support shading=None in pcolor(mesh)

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1790,8 +1790,8 @@ class GeoAxes(matplotlib.axes.Axes):
         the data coordinates before passing on to Matplotlib.
         """
         default_shading = mpl.rcParams.get('pcolor.shading')
-        if not (kwargs.get('shading', default_shading) in
-                ('nearest', 'auto') and len(args) == 3 and
+        shading = kwargs.get('shading') or default_shading
+        if not (shading in ('nearest', 'auto') and len(args) == 3 and
                 getattr(kwargs.get('transform'), '_wrappable', False)):
             return args, kwargs
 

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -773,9 +773,24 @@ def test_pcolormesh_shading(shading, input_size, expected):
     d = np.zeros((3, 3))
 
     coll = ax.pcolormesh(x, y, d, shading=shading)
-    # We can use coll.get_coordinates() once MPL >= 3.5 is required
-    # For now, we use the private variable for testing
-    assert coll._coordinates.shape == (expected, expected, 2)
+    assert coll.get_coordinates().shape == (expected, expected, 2)
+
+
+def test__wrap_args_default_shading():
+    # Passing shading=None should give the same as not passing the shading parameter.
+    x = np.linspace(0, 360, 12)
+    y = np.linspace(0, 90, 5)
+    z = np.zeros((12, 5))
+
+    ax = plt.subplot(projection=ccrs.Orthographic())
+    args_ref, kwargs_ref = ax._wrap_args(x, y, z, transform=ccrs.PlateCarree())
+    args_test, kwargs_test = ax._wrap_args(
+        x, y, z, transform=ccrs.PlateCarree(), shading=None)
+
+    for array_ref, array_test in zip(args_ref, args_test):
+        np.testing.assert_allclose(array_ref, array_test)
+
+    assert kwargs_ref == kwargs_test
 
 
 @pytest.mark.natural_earth


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
If `pcolor`/`pcolormesh` receives `shading=None`, that should be treated the same as if _shading_ was not set.  My colleague was using `pyplot.pcolormesh` on a geoaxes, and pyplot [explicitly defaults the shading to `None`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.pcolormesh.html#matplotlib.pyplot.pcolormesh).  This caused a hard-to-debug artefact!

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
