### PR TITLE
TST: xfail France test due to data server issues

### DIFF
--- a/lib/cartopy/tests/mpl/test_features.py
+++ b/lib/cartopy/tests/mpl/test_features.py
@@ -83,6 +83,7 @@ def test_wfs():
                     reason='OWSLib and at least one of pykdtree or scipy is required')
 @pytest.mark.xfail(raises=(ParseError, AttributeError),
                    reason="Bad XML returned from the URL")
+@pytest.mark.xfail(reason="ReadTimeoutError from host currently")
 @pytest.mark.mpl_image_compare(filename='wfs_france.png')
 def test_wfs_france():
     ax = plt.axes(projection=ccrs.epsg(2154))


### PR DESCRIPTION
This test is failing due to a timeout with the server. I am not sure if the server has changed locations and needs a new address or if it is deprecated now, but this is the quickest fix to get tests passing again.

@mcuntz do you have any insight into this server since you added the test?