### PR TITLE
ENH: support autolim keyword for `add_feature`/`add_geometries`

### DIFF
--- a/lib/cartopy/mpl/feature_artist.py
+++ b/lib/cartopy/mpl/feature_artist.py
@@ -205,6 +205,17 @@ class FeatureArtist(matplotlib.collections.Collection):
 
             yield geom, geom_path
 
+    def get_paths(self):
+        paths = super().get_paths()
+        if paths:
+            # When we are drawing, there is an explicit list of paths set.
+            # Return these for the renderer.
+            return paths
+
+        # When not drawing, the path list is empty.  Find all the relevant paths for
+        # the current axes extent.
+        return [path for _, path in self._get_geoms_paths()]
+
     @matplotlib.artist.allow_rasterization
     def draw(self, renderer):
         """

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -671,7 +671,7 @@ class GeoAxes(matplotlib.axes.Axes):
                                                  **kwargs)
         return self.add_feature(feature)
 
-    def add_feature(self, feature, **kwargs):
+    def add_feature(self, feature, *, autolim=False, **kwargs):
         """
         Add the given :class:`~cartopy.feature.Feature` instance to the axes.
 
@@ -679,6 +679,9 @@ class GeoAxes(matplotlib.axes.Axes):
         ----------
         feature
             An instance of :class:`~cartopy.feature.Feature`.
+        autolim: bool, default=False
+            Whether to automatically update the axes extents to include the
+            feature.
 
         Returns
         -------
@@ -694,9 +697,9 @@ class GeoAxes(matplotlib.axes.Axes):
         """
         # Instantiate an artist to draw the feature and add it to the axes.
         artist = feature_artist.FeatureArtist(feature, **kwargs)
-        return self.add_collection(artist)
+        return self.add_collection(artist, autolim=autolim)
 
-    def add_geometries(self, geoms, crs, **kwargs):
+    def add_geometries(self, geoms, crs, *, autolim=False, **kwargs):
         """
         Add the given shapely geometries (in the given crs) to the axes.
 
@@ -708,6 +711,9 @@ class GeoAxes(matplotlib.axes.Axes):
             The cartopy CRS in which the provided geometries are defined.
         styler
             A callable that returns matplotlib patch styling given a geometry.
+        autolim: bool, default=False
+            Whether to automatically update the axes extents to include the
+            geometries.
 
         Returns
         -------
@@ -724,7 +730,7 @@ class GeoAxes(matplotlib.axes.Axes):
         """
         styler = kwargs.pop('styler', None)
         feature = cartopy.feature.ShapelyFeature(geoms, crs, **kwargs)
-        return self.add_feature(feature, styler=styler)
+        return self.add_feature(feature, styler=styler, autolim=autolim)
 
     def get_extent(self, crs=None):
         """

--- a/lib/cartopy/tests/mpl/test_axes.py
+++ b/lib/cartopy/tests/mpl/test_axes.py
@@ -105,7 +105,7 @@ class Test_Axes_add_geometries:
             mock.sentinel.geometries, mock.sentinel.crs, wibble='wobble')
 
         add_feature_method.assert_called_once_with(
-            ShapelyFeature(), styler=mock.sentinel.styler)
+            ShapelyFeature(), styler=mock.sentinel.styler, autolim=False)
 
     @pytest.mark.natural_earth
     def test_single_geometry(self):

--- a/lib/cartopy/tests/mpl/test_feature_artist.py
+++ b/lib/cartopy/tests/mpl/test_feature_artist.py
@@ -114,7 +114,7 @@ def test_feature_artist_draw_styler(feature):
             return {'facecolor':'blue'}
 
     fig, ax = robinson_map()
-    ax.add_feature(feature, facecolor='red', styler=styler)
+    ax.add_feature(feature, facecolor='grey', styler=styler)
 
     return fig
 
@@ -130,3 +130,19 @@ def test_feature_artist_geom_single_path(feature):
     # plotted as one compound path to ensure style consistency.
     for geom in feature.geometries():
         assert isinstance(cached_paths(geom, plot_crs), mpath.Path)
+
+
+@pytest.mark.parametrize('autolim', [False, True])
+def test_feature_artist_autolim(autolim):
+    plot_crs = ccrs.PlateCarree(central_longitude=180)
+    fig, ax = plt.subplots(subplot_kw={'projection': plot_crs})
+
+    square = sgeom.Polygon([(30, 0), (50, 0), (50, 20), (30, 20), (30, 0)])
+    ax.add_geometries([square], crs=ccrs.PlateCarree(), autolim=autolim)
+
+    if autolim:
+        expected = [-150, 0, 20, 20]  # Fit to square projected 180 degrees
+    else:
+        expected = [-180, -90, 360, 180]  # Leave at default of whole globe
+
+    np.testing.assert_allclose(ax.dataLim.bounds, expected)


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Inspired by [this StackOverflow question](https://stackoverflow.com/q/79733680/3501128).  The automatic update of the axes extent does not currently work because `Collection.get_datalim` relies on the [get_paths](https://github.com/matplotlib/matplotlib/blob/780e66c7975ccf27abd104f105bf773f1e6cd0d2/lib/matplotlib/collections.py#L272-L275) method.  Since the `FeatureArtist` paths are created on-the-fly at draw, the rest of the time `get_paths` returns an empty list.  This PR modifies `get_paths` to return the same paths that `draw` would use.  It also adds the _autolim_ keyword to `add_feature` and `add_geometries`, defaulting to `False` for backward compatibility and because that is almost certainly what you want if using something like a Natural Earth feature.

We can now do

```python
import matplotlib.pyplot as plt
import cartopy.crs as ccrs
from shapely.geometry import Point

f = plt.figure()
ax = f.add_subplot(projection=ccrs.Mollweide())

# plot a normal artist
ax.plot([-150000,2000,150000, 250000], 
        [-50000, 2000, 50000, -250000], 
        lw=5, c="g")

# add some geometries
for x, y in zip([10, 20, 40], [12, 34, 46]):
    p = Point((x, y)).buffer(3)
    ax.add_geometries(p, fc="r",crs=ccrs.PlateCarree(), autolim=True)

ax.autoscale_view()

plt.show()
```
The call to `autoscale_view` will not be necessary from Matplotlib v3.11 because of https://github.com/matplotlib/matplotlib/pull/29958

<img width="640" height="480" alt="Figure_1" src="https://github.com/user-attachments/assets/b1cf3ccb-6129-4695-9ee4-d00db53153fd" />



## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
