### PR TITLE
Reinstate missing renderer argument in `GeoAxes._preprocess_draw`

### DIFF
--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -43,6 +43,7 @@ the package wouldn't be as rich or diverse as it is today:
  * Stephane Raynaud
  * John Krasting
  * Matthias Cuntz
+ * James Frost
 
 Thank you!
 

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -451,10 +451,12 @@ class GeoAxes(matplotlib.axes.Axes):
                                self.get_autoscaley_on())
             yield
 
-    def _draw_preprocess(self):
+    def _draw_preprocess(self, renderer=None):
         """
         Perform pre-processing steps shared between :func:`GeoAxes.draw`
         and :func:`GeoAxes.get_tightbbox`.
+
+        Renderer argument does nothing, but is retained for API compatibility.
         """
         # If data has been added (i.e. autoscale hasn't been turned off)
         # then we should autoscale the view.


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

Fixes #2464.

I've reimplemented what I believe was the intent of 454567a2c8876f90969617be6fe4fd053f5e5e21 from PR #2424, in such a way that it no longer changes the method signature in a problematic way.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
This should now be fully compatible with existing code.

<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->

I have manually tested this change however I haven't added any automatic tests. If one is needed then I'm happy to create one.