### PR TITLE
Added winkel tripel projection class

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -2493,6 +2493,33 @@ class Robinson(_WarpedRectangularProjection):
         return result
 
 
+class WinkelTripel(_WarpedRectangularProjection):
+    """
+    A Winkel-Tripel projection.
+
+    Compromise modified azimuthal projection that is less distorted
+    and more area-accurate. It is comparable to the Robinson
+    projection in both appearance and popularity.
+
+    The National Geographic Society uses the Winkel-Tripel projection
+    for most of the maps they produce.
+    """
+
+    def __init__(self, central_longitude=0.0, globe=None):
+        globe = globe or Globe(semimajor_axis=WGS84_SEMIMAJOR_AXIS)
+        proj4_params = [('proj', 'wintri'),
+                        ('lon_0', central_longitude),
+                        ('lat_0', 0.0)]
+
+        super(WinkelTripel, self).__init__(proj4_params,
+                                           central_longitude,
+                                           globe=globe)
+
+    @property
+    def threshold(self):
+        return 1e4
+
+
 class InterruptedGoodeHomolosine(Projection):
     """
     Composite equal-area projection emphasizing either land or


### PR DESCRIPTION
## Rationale
Winkel-Tripel is a popular projection that would be used by multiple users (my group at UT and folks at NCAR). It is also the primary projection for the National Geographic Society.


## Implications
I have created a new CRS projection object without modifying any code by utilizing existing class objects and the pyproj backend.


## Checklist
1. The new class object can be utilized in similar fashion to the other projection classes. 
2. I am unsure how to integrate this into the existing test suite, however I imagine it would undergo the same testing as other projections. I am happy to assist with that integration if  I could be pointed in the right direction.

This is my first pull request! I am open to input how on to properly contribute.
