### PR TITLE
ENH: Azimuthal rotation for Orthographic projection

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -2093,9 +2093,20 @@ class Orthographic(Projection):
     _handles_ellipses = False
 
     def __init__(self, central_longitude=0.0, central_latitude=0.0,
-                 azimuth=0.0, globe=None):
-        proj4_params = [('proj', 'ortho'), ('lon_0', central_longitude),
-                        ('lat_0', central_latitude), ('alpha', azimuth)]
+                 azimuth=None, globe=None):
+        if pyproj.__proj_version__ >= '9.5.0':
+            if azimuth is None:
+                azimuth = 0.0
+            proj4_params = [('proj', 'ortho'), ('lon_0', central_longitude),
+                            ('lat_0', central_latitude), ('alpha', azimuth)]
+        else:
+            proj4_params = [('proj', 'ortho'), ('lon_0', central_longitude),
+                            ('lat_0', central_latitude)]
+            if azimuth is not None:
+                warnings.warn(
+                    'Setting azimuth is not supported with PROJ versions < 9.5.0. '
+                    'Assuming azimuth=0.'
+                    'Current PROJ version: %s' % pyproj.__proj_version__)
         super().__init__(proj4_params, globe=globe)
 
         # TODO: Let the globe return the semimajor axis always.

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -2093,16 +2093,14 @@ class Orthographic(Projection):
     _handles_ellipses = False
 
     def __init__(self, central_longitude=0.0, central_latitude=0.0,
-                 azimuth=None, globe=None):
+                 azimuth=0.0, globe=None):
         if pyproj.__proj_version__ >= '9.5.0':
-            if azimuth is None:
-                azimuth = 0.0
             proj4_params = [('proj', 'ortho'), ('lon_0', central_longitude),
                             ('lat_0', central_latitude), ('alpha', azimuth)]
         else:
             proj4_params = [('proj', 'ortho'), ('lon_0', central_longitude),
                             ('lat_0', central_latitude)]
-            if azimuth is not None:
+            if azimuth != 0.0:
                 warnings.warn(
                     'Setting azimuth is not supported with PROJ versions < 9.5.0. '
                     'Assuming azimuth=0.'

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -2093,9 +2093,9 @@ class Orthographic(Projection):
     _handles_ellipses = False
 
     def __init__(self, central_longitude=0.0, central_latitude=0.0,
-                 globe=None):
+                 azimuth=0.0, globe=None):
         proj4_params = [('proj', 'ortho'), ('lon_0', central_longitude),
-                        ('lat_0', central_latitude)]
+                        ('lat_0', central_latitude), ('alpha', azimuth)]
         super().__init__(proj4_params, globe=globe)
 
         # TODO: Let the globe return the semimajor axis always.

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -2094,17 +2094,13 @@ class Orthographic(Projection):
 
     def __init__(self, central_longitude=0.0, central_latitude=0.0,
                  azimuth=0.0, globe=None):
-        if pyproj.__proj_version__ >= '9.5.0':
-            proj4_params = [('proj', 'ortho'), ('lon_0', central_longitude),
-                            ('lat_0', central_latitude), ('alpha', azimuth)]
-        else:
-            proj4_params = [('proj', 'ortho'), ('lon_0', central_longitude),
-                            ('lat_0', central_latitude)]
-            if azimuth != 0.0:
-                warnings.warn(
-                    'Setting azimuth is not supported with PROJ versions < 9.5.0. '
-                    'Assuming azimuth=0.'
-                    'Current PROJ version: %s' % pyproj.__proj_version__)
+        proj4_params = [('proj', 'ortho'), ('lon_0', central_longitude),
+                        ('lat_0', central_latitude), ('alpha', azimuth)]
+        if pyproj.__proj_version__ < '9.5.0' and azimuth != 0.0:
+            warnings.warn(
+                'Setting azimuth is not supported with PROJ versions < 9.5.0. '
+                'Assuming azimuth=0. '
+                'Current PROJ version: %s' % pyproj.__proj_version__)
         super().__init__(proj4_params, globe=globe)
 
         # TODO: Let the globe return the semimajor axis always.

--- a/lib/cartopy/tests/crs/test_orthographic.py
+++ b/lib/cartopy/tests/crs/test_orthographic.py
@@ -18,7 +18,10 @@ from .helpers import check_proj_params
 
 def test_default():
     ortho = ccrs.Orthographic()
-    other_args = {'a=6378137.0', 'lat_0=0.0', 'lon_0=0.0'}
+    if pyproj.__proj_version__ >= '9.5.0': # support for alpha
+        other_args = {'a=6378137.0', 'lat_0=0.0', 'lon_0=0.0', 'alpha=0.0'}
+    else:
+        other_args = {'a=6378137.0', 'lat_0=0.0', 'lon_0=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     # WGS84 radius * 0.99999
@@ -31,7 +34,10 @@ def test_default():
 def test_sphere_globe():
     globe = ccrs.Globe(semimajor_axis=1000, ellipse=None)
     ortho = ccrs.Orthographic(globe=globe)
-    other_args = {'a=1000', 'lat_0=0.0', 'lon_0=0.0'}
+    if pyproj.__proj_version__ >= '9.5.0': # support for alpha
+        other_args = {'a=1000', 'lat_0=0.0', 'lon_0=0.0', 'alpha=0.0'}
+    else:
+        other_args = {'a=1000', 'lat_0=0.0', 'lon_0=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     assert_almost_equal(ortho.x_limits, [-999.99, 999.99])
@@ -45,7 +51,11 @@ def test_ellipse_globe():
         ortho = ccrs.Orthographic(globe=globe)
         assert len(w) == 1
 
-    other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0'}
+    if pyproj.__proj_version__ >= '9.5.0': # support for alpha
+        other_args = {'ellps=WGS84', 'lat_0=0.0',
+                      'lon_0=0.0', 'alpha=0.0'}
+    else:
+        other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     # Limits are the same as default since ellipses are not supported.
@@ -61,7 +71,11 @@ def test_eccentric_globe():
         ortho = ccrs.Orthographic(globe=globe)
         assert len(w) == 1
 
-    other_args = {'a=1000', 'b=500', 'lon_0=0.0', 'lat_0=0.0'}
+    if pyproj.__proj_version__ >= '9.5.0': # support for alpha
+        other_args = {'a=1000', 'b=500', 'lat_0=0.0', 'lon_0=0.0',
+                      'alpha=0.0'}
+    else:
+        other_args = {'a=1000', 'b=500', 'lon_0=0.0', 'lat_0=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     # Limits are the same as spheres since ellipses are not supported.
@@ -73,8 +87,12 @@ def test_eccentric_globe():
 @pytest.mark.parametrize('lon', [-10, 0, 10])
 def test_central_params(lon, lat):
     ortho = ccrs.Orthographic(central_latitude=lat, central_longitude=lon)
-    other_args = {f'lat_0={lat}', f'lon_0={lon}',
-                  'a=6378137.0'}
+    if pyproj.__proj_version__ >= '9.5.0': # support for alpha
+        other_args = {f'lat_0={lat}', f'lon_0={lon}',
+                      'a=6378137.0', 'alpha=0.0'}
+    else:
+        other_args = {f'lat_0={lat}', f'lon_0={lon}',
+                    'a=6378137.0'}
     check_proj_params('ortho', ortho, other_args)
 
     # WGS84 radius * 0.99999
@@ -91,7 +109,11 @@ def test_grid():
     ortho = ccrs.Orthographic(globe=globe)
     geodetic = ortho.as_geodetic()
 
-    other_args = {'a=1.0', 'b=1.0', 'lon_0=0.0', 'lat_0=0.0'}
+    if pyproj.__proj_version__ >= '9.5.0': # support for alpha
+        other_args = {'a=1.0', 'b=1.0', 'lon_0=0.0', 'lat_0=0.0',
+                      'alpha=0.0'}
+    else:
+        other_args = {'a=1.0', 'b=1.0', 'lon_0=0.0', 'lat_0=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     assert_almost_equal(np.array(ortho.x_limits),
@@ -144,7 +166,11 @@ def test_sphere_transform():
                               globe=globe)
     geodetic = ortho.as_geodetic()
 
-    other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0'}
+    if pyproj.__proj_version__ >= '9.5.0': # support for alpha
+        other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0',
+                      'alpha=0.0'}
+    else:
+        other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0'}
     check_proj_params('ortho', ortho, other_args)
 
     assert_almost_equal(np.array(ortho.x_limits),
@@ -166,7 +192,8 @@ def test_sphere_rotate():
     geodetic = ortho.as_geodetic()
 
     if pyproj.__proj_version__ >= '9.5.0': # support for alpha (azimuthal rotation)
-        other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0', 'alpha=180.0'}
+        other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0',
+                      'alpha=180.0'}
     else:
         other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0'}
     check_proj_params('ortho', ortho, other_args)

--- a/lib/cartopy/tests/crs/test_orthographic.py
+++ b/lib/cartopy/tests/crs/test_orthographic.py
@@ -9,6 +9,7 @@ Tests for the Orthographic coordinate system.
 
 import numpy as np
 from numpy.testing import assert_almost_equal
+import pyproj
 import pytest
 
 import cartopy.crs as ccrs
@@ -17,7 +18,7 @@ from .helpers import check_proj_params
 
 def test_default():
     ortho = ccrs.Orthographic()
-    other_args = {'a=6378137.0', 'lon_0=0.0', 'lat_0=0.0', 'alpha=0.0'}
+    other_args = {'a=6378137.0', 'lat_0=0.0', 'lon_0=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     # WGS84 radius * 0.99999
@@ -30,7 +31,7 @@ def test_default():
 def test_sphere_globe():
     globe = ccrs.Globe(semimajor_axis=1000, ellipse=None)
     ortho = ccrs.Orthographic(globe=globe)
-    other_args = {'a=1000', 'lon_0=0.0', 'lat_0=0.0', 'alpha=0.0'}
+    other_args = {'a=1000', 'lat_0=0.0', 'lon_0=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     assert_almost_equal(ortho.x_limits, [-999.99, 999.99])
@@ -44,7 +45,7 @@ def test_ellipse_globe():
         ortho = ccrs.Orthographic(globe=globe)
         assert len(w) == 1
 
-    other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0', 'alpha=0.0'}
+    other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     # Limits are the same as default since ellipses are not supported.
@@ -60,7 +61,7 @@ def test_eccentric_globe():
         ortho = ccrs.Orthographic(globe=globe)
         assert len(w) == 1
 
-    other_args = {'a=1000', 'b=500', 'lon_0=0.0', 'lat_0=0.0', 'alpha=0.0'}
+    other_args = {'a=1000', 'b=500', 'lon_0=0.0', 'lat_0=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     # Limits are the same as spheres since ellipses are not supported.
@@ -73,7 +74,7 @@ def test_eccentric_globe():
 def test_central_params(lon, lat):
     ortho = ccrs.Orthographic(central_latitude=lat, central_longitude=lon)
     other_args = {f'lat_0={lat}', f'lon_0={lon}',
-                  'a=6378137.0', 'alpha=0.0'}
+                  'a=6378137.0'}
     check_proj_params('ortho', ortho, other_args)
 
     # WGS84 radius * 0.99999
@@ -90,7 +91,7 @@ def test_grid():
     ortho = ccrs.Orthographic(globe=globe)
     geodetic = ortho.as_geodetic()
 
-    other_args = {'a=1.0', 'b=1.0', 'lon_0=0.0', 'lat_0=0.0', 'alpha=0.0'}
+    other_args = {'a=1.0', 'b=1.0', 'lon_0=0.0', 'lat_0=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     assert_almost_equal(np.array(ortho.x_limits),
@@ -143,7 +144,7 @@ def test_sphere_transform():
                               globe=globe)
     geodetic = ortho.as_geodetic()
 
-    other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0', 'alpha=0.0'}
+    other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0'}
     check_proj_params('ortho', ortho, other_args)
 
     assert_almost_equal(np.array(ortho.x_limits),
@@ -164,7 +165,10 @@ def test_sphere_rotate():
                               azimuth=180.0, globe=globe)
     geodetic = ortho.as_geodetic()
 
-    other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0', 'alpha=180.0'}
+    if pyproj.__proj_version__ >= '9.5.0': # support for alpha (azimuthal rotation)
+        other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0', 'alpha=180.0'}
+    else:
+        other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0'}
     check_proj_params('ortho', ortho, other_args)
 
     assert_almost_equal(np.array(ortho.x_limits),
@@ -173,7 +177,10 @@ def test_sphere_rotate():
                         [-0.99999, 0.99999])
 
     result = ortho.transform_point(-110.0, 30.0, geodetic)
-    assert_almost_equal(result, np.array([ 0.1503837,  0.1651911]))
+    if pyproj.__proj_version__ >= '9.5.0': # support for alpha (azimuthal rotation)
+        assert_almost_equal(result, np.array([ 0.1503837,  0.1651911]))
+    else:
+        assert_almost_equal(result, np.array([-0.1503837, -0.1651911]))
 
     inverse_result = geodetic.transform_point(result[0], result[1], ortho)
     assert_almost_equal(inverse_result, [-110.0, 30.0])

--- a/lib/cartopy/tests/crs/test_orthographic.py
+++ b/lib/cartopy/tests/crs/test_orthographic.py
@@ -18,10 +18,7 @@ from .helpers import check_proj_params
 
 def test_default():
     ortho = ccrs.Orthographic()
-    if pyproj.__proj_version__ >= '9.5.0': # support for alpha
-        other_args = {'a=6378137.0', 'lat_0=0.0', 'lon_0=0.0', 'alpha=0.0'}
-    else:
-        other_args = {'a=6378137.0', 'lat_0=0.0', 'lon_0=0.0'}
+    other_args = {'a=6378137.0', 'lat_0=0.0', 'lon_0=0.0', 'alpha=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     # WGS84 radius * 0.99999
@@ -34,10 +31,7 @@ def test_default():
 def test_sphere_globe():
     globe = ccrs.Globe(semimajor_axis=1000, ellipse=None)
     ortho = ccrs.Orthographic(globe=globe)
-    if pyproj.__proj_version__ >= '9.5.0': # support for alpha
-        other_args = {'a=1000', 'lat_0=0.0', 'lon_0=0.0', 'alpha=0.0'}
-    else:
-        other_args = {'a=1000', 'lat_0=0.0', 'lon_0=0.0'}
+    other_args = {'a=1000', 'lat_0=0.0', 'lon_0=0.0', 'alpha=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     assert_almost_equal(ortho.x_limits, [-999.99, 999.99])
@@ -51,11 +45,7 @@ def test_ellipse_globe():
         ortho = ccrs.Orthographic(globe=globe)
         assert len(w) == 1
 
-    if pyproj.__proj_version__ >= '9.5.0': # support for alpha
-        other_args = {'ellps=WGS84', 'lat_0=0.0',
-                      'lon_0=0.0', 'alpha=0.0'}
-    else:
-        other_args = {'ellps=WGS84', 'lon_0=0.0', 'lat_0=0.0'}
+    other_args = {'ellps=WGS84', 'lat_0=0.0', 'lon_0=0.0', 'alpha=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     # Limits are the same as default since ellipses are not supported.
@@ -71,11 +61,7 @@ def test_eccentric_globe():
         ortho = ccrs.Orthographic(globe=globe)
         assert len(w) == 1
 
-    if pyproj.__proj_version__ >= '9.5.0': # support for alpha
-        other_args = {'a=1000', 'b=500', 'lat_0=0.0', 'lon_0=0.0',
-                      'alpha=0.0'}
-    else:
-        other_args = {'a=1000', 'b=500', 'lon_0=0.0', 'lat_0=0.0'}
+    other_args = {'a=1000', 'b=500', 'lat_0=0.0', 'lon_0=0.0', 'alpha=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     # Limits are the same as spheres since ellipses are not supported.
@@ -87,12 +73,8 @@ def test_eccentric_globe():
 @pytest.mark.parametrize('lon', [-10, 0, 10])
 def test_central_params(lon, lat):
     ortho = ccrs.Orthographic(central_latitude=lat, central_longitude=lon)
-    if pyproj.__proj_version__ >= '9.5.0': # support for alpha
-        other_args = {f'lat_0={lat}', f'lon_0={lon}',
-                      'a=6378137.0', 'alpha=0.0'}
-    else:
-        other_args = {f'lat_0={lat}', f'lon_0={lon}',
-                    'a=6378137.0'}
+    other_args = {f'lat_0={lat}', f'lon_0={lon}',
+                  'a=6378137.0', 'alpha=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     # WGS84 radius * 0.99999
@@ -109,11 +91,7 @@ def test_grid():
     ortho = ccrs.Orthographic(globe=globe)
     geodetic = ortho.as_geodetic()
 
-    if pyproj.__proj_version__ >= '9.5.0': # support for alpha
-        other_args = {'a=1.0', 'b=1.0', 'lon_0=0.0', 'lat_0=0.0',
-                      'alpha=0.0'}
-    else:
-        other_args = {'a=1.0', 'b=1.0', 'lon_0=0.0', 'lat_0=0.0'}
+    other_args = {'a=1.0', 'b=1.0', 'lon_0=0.0', 'lat_0=0.0', 'alpha=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     assert_almost_equal(np.array(ortho.x_limits),
@@ -166,11 +144,7 @@ def test_sphere_transform():
                               globe=globe)
     geodetic = ortho.as_geodetic()
 
-    if pyproj.__proj_version__ >= '9.5.0': # support for alpha
-        other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0',
-                      'alpha=0.0'}
-    else:
-        other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0'}
+    other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0', 'alpha=0.0'}
     check_proj_params('ortho', ortho, other_args)
 
     assert_almost_equal(np.array(ortho.x_limits),
@@ -191,11 +165,8 @@ def test_sphere_rotate():
                               azimuth=180.0, globe=globe)
     geodetic = ortho.as_geodetic()
 
-    if pyproj.__proj_version__ >= '9.5.0': # support for alpha (azimuthal rotation)
-        other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0',
-                      'alpha=180.0'}
-    else:
-        other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0'}
+    other_args = {'a=1.0', 'b=1.0', 'lon_0=-100.0', 'lat_0=40.0',
+                  'alpha=180.0'}
     check_proj_params('ortho', ortho, other_args)
 
     assert_almost_equal(np.array(ortho.x_limits),


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

This update adds `azimuth` argument to `ccrs.Orthographic()`, with a corresponding test. It will enable users to rotate the projection around the central point. It uses new Proj parameter `alpha`, which was added to `Orthographic` in Proj version 9.5.0. 
https://proj.org/en/stable/operations/projections/ortho.html

An equivalent `azimuth` argument has already been implemented to `ccrs.ObliqueMercator()`.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
Users will become able to rotate the map as they prefer. For example, one can orient a satellite image along the solar direction to emphasize which direction the sun glint and shadow appear.
This update is a minimal update, adding just one argument to the function.

<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
