### PR TITLE
TST: add pyproj to nightly tests

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -59,7 +59,7 @@ jobs:
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
           # Install Nightly builds from Scientific Python
-          python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib scipy shapely
+          python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib pyproj scipy shapely
 
       - name: Install Cartopy
         id: install
@@ -129,9 +129,9 @@ jobs:
         with:
           title: "[TST] Upcoming dependency test failures"
           body: |
-            The build with nightly wheels from matplotlib, scipy, shapely and their
-            dependencies has failed. Check the logs for any updates that need to be
-            made in cartopy.
+            The build with nightly wheels from matplotlib, pyproj, scipy, shapely and
+            their dependencies has failed. Check the logs for any updates that need to
+            be made in cartopy.
             https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
 
           pinned: false


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
I just noticed that pyproj publishes nightly wheels, so added them to the relevant tests.  They all [pass on my fork](https://github.com/rcomer/cartopy/actions/runs/10653510523).

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
