### PR TITLE
Replace urllib.request with urllib3 to support WebAssembly

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - pyshp>=2.3
   - pyproj>=3.3.1
   - packaging>=21
+  - urllib3>=2.3
   # The testing label has the proper version of freetype included
   - conda-forge/label/testing::matplotlib-base>=3.6
 

--- a/lib/cartopy/io/__init__.py
+++ b/lib/cartopy/io/__init__.py
@@ -228,6 +228,7 @@ class Downloader:
         response = self._urlopen(url)
 
         target_path.write_bytes(response.read())
+        response.release_conn()
 
         return target_path
 

--- a/lib/cartopy/io/__init__.py
+++ b/lib/cartopy/io/__init__.py
@@ -13,8 +13,9 @@ sub-packages for loading, saving and retrieving various data formats.
 import collections
 from pathlib import Path
 import string
-from urllib.request import urlopen
 import warnings
+
+from urllib3 import request
 
 from cartopy import config
 
@@ -238,7 +239,7 @@ class Downloader:
 
         """
         warnings.warn(f'Downloading: {url}', DownloadWarning)
-        return urlopen(url)
+        return request('GET', url, preload_content=False)
 
     @staticmethod
     def from_config(specification, config_dict=None):

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -202,7 +202,8 @@ class GoogleWTS(metaclass=ABCMeta):
         pass
 
     def get_image(self, tile):
-        from urllib.request import HTTPError, Request, URLError, urlopen
+        from urllib3 import request
+        from urllib3.exceptions import HTTPError
 
         if self.cache_path is not None:
             filename = "_".join([str(i) for i in tile]) + ".npy"
@@ -215,13 +216,12 @@ class GoogleWTS(metaclass=ABCMeta):
         else:
             url = self._image_url(tile)
             try:
-                request = Request(url, headers={"User-Agent": self.user_agent})
-                fh = urlopen(request)
-                im_data = io.BytesIO(fh.read())
-                fh.close()
+                r = request('GET', url, headers={"User-Agent": self.user_agent}, preload_content=False)
+                im_data = io.BytesIO(r.read())
+                r.release_conn()
                 img = Image.open(im_data)
 
-            except (HTTPError, URLError) as err:
+            except HTTPError as err:
                 print(err)
                 img = Image.fromarray(np.full((256, 256, 3), (250, 250, 250),
                                               dtype=np.uint8))

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -19,7 +19,7 @@ import collections
 import io
 import math
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib3.util import parse_url
 import warnings
 import weakref
 from xml.etree import ElementTree
@@ -753,7 +753,7 @@ class WFSGeometrySource:
             # agroenvgeo.data.inra.fr from full address
             # http://mapserver.gis.umn.edu/mapserver
             # or https://agroenvgeo.data.inra.fr:443/geoserver/wfs
-            self.url = urlparse(service).hostname
+            self.url = parse_url(service).hostname
             # WebFeatureService of owslib
             service = WebFeatureService(service)
         else:

--- a/lib/cartopy/io/shapereader.py
+++ b/lib/cartopy/io/shapereader.py
@@ -30,7 +30,7 @@ geometry representation of shapely:
 import io
 import itertools
 from pathlib import Path
-from urllib.error import HTTPError
+from urllib3.exceptions import HTTPError
 
 import shapefile
 import shapely.geometry as sgeom

--- a/lib/cartopy/io/srtm.py
+++ b/lib/cartopy/io/srtm.py
@@ -403,8 +403,9 @@ class SRTMDownloader(Downloader):
         if filename is None:
             from urllib3 import request
             url = SRTMDownloader._SRTM_BASE_URL.format(resolution=resolution)
-            with request('GET', url, preload_content=False) as f:
+            with request('GET', url, preload_content=False) as r:
                 html = f.read()
+                r.release_conn()
         else:
             html = Path(filename).read_text()
 

--- a/lib/cartopy/io/srtm.py
+++ b/lib/cartopy/io/srtm.py
@@ -404,7 +404,7 @@ class SRTMDownloader(Downloader):
             from urllib3 import request
             url = SRTMDownloader._SRTM_BASE_URL.format(resolution=resolution)
             with request('GET', url, preload_content=False) as r:
-                html = f.read()
+                html = r.read()
                 r.release_conn()
         else:
             html = Path(filename).read_text()

--- a/lib/cartopy/io/srtm.py
+++ b/lib/cartopy/io/srtm.py
@@ -401,9 +401,9 @@ class SRTMDownloader(Downloader):
         # dependencies of cartopy.
         from bs4 import BeautifulSoup
         if filename is None:
-            from urllib.request import urlopen
+            from urllib3 import request
             url = SRTMDownloader._SRTM_BASE_URL.format(resolution=resolution)
-            with urlopen(url) as f:
+            with request('GET', url, preload_content=False) as f:
                 html = f.read()
         else:
             html = Path(filename).read_text()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "packaging>=21",
     "pyshp>=2.3",
     "pyproj>=3.3.1",
+    "urllib3>=2.3"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
As discussed in #2514, `urllib.request` is [not supported in WebAssembly](https://docs.python.org/3/library/urllib.request.html). This replaces `urllib.request` where needed with `urllib3` which does work with WebAssembly. I've tried to keep the code changes to a minimum and to reuse existing semantic patterns.

The linter did introduce new lines in one of the imports. I found it odd but left it in place.

## Rationale

This enables the use of Cartopy is [Pyodide](http://pyodide.org/) and [JupyterLite](http://jupyterlite.readthedocs.io/). Without it, downloading of shape files, etc., fail. See #2514.

## Implications

I've run the unit tests and nothing new fails. It's also been tested in JupyterLite and works. There is a chance that the download code path hasn't been fully tested and something may still need to be changed to support `urllib3`.

This also introduces a new dependency, even though `urllib3` is widely available. It is also an existing package in Pyodide.

<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
