### PR TITLE
TST: Bump tolerance for one image in future version testing

### DIFF
--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -116,7 +116,7 @@ def test_imshow():
 
 @pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(filename='imshow_regional_projected.png',
-                               tolerance=1.96)
+                               tolerance=1.97)
 def test_imshow_projected():
     source_proj = ccrs.PlateCarree()
     img_extent = (-120.67660000000001, -106.32104523100001,


### PR DESCRIPTION
A new version of one of the dependencies has shifted the baseline image ever so slightly on the boundary. It is 0.003 over the current tolerance and hardly noticeable in the image diff, so lets just raise the tolerance by a small amount.
https://github.com/SciTools/cartopy/actions/runs/14369513757/job/40289779761#step:9:183

Result / Difference image from CI:

![result](https://github.com/user-attachments/assets/9f6ecb08-eb2b-4b3a-a100-9d5f4f401896)
![result-failed-diff](https://github.com/user-attachments/assets/b6666994-5562-4097-83d1-89d6dfdc823f)


closes #2517 