### PR TITLE
TST/FIX: Spilhaus doesn't contain units or datum by default, so remove

### DIFF
--- a/lib/cartopy/tests/crs/test_spilhaus.py
+++ b/lib/cartopy/tests/crs/test_spilhaus.py
@@ -15,10 +15,8 @@ from .helpers import check_proj_params
 
 proj_version = parse_version(pyproj.proj_version_str)
 common_arg = {
-    'datum=WGS84',
     'ellps=WGS84',
     'no_defs',
-    'units=m',
 }
 @pytest.mark.skipif(
     (proj_version < parse_version("9.6.0")),


### PR DESCRIPTION
Running locally with PROJ 9.6 I get failures within Spilhaus. I think this is because the class defaults were updated, but the corresponding tests were not from this comment: https://github.com/SciTools/cartopy/pull/2529#discussion_r2083614607
We don't have any CI running with PROJ 9.6, so can't test there yet. I think we should address that as a follow-up issue.