### PR TITLE
pep639: setuptools license and license-files fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools >= 40.6.0",
+    "setuptools >= 77.0.3",
     "Cython >= 0.29.24",
     # numpy requirement for wheel builds for distribution on PyPI - building
     # against 2.x yields wheels that are also compatible with numpy 1.x at
@@ -10,7 +10,7 @@ requires = [
     # redistributors can do this by installing the numpy version they like and
     # disabling build isolation.
     "numpy>=2.0.0rc1",
-    "setuptools_scm >= 7.0.0",
+    "setuptools_scm >= 8.0.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -23,11 +23,11 @@ description = "A Python library for cartographic visualizations with Matplotlib"
 readme = "README.md"
 requires-python = ">=3.10"
 keywords = ["cartography", "map", "transform", "projection", "pyproj", "shapely", "shapefile"]
-license = {file = "LICENSE"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 classifiers = [
     'Development Status :: 4 - Beta',
     'Framework :: Matplotlib',
-    'License :: OSI Approved :: BSD License',
     'Operating System :: MacOS :: MacOS X',
     'Operating System :: Microsoft :: Windows',
     'Operating System :: POSIX',


### PR DESCRIPTION
This pull-request mops up some tech debt to comply with [PEP639](https://peps.python.org/pep-0639/) for `setuptools`, also see [license and license-files](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files).

Additionally avoids the following `setuptools` deprecation warning:
```
!!
          ********************************************************************************
          Please consider removing the following classifiers in favor of a SPDX license expression:
          License :: OSI Approved :: BSD License
          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
!!
```
See [Deprecated license classifiers](https://peps.python.org/pep-0639/#deprecate-license-classifiers).