### PR TITLE
Use pathlib.Path's read and write methods

### DIFF
--- a/lib/cartopy/io/__init__.py
+++ b/lib/cartopy/io/__init__.py
@@ -226,8 +226,7 @@ class Downloader:
         # try getting the resource (no exception handling, just let it raise)
         response = self._urlopen(url)
 
-        with open(target_path, 'wb') as fh:
-            fh.write(response.read())
+        target_path.write_bytes(response.read())
 
         return target_path
 

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -18,7 +18,6 @@ this way can be found at :ref:`sphx_glr_gallery_web_services_wmts.py`.
 import collections
 import io
 import math
-import os
 from pathlib import Path
 from urllib.parse import urlparse
 import warnings
@@ -539,7 +538,7 @@ class WMTSRasterSource(RasterSource):
         if self.cache_path is not None:
             cache_dir = self._cache_dir
             if not cache_dir.exists():
-                os.makedirs(cache_dir)
+                cache_dir.mkdir(parents=True, exist_ok=True)
                 if self._default_cache:
                     warnings.warn(
                         'Cartopy created the following directory to cache '

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -361,10 +361,10 @@ class NEShpDownloader(Downloader):
         zfh = ZipFile(io.BytesIO(shapefile_online.read()), 'r')
 
         for member_path in self.zip_file_contents(format_dict):
-            member = zfh.getinfo(member_path.replace('\\', '/'))
-            with open(target_path.with_suffix(
-                    Path(member_path).suffix), 'wb') as fh:
-                fh.write(zfh.open(member).read())
+            member = zfh.getinfo(member_path.replace("\\", "/"))
+            target_path.with_suffix(Path(member_path).suffix).write_bytes(
+                zfh.open(member).read()
+            )
 
         shapefile_online.close()
         zfh.close()
@@ -504,10 +504,9 @@ class GSHHSShpDownloader(Downloader):
 
             for member_path in self.zip_file_contents(modified_format_dict):
                 member = zfh.getinfo(member_path.replace('\\', '/'))
-                with open(target_path.with_suffix(
-                        Path(member_path).suffix), 'wb') as fh:
-                    fh.write(zfh.open(member).read())
-
+                target_path.with_suffix(Path(member_path).suffix).write_bytes(
+                    zfh.open(member).read()
+                )
         zfh.close()
 
     def acquire_resource(self, target_path, format_dict):

--- a/lib/cartopy/io/srtm.py
+++ b/lib/cartopy/io/srtm.py
@@ -373,8 +373,7 @@ class SRTMDownloader(Downloader):
 
         zip_member_path = '{y}{x}.hgt'.format(**format_dict)
         member = zfh.getinfo(zip_member_path)
-        with open(target_path, 'wb') as fh:
-            fh.write(zfh.open(member).read())
+        target_path.write_bytes(zfh.open(member).read())
 
         srtm_online.close()
         zfh.close()
@@ -407,8 +406,7 @@ class SRTMDownloader(Downloader):
             with urlopen(url) as f:
                 html = f.read()
         else:
-            with open(filename) as f:
-                html = f.read()
+            html = Path(filename).read_text()
 
         mask = np.zeros((360, 181), dtype=bool)
 

--- a/lib/cartopy/tests/test_coding_standards.py
+++ b/lib/cartopy/tests/test_coding_standards.py
@@ -88,8 +88,7 @@ class TestLicenseHeaders:
                     # Allow completely empty files (e.g. ``__init__.py``)
                     continue
 
-                with open(full_fname, encoding='utf-8') as fh:
-                    content = fh.read()
+                content = full_fname.read_text(encoding="utf-8")
 
                 if not bool(LICENSE_RE.match(content)):
                     failed.append(full_fname)

--- a/lib/cartopy/tests/test_img_nest.py
+++ b/lib/cartopy/tests/test_img_nest.py
@@ -61,8 +61,7 @@ def _save_world(fname, args):
               '{y_pix_size}\n'
               '{x_center}\n'
               '{y_center}\n')
-    with open(fname, 'w') as fh:
-        fh.write(_world.format(**args))
+    fname.write_text(_world.format(**args))
 
 
 def test_intersect(tmp_path):
@@ -298,8 +297,7 @@ def wmts_data():
                           f'{_TEST_DATA_DIR}.')
             shutil.rmtree(_TEST_DATA_DIR)
             _TEST_DATA_DIR.mkdir(parents=True)
-            with open(data_version_fname, 'w') as fh:
-                fh.write(str(_TEST_DATA_VERSION))
+            data_version_fname.write_text(str(_TEST_DATA_VERSION))
 
     # Download the tiles.
     for tile in tiles:


### PR DESCRIPTION
## Rationale

Code refactoring: use `pathlib.Path`'s read and write methods.

## Implications

You're already using `pathlib.Path` objects everywhere in file manipulation. With this changes, the code should be more straightforward to read. No implications on the functionality.
