### PR TITLE
FIX: create a single inverted polygon when no exteriors found

### DIFF
--- a/lib/cartopy/tests/test_polygon.py
+++ b/lib/cartopy/tests/test_polygon.py
@@ -446,6 +446,18 @@ class TestHoles(PolygonTests):
         self._assert_bounds(polygon.interiors[0].bounds,
                             - 1.2e7, -1.2e7, 1.2e7, 1.2e7, 1e6)
 
+    def test_inverted_poly_multi_hole(self):
+        # Adapted from 1149
+        proj = ccrs.LambertAzimuthalEqualArea(
+            central_latitude=45, central_longitude=-100)
+        poly = sgeom.Polygon([(-180, -80), (180, -80), (180, 90), (-180, 90)],
+                             [[(-50, -50), (-50, 0), (0, 0), (0, -50)]])
+        multi_polygon = proj.project_geometry(poly)
+        # Should project to single polygon with multiple holes
+        assert len(multi_polygon.geoms) == 1
+        assert len(multi_polygon.geoms[0].interiors) >= 2
+
+
     def test_inverted_poly_clipped_hole(self):
         proj = ccrs.NorthPolarStereo()
         poly = sgeom.Polygon([(0, 0), (-90, 0), (-180, 0), (-270, 0)],


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
When `_rings_to_multipolygon` finds interior rings without associated exteriors, for each of these interiors it creates a new polygon as the difference between ~the whole map and that interior.  Intuitively, if there are multiple interiors, then all of those whole map polygons will overlay each other and you won't see the holes.  Instead it should create a single ~whole map polygon which uses all of those left over interiors.

I also switched out use of `.buffer(0)` for `shapely.make_valid` as that seems like the more official way to do that.

Fixes #1149, fixes #1674, fixes #2160 (all ocean feature examples) and fixes #1449 (`contourf` example)
Also fixes the original case from #2030 (but not the second example so not linking that issue)
Also fixes the `contourf` examples at https://github.com/SciTools/cartopy/issues/1076#issuecomment-1774329796 and https://github.com/SciTools/cartopy/issues/1076#issuecomment-591926911

I turned #1149 into an image test.  Really there should be something more specific in `test_polygon.py`, but I'm at a loss how to create an artificial example for this.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
