### PR TITLE
FIX: Add half-pixel shift to img_transform y coordinate

### DIFF
--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -215,7 +215,9 @@ def _determine_bounds(x_coords, y_coords, source_cs):
         bounds['x'].append([x_coords.min() - half_px,
                             x_coords.max() + half_px])
 
-    bounds['y'] = [y_coords.min(), y_coords.max()]
+    # y_coords are the centers, so adjust a half-pixel out in y too
+    half_px = abs(np.diff(y_coords, axis=0)).max() / 2.
+    bounds['y'] = [y_coords.min() - half_px, y_coords.max() + half_px]
     return bounds
 
 

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -116,7 +116,7 @@ def test_imshow():
 
 @pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(filename='imshow_regional_projected.png',
-                               tolerance=0.8)
+                               tolerance=1.96)
 def test_imshow_projected():
     source_proj = ccrs.PlateCarree()
     img_extent = (-120.67660000000001, -106.32104523100001,

--- a/lib/cartopy/tests/test_img_transform.py
+++ b/lib/cartopy/tests/test_img_transform.py
@@ -68,16 +68,16 @@ def test_gridding_data_std_range():
                              mask_extrapolated=True)
 
     # The expected image. n.b. on a map the data is reversed in the y axis.
-    expected = np.array([[3, 3, 3, 3, 3, 3, 3, 3],
-                         [3, 1, 2, 2, 2, 3, 3, 3],
-                         [1, 1, 1, 2, 2, 2, 3, 1],
-                         [1, 1, 1, 1, 1, 1, 1, 1]], dtype=np.float64)
+    expected = np.array([[1, 1, 2, 2, 3, 3, 3, 3],
+                         [1, 1, 2, 2, 2, 3, 3, 3],
+                         [1, 1, 1, 2, 2, 2, 3, 3],
+                         [1, 1, 1, 2, 2, 2, 3, 3]], dtype=np.float64)
 
     expected_mask = np.array(
-        [[True, True, True, True, True, True, True, True],
+        [[True, False, False, False, False, False, False, True],
          [True, False, False, False, False, False, False, True],
          [True, False, False, False, False, False, False, True],
-         [True, True, True, True, True, True, True, True]])
+         [True, False, False, False, False, False, False, True]])
 
     assert_array_equal([-180, 180, -90, 90], extent)
     assert_array_equal(expected, image)
@@ -108,10 +108,10 @@ def test_gridding_data_outside_projection():
          [3, 3, 3, 1, 1, 1, 1, 1]], dtype=np.float64)
 
     expected_mask = np.array(
-        [[True, True, True, True, True, True, True, True],
+        [[False, False, True, True, True, True, False, False],
          [False, False, True, True, True, True, False, False],
          [False, False, True, True, True, True, False, False],
-         [True, True, True, True, True, True, True, True]])
+         [False, False, True, True, True, True, False, False]])
 
     assert_array_equal([-180, 180, -90, 90], extent)
     assert_array_equal(expected, image)


### PR DESCRIPTION

## Rationale

The y-coordinates input to the bounds calculation are the centers. The x-coordinates are shifted by half a pixel already, but we also need to do that to the y-coordinates otherwise we get some anomalous masking at the bottom/top of the images.

closes #2459