### PR TITLE
Capitalise and protect "Python" and "Matplotlib" in suggested BibTeX citation

### DIFF
--- a/docs/source/citation.rst
+++ b/docs/source/citation.rst
@@ -22,7 +22,7 @@ For example::
 
  @manual{Cartopy,
  author = {{Met Office}},
- title = {Cartopy: a cartographic python library with a Matplotlib interface},
+ title = {Cartopy: a cartographic {Python} library with a {Matplotlib} interface},
  year = {2010 - 2015},
  address = {Exeter, Devon },
  url = {https://scitools.org.uk/cartopy}


### PR DESCRIPTION
## Rationale

"Python" and "Matplotlib" are not capitalised in the example BibTeX citation and it is being copied verbatim, propagating the error.

## Implications

Editors will no longer have to fix the capitalisation of the citation downstream.
