### PR TITLE
DOC: Fix tagged versions on ReadTheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,15 @@ build:
     os: "ubuntu-22.04"
     tools:
         python: "mambaforge-23.11"
+    jobs:
+        # Sometimes RTD only fetches a commit and not a tag.
+        # https://github.com/readthedocs/readthedocs.org/issues/10715
+        post_checkout:
+            - git fetch --tags
+        # Avoid a dirty index:
+        # https://docs.readthedocs.com/platform/latest/build-customization.html#avoid-having-a-dirty-git-index
+        pre_install:
+            - git update-index --assume-unchanged environment.yml docs/source/conf.py
 
 conda:
     environment: environment.yml


### PR DESCRIPTION
## Rationale

Based on https://github.com/readthedocs/readthedocs.org/issues/10715, add additional build steps to ensure that tags are available, and the working tree isn't marked as dirty.

## Implications

RTD builds should have the right version.