### PR TITLE
TST/FIX: xfail test-wfs-france due to unauthorized server

### DIFF
--- a/lib/cartopy/tests/mpl/test_features.py
+++ b/lib/cartopy/tests/mpl/test_features.py
@@ -83,6 +83,7 @@ def test_wfs():
                     reason='OWSLib and at least one of pykdtree or scipy is required')
 @pytest.mark.xfail(raises=(ParseError, AttributeError),
                    reason="Bad XML returned from the URL")
+@pytest.mark.xfail(reason="Unauthorized access to the WFS service")
 @pytest.mark.mpl_image_compare(filename='wfs_france.png')
 def test_wfs_france():
     ax = plt.axes(projection=ccrs.epsg(2154))


### PR DESCRIPTION
This xfails the failing test that is due to Unauthorized access errors currently to get CI passing again.

xref: https://github.com/SciTools/cartopy/issues/2533