### PR TITLE
MNT: Switch to (lon, lat) for all argument and return ordering

### DIFF
--- a/lib/cartopy/feature/nightshade.py
+++ b/lib/cartopy/feature/nightshade.py
@@ -47,7 +47,7 @@ class Nightshade(ShapelyFeature):
 
         # Returns the Greenwich hour angle,
         # need longitude (opposite direction)
-        lat, lon = _solar_position(date)
+        lon, lat = _solar_position(date)
         pole_lon = lon
         if lat > 0:
             pole_lat = -90 + lat
@@ -149,7 +149,7 @@ def _solar_position(date):
 
     Returns
     -------
-    (latitude, longitude) in degrees
+    (longitude, latitude) in degrees
 
     Note
     ----
@@ -203,4 +203,4 @@ def _solar_position(date):
     if lon < -180:
         lon += 360
 
-    return (delta_sun, lon)
+    return (lon, delta_sun)

--- a/lib/cartopy/tests/crs/test_gnomonic.py
+++ b/lib/cartopy/tests/crs/test_gnomonic.py
@@ -69,7 +69,7 @@ def test_eccentric_globe():
 
 @pytest.mark.parametrize('lat', [-10, 0, 10])
 @pytest.mark.parametrize('lon', [-10, 0, 10])
-def test_central_params(lat, lon):
+def test_central_params(lon, lat):
     gnom = ccrs.Gnomonic(central_latitude=lat, central_longitude=lon)
     other_args = {f'lat_0={lat}', f'lon_0={lon}',
                   'a=6378137.0'}

--- a/lib/cartopy/tests/crs/test_orthographic.py
+++ b/lib/cartopy/tests/crs/test_orthographic.py
@@ -70,7 +70,7 @@ def test_eccentric_globe():
 
 @pytest.mark.parametrize('lat', [-10, 0, 10])
 @pytest.mark.parametrize('lon', [-10, 0, 10])
-def test_central_params(lat, lon):
+def test_central_params(lon, lat):
     ortho = ccrs.Orthographic(central_latitude=lat, central_longitude=lon)
     other_args = {f'lat_0={lat}', f'lon_0={lon}',
                   'a=6378137.0'}

--- a/lib/cartopy/tests/feature/test_nightshade.py
+++ b/lib/cartopy/tests/feature/test_nightshade.py
@@ -40,7 +40,7 @@ def test_julian_day():
     (datetime(2030, 6, 21, 0, 0), (23 + 26 / 60), -(179 + 34 / 60))
 ])
 def test_solar_position(dt, true_lat, true_lon):
-    lat, lon = _solar_position(dt)
+    lon, lat = _solar_position(dt)
     assert pytest.approx(true_lat, 0.1) == lat
     assert pytest.approx(true_lon, 0.1) == lon
 

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -36,7 +36,7 @@ class TestCRS:
         ll = ccrs.Geodetic()
 
         # results obtained by nearby.org.uk.
-        lat, lon = np.array([54.5622169298669, -5.54159863617957],
+        lon, lat = np.array([-5.54159863617957, 54.5622169298669],
                             dtype=np.double)
         east, north = np.array([359000, 371000], dtype=np.double)
 
@@ -65,7 +65,7 @@ class TestCRS:
         ll = ccrs.Geodetic()
 
         # results obtained by streetmap.co.uk.
-        lat, lon = np.array([50.462023, -3.478831], dtype=np.double)
+        lon, lat = np.array([-3.478831, 50.462023], dtype=np.double)
         east, north = np.array([295132.1, 63512.6], dtype=np.double)
 
         # note the handling of precision here...
@@ -233,7 +233,7 @@ class TestCRS:
     def test_utm(self):
         utm30n = ccrs.UTM(30)
         ll = ccrs.Geodetic()
-        lat, lon = np.array([51.5, -3.0], dtype=np.double)
+        lon, lat = np.array([-3.0, 51.5], dtype=np.double)
         east, north = np.array([500000, 5705429.2], dtype=np.double)
         assert_arr_almost_eq(utm30n.transform_point(lon, lat, ll),
                              [east, north],
@@ -242,7 +242,7 @@ class TestCRS:
                              [lon, lat],
                              decimal=1)
         utm38s = ccrs.UTM(38, southern_hemisphere=True)
-        lat, lon = np.array([-18.92, 47.5], dtype=np.double)
+        lon, lat = np.array([47.5, -18.92], dtype=np.double)
         east, north = np.array([763316.7, 7906160.8], dtype=np.double)
         assert_arr_almost_eq(utm38s.transform_point(lon, lat, ll),
                              [east, north],


### PR DESCRIPTION
There are more usages of (lon, lat) currently and only a few private versions of (lat, lon) so it is easy enough to switch everything over to (lon, lat) for consistency. This matches what we are expecting from transform_point(x, y) as well.