### PR TITLE
MNT: Replace deprecated utcnow() call

### DIFF
--- a/lib/cartopy/feature/nightshade.py
+++ b/lib/cartopy/feature/nightshade.py
@@ -22,7 +22,7 @@ class Nightshade(ShapelyFeature):
         ----------
         date : datetime
             A UTC datetime object used to calculate the position of the sun.
-            Default: datetime.datetime.utcnow()
+            Default: The current UTC time.
         delta : float
             Stepsize in degrees to determine the resolution of the
             night polygon feature (``npts = 180 / delta``).
@@ -38,7 +38,7 @@ class Nightshade(ShapelyFeature):
 
         """
         if date is None:
-            date = datetime.datetime.utcnow()
+            date = datetime.datetime.now(datetime.UTC)
 
         # make sure date is UTC, or naive with respect to time zones
         if date.utcoffset():


### PR DESCRIPTION

## Rationale

Update to move away from the deprecated call.