### PR TITLE
MNT: Deprecate unused clip_path module

### DIFF
--- a/lib/cartopy/mpl/clip_path.py
+++ b/lib/cartopy/mpl/clip_path.py
@@ -2,8 +2,15 @@
 #
 # This file is part of Cartopy and is released under the BSD 3-clause license.
 # See LICENSE in the root of the repository for full licensing details.
+import warnings
+
 import matplotlib.path as mpath
 import numpy as np
+
+
+warnings.warn('The clip_path module is deprecated and will be removed '
+              'in a future release with no replacement.',
+              DeprecationWarning, stacklevel=2)
 
 
 def intersection_point(p0, p1, p2, p3):


### PR DESCRIPTION
None of these functions are used anywhere within Cartopy and they can easily be implemented by others downstream if needed.