### PR TITLE
Corrected French WFS server address

### DIFF
--- a/lib/cartopy/tests/mpl/test_features.py
+++ b/lib/cartopy/tests/mpl/test_features.py
@@ -83,11 +83,10 @@ def test_wfs():
                     reason='OWSLib and at least one of pykdtree or scipy is required')
 @pytest.mark.xfail(raises=(ParseError, AttributeError),
                    reason="Bad XML returned from the URL")
-@pytest.mark.xfail(reason="ReadTimeoutError from host currently")
 @pytest.mark.mpl_image_compare(filename='wfs_france.png')
 def test_wfs_france():
     ax = plt.axes(projection=ccrs.epsg(2154))
-    url = 'https://agroenvgeo.data.inra.fr:443/geoserver/wfs'
+    url = 'https://geodata.inrae.fr/geoserver/wfs'
     typename = 'collectif:t_ser_l93'
     feature = cfeature.WFSFeature(url, typename, edgecolor='red')
     ax.add_feature(feature)


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

@greglucas found in [#2522](https://github.com/SciTools/cartopy/pull/2522) that the test for the French webserver timed out.

<!-- Please provide detail as to *why* you are making this change. -->

 I just found out that the server changed. INRAE, France, has consolidated several servers into the new 
https://geodata.inrae.fr

I give the correct new address now and removed the temporary workaround to `xfail`.

## Implications

Test `test_wfs_france` works again.