### PR TITLE
Fix handling of PosixPath in cartopy.io fh_getter function

### DIFF
--- a/lib/cartopy/io/__init__.py
+++ b/lib/cartopy/io/__init__.py
@@ -41,6 +41,8 @@ def fh_getter(fh, mode='r', needs_filename=False):
     if mode != 'r':
         raise ValueError('Only mode "r" currently supported.')
 
+    filename = None
+
     if isinstance(fh, str):
         filename = fh
         fh = open(fh, mode)


### PR DESCRIPTION
## Rationale

fh_getter fails when fh is a PosixPath because it attempts at checking filename, which has not been initialized.

## Fix

Initialize filename to None

## Implications

Minimal