### PR TITLE
CI: Update release runner version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
         include:
           - os: ubuntu-latest
             cibw_archs: "x86_64"
-          - os: windows-2019
+          - os: windows-latest
             cibw_archs: "auto64"
           - os: macos-latest
             cibw_archs: "x86_64"


### PR DESCRIPTION
The release build failed because windows-2019 wasn't supported anymore. Lets try bumping that up to `-latest` instead.
https://github.com/SciTools/cartopy/actions/runs/16674795688