### PR TITLE
CI: Remove concurrency cancellation from release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,6 @@
 ---
 name: Build and upload to PyPI
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
-  cancel-in-progress: true
-
 # Only build on published releases
 on:
   release:


### PR DESCRIPTION
This removes the concurrency check from the release Action. It was causing jobs to be cancelled before the checks could run and skip. The skip happens within 1-2 seconds so just let the job skip happen automatically.