### PR TITLE
Replace deprecated numpy.math with libc.math

### DIFF
--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -16,8 +16,7 @@ from __future__ import print_function
 from functools import lru_cache
 
 cimport cython
-from libc.math cimport HUGE_VAL, sqrt
-from numpy.math cimport isfinite, isnan
+from libc.math cimport HUGE_VAL, sqrt, isfinite, isnan
 from libcpp cimport bool
 from libcpp.list cimport list
 


### PR DESCRIPTION
The Cartopy test builds are currently failing with the release of Cython 3.1.0 which deprecates `numpy.math` instead recommending the use of `libc.math` directly.  

This PR makes that change in Cartopy.

Closes #2527

Admittedly this isn't something I'm particularly familiar with, but had noticed the builds failing and started looking into it.

However, I have tested this locally and everything passed.