### PR TITLE
DOC: add warning banner for unreleased docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 from datetime import datetime
+import os
 from pathlib import Path
 import sys
 
@@ -169,6 +170,15 @@ html_theme_options = {
     "external_links": [],
     "github_url": "https://github.com/SciTools/cartopy",
 }
+
+# Warn users if they are looking at latest unreleased docs on RTD.
+if (os.environ.get("READTHEDOCS") == "True" and
+        os.environ.get("READTHEDOCS_VERSION") == "latest"):
+    html_theme_options["announcement"] = f"""
+        You are viewing the <b>latest</b> unreleased documentation
+        <strong>{version}</strong>. You can switch to a
+        <a href="https://cartopy.readthedocs.io/stable/">stable</a>
+        version."""
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
[Copied from Iris](https://github.com/SciTools/iris/blob/85787bc23566e4935ce0ebfc66f010fe0afae067/docs/src/conf.py#L354-L360).  Adds a warning if you are on the "latest" RTD docs.

<img width="1454" height="447" alt="Screenshot from 2025-08-08 11-58-00" src="https://github.com/user-attachments/assets/4c39676f-1628-4e90-9fb0-e2f614e1a0be" />


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
