### PR TITLE
allow RGBA mapbox styles

### DIFF
--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -505,7 +505,8 @@ class MapboxStyleTiles(GoogleWTS):
 
     """
 
-    def __init__(self, access_token, username, map_id, cache=False):
+    def __init__(self, access_token, username, map_id, 
+                 desired_tile_form='RGB', cache=False):
         """
         Set up a new instance to retrieve tiles from a Mapbox style.
 
@@ -523,12 +524,15 @@ class MapboxStyleTiles(GoogleWTS):
             tiles will be retrieved through this process. Note that this style
             may be private and if your access token does not have permissions
             to view this style, then map tile retrieval will fail.
+        desired_tile_form: optional
+            The desired tile format. Use 'RGBA' if desired style includes
+            transparency.
 
         """
         self.access_token = access_token
         self.username = username
         self.map_id = map_id
-        super().__init__(cache=cache)
+        super().__init__(cache=cache, desired_tile_form=desired_tile_form)
 
     def _image_url(self, tile):
         x, y, z = tile


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->

Some custom Mapbox styles include transparency. In my case, I made a style that was just place names so that I could overlay it on top of some radar data. This very simple change makes that possible, otherwise transparent areas are rendered as black.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->

No real implications, just a small additional option for those who need it.

<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
