### PR TITLE
Update __init__.py in cartopy.io

### DIFF
--- a/lib/cartopy/io/__init__.py
+++ b/lib/cartopy/io/__init__.py
@@ -39,7 +39,6 @@ def fh_getter(fh, mode='r', needs_filename=False):
 
     """
 
-    # Initiliaze a variable
     filename = None
     
     if mode != 'r':

--- a/lib/cartopy/io/__init__.py
+++ b/lib/cartopy/io/__init__.py
@@ -38,6 +38,10 @@ def fh_getter(fh, mode='r', needs_filename=False):
         Opened in the given mode.
 
     """
+
+    # Initiliaze a variable
+    filename = None
+    
     if mode != 'r':
         raise ValueError('Only mode "r" currently supported.')
 


### PR DESCRIPTION
## Rationale
When fh argument is a PosixPath, the function fh_getter fails as the variable filename has not been initialized. 

## Fix: 
Initialize filename to None.

## Implications
Implications should be minimal.