### PR TITLE
FIX: `_trigger_patch_reclip` takes axes instance

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -2302,13 +2302,12 @@ GeoAxesSubplot = matplotlib.axes.subplot_class_factory(GeoAxes)
 GeoAxesSubplot.__module__ = GeoAxes.__module__
 
 
-def _trigger_patch_reclip(event):
+def _trigger_patch_reclip(axes):
     """
     Define an event callback for a GeoAxes which forces the background patch to
     be re-clipped next time it is drawn.
 
     """
-    axes = event.axes
     # trigger the outline and background patches to be re-clipped
     axes.spines['geo'].stale = True
     axes.patch.stale = True

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -1071,3 +1071,9 @@ def test_annotate():
                 )
 
     return fig
+
+
+def test_inset_axes():
+    fig, ax = plt.subplots()
+    ax.inset_axes([0.75, 0.75, 0.25, 0.25], projection=ccrs.PlateCarree())
+    fig.draw_without_rendering()


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
According to the [Axes documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.html), the callbacks attached to an axes "will be called with func(ax) where ax is the `Axes` instance."  So changed the `_trigger_patch_reclip` function to expect the axes rather than the event.  This fix was prompted by [this StackOverflow question](https://stackoverflow.com/questions/79018815/keyerror-geo-when-attempting-to-add-geoaxes-using-axes-inset-axes) and the new test adapted from that.  Note that [the axes property of a normal axes is itself, but the axes property of an inset axes is its parent](https://github.com/matplotlib/matplotlib/blob/613c9c996c20e034de67126e3e1cc42d19835b1f/lib/matplotlib/axes/_base.py#L2277-L2279).  Unfortunately the test coverage of this callback is minimal: when I removed it completely, the only test failure I got was [here](https://github.com/SciTools/cartopy/blob/d57fa1328c701d40edffbd5882a12fb191c5ccf9/lib/cartopy/tests/mpl/test_gridliner.py#L598), where `labels` became an empty list.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
