### PR TITLE
DOC: Add a raster reprojection example

### DIFF
--- a/examples/scalar_data/raster_reprojections.py
+++ b/examples/scalar_data/raster_reprojections.py
@@ -5,10 +5,11 @@ Raster reprojections
 When plotting raster data onto a map with `imshow`, we need to first set the
 extend of the map so the reprojection is done correctly.
 
-In this example, we have a raster data stored as a numpy array that is
+In this example, we have some raster data stored as a numpy array that is
 referenced to a rectangular coordinate system. Cartopy reproject these
 data to match the map's coordinate system, however, the map extent
-must be set *before* `imshow` is called.
+must be set *before* `imshow` is called, otherwise, the reprojection
+will not succeed.
 
 """
 

--- a/examples/scalar_data/raster_reprojections.py
+++ b/examples/scalar_data/raster_reprojections.py
@@ -1,0 +1,98 @@
+"""
+Raster reprojections
+====================
+
+When plotting raster data onto a map with `imshow`, we need to first set the
+extend of the map so the reprojection is done correctly.
+
+In this example, we have a raster data stored as a numpy array that is
+referenced to a rectangular coordinate system. Cartopy reproject these
+data to match the map's coordinate system, however, the map extent
+must be set *before* `imshow` is called.
+
+"""
+
+from matplotlib.patches import Rectangle
+import matplotlib.pyplot as plt
+import numpy as np
+
+import cartopy.crs as ccrs
+import cartopy.feature as cf
+
+
+def main():
+    # Generate raster data as a numpy array
+    img = np.linspace(0, 1, 10_000).reshape(100, 100)
+
+    # Define the origin and extent of the image following matplotlib's
+    # convention `(left, right, bottom, top)`. These are referenced to
+    # a rectangular coordinate system.
+    img_origin = "lower"
+    img_extent = (-87.6, -86.4, 41.4, 42.0)
+    img_proj = ccrs.PlateCarree()
+
+    imshow_kwargs = dict(
+        extent=img_extent,
+        origin=img_origin,
+        transform=img_proj,
+        cmap="spring",
+    )
+
+    # Define extent and projection for the map
+    map_extent = (-88.1, -86.1, 41.2, 42.2)
+    map_proj = ccrs.RotatedPole(pole_longitude=120.0, pole_latitude=70.0)
+
+    fig, axs = plt.subplots(
+        nrows=1,
+        ncols=2,
+        figsize=(12, 5),
+        subplot_kw={"projection": map_proj},
+        sharex=True,
+        sharey=True,
+    )
+
+    # Adding the raster *before* setting the map extent
+    ax = axs[0]
+    ax.set_title("\u2717 Adding the raster\nBEFORE setting the map extent")
+
+    ax.imshow(img, **imshow_kwargs)
+    ax.set_extent(map_extent, crs=img_proj)
+
+    # Adding the raster *after* setting the map extent
+    ax = axs[1]
+    ax.set_title("\u2713 Adding the raster\nAFTER setting the map extent")
+
+    ax.set_extent(map_extent, crs=img_proj)
+    ax.imshow(img, **imshow_kwargs)
+
+    for ax in axs:
+        # Add other map features
+        ax.add_feature(cf.LAKES, alpha=0.6)
+        ax.add_feature(cf.STATES)
+
+        # Highlight raster boundaries
+        xy = (img_extent[0], img_extent[2])
+        width = img_extent[1] - img_extent[0]
+        height = img_extent[3] - img_extent[2]
+        ax.add_patch(
+            Rectangle(
+                xy,
+                width,
+                height,
+                transform=img_proj,
+                edgecolor="black",
+                facecolor="None",
+                linewidth=3,
+                label="Raster data bounds",
+            )
+        )
+
+        ax.legend()
+        ax.gridlines(draw_labels=True, x_inline=False, dms=True)
+
+    fig.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/scalar_data/raster_reprojections.py
+++ b/examples/scalar_data/raster_reprojections.py
@@ -3,13 +3,12 @@ Raster reprojections
 ====================
 
 When plotting raster data onto a map with `imshow`, we need to first set the
-extend of the map so the reprojection is done correctly.
+extent of the map so the reprojection is done correctly.
 
 In this example, we have some raster data stored as a numpy array that is
-referenced to a rectangular coordinate system. Cartopy reproject these
-data to match the map's coordinate system, however, the map extent
-must be set *before* `imshow` is called, otherwise, the reprojection
-will not succeed.
+referenced to a rectangular coordinate system (PlateCarree). Cartopy reprojects the
+data to match the map's coordinate system based on the currently set map limits.
+This means that the map extent/boundary must be set *before* `imshow` is called.
 
 """
 
@@ -50,6 +49,7 @@ def main():
         subplot_kw={"projection": map_proj},
         sharex=True,
         sharey=True,
+        layout="constrained",
     )
 
     # Adding the raster *before* setting the map extent
@@ -91,7 +91,6 @@ def main():
         ax.legend()
         ax.gridlines(draw_labels=True, x_inline=False, dms=True)
 
-    fig.tight_layout()
     plt.show()
 
 


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

Plotting a raster image with `ax.imshow` requires data to be warped and reprojected. This does not works well if the map's extent is not set in advance. I am adding an additional example to the documentation to cover that common pitfall: 

- https://github.com/SciTools/cartopy/issues/2480
- https://github.com/SciTools/cartopy/issues/1468


## Implications

This is just an additional example to put in the documentation; no functionality in the package is modified. Below is a screenshot of rebuilding the docs with sphinx:

```sh
sphinx-build -M html docs/source/ docs/build
```

![image](https://github.com/user-attachments/assets/5b56cf4a-14e7-468f-8193-feb1f72fd553)


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
