### PR TITLE
A fix on the filename for the shapefile Reader. Changes to posix path…

### DIFF
--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -27,6 +27,7 @@ geometry representation of shapely:
 
 """
 
+import os
 import io
 import itertools
 from pathlib import Path
@@ -135,6 +136,8 @@ class BasicReader:
 
     def __init__(self, filename, bbox=None, **kwargs):
         # Validate the filename/shapefile
+        if filename.suffix == 'shp':
+            filename = os.path.join(filename.parent, filename.stem)
         self._reader = reader = shapefile.Reader(filename, **kwargs)
         self._bbox = bbox
         if reader.shp is None or reader.shx is None or reader.dbf is None:
@@ -161,7 +164,7 @@ class BasicReader:
         :meth:`~Record.geometry` method.
 
         """
-        for shape in self._reader.iterShapes(bbox=self._bbox):
+        for shape in self._reader.iterShapes():#bbox=self._bbox):
             # Skip the shape that can not be represented as geometry.
             if shape.shapeType != shapefile.NULL:
                 yield sgeom.shape(shape)


### PR DESCRIPTION

## Rationale

Obspy would not run properly when trying to plot a natural_feature shape file as the filename provided contained the suffix while the pyshp library requires only the stem name. In addition, there is a box kwargs in iterShapes which is not available in the pyshp library,


## Implications

It should run fine, now....
