### PR TITLE
Add support for Thunderforest tiles

### DIFF
--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -43,6 +43,7 @@ the package wouldn't be as rich or diverse as it is today:
  * Stephane Raynaud
  * John Krasting
  * Matthias Cuntz
+ * Thomas Guymer
 
 Thank you!
 

--- a/docs/source/reference/io.rst
+++ b/docs/source/reference/io.rst
@@ -58,6 +58,7 @@ Image tiles
     QuadtreeTiles
     StadiaMapsTiles
     Stamen
+    Thunderforest
 
 Open Geospatial Consortium (OGC) Clients
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/reference/io.rst
+++ b/docs/source/reference/io.rst
@@ -58,7 +58,7 @@ Image tiles
     QuadtreeTiles
     StadiaMapsTiles
     Stamen
-    Thunderforest
+    ThunderforestTiles
 
 Open Geospatial Consortium (OGC) Clients
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -476,7 +476,7 @@ class Stamen(GoogleWTS):
             f'{self.style}/{z}/{x}/{y}.{self.extension}'
 
 
-class ThunderforestTiles(GoogleWTS):
+class Thunderforest(GoogleWTS):
     """
     Retrieves tiles from https://www.thunderforest.com.
 

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -476,7 +476,7 @@ class Stamen(GoogleWTS):
             f'{self.style}/{z}/{x}/{y}.{self.extension}'
 
 
-class Thunderforest(GoogleWTS):
+class ThunderforestTiles(GoogleWTS):
     """
     Retrieves tiles from https://www.thunderforest.com.
 
@@ -488,7 +488,7 @@ class Thunderforest(GoogleWTS):
     apikey : str, required
         The authentication key provided by Thunderforest to query their APIs
     style : str, optional
-        Name of the desired style. Defaults to "atlas". See
+        Name of the desired style. Defaults to "landscape". See
         https://www.thunderforest.com/maps/ for a full list of styles.
     resolution : str, optional
         Resolution of the images to return. Defaults to an empty string,
@@ -509,7 +509,7 @@ class Thunderforest(GoogleWTS):
 
     def __init__(self,
                     apikey,
-                    style="atlas",
+                    style="landscape",
                     resolution="",
                     cache=False):
         super().__init__(cache=cache, desired_tile_form="RGBA")

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -252,6 +252,13 @@ class GoogleTiles(GoogleWTS):
             Such as: ``'https://server.arcgisonline.com/ArcGIS/rest/services/\
 World_Shaded_Relief/MapServer/tile/{z}/{y}/{x}.jpg'``
 
+        Notes
+        -----
+        Currently, the ``GoogleWTS`` class does not use ``style`` when
+        determining the local file path in the cache. Therefore, if a tile
+        already exists for the same ``(x, y, z)`` then it will be blindly used
+        even if the style is not what was asked for. You may need to manage
+        multiple cache paths to work around this issue.
         """
         styles = ["street", "satellite", "terrain", "only_streets"]
         style = style.lower()
@@ -356,6 +363,14 @@ class StadiaMapsTiles(GoogleWTS):
     cache : bool or str, optional
         If True, the default cache directory is used. If False, no cache is
         used. If a string, the string is used as the path to the cache.
+
+    Notes
+    -----
+    Currently, the ``GoogleWTS`` class does not use either ``resolution`` or
+    ``style`` when determining the local file path in the cache. Therefore, if a
+    tile already exists for the same ``(x, y, z)`` then it will be blindly used
+    even if the resolution or style is not what was asked for. You may need to
+    manage multiple cache paths to work around this issue.
     """
 
     def __init__(self,
@@ -398,6 +413,14 @@ class Stamen(GoogleWTS):
 
     Please see the attribution notice at http://maps.stamen.com on how to
     attribute this imagery.
+
+    Notes
+    -----
+    Currently, the ``GoogleWTS`` class does not use ``style`` when determining
+    the local file path in the cache. Therefore, if a tile already exists for
+    the same ``(x, y, z)`` then it will be blindly used even if the style is not
+    what was asked for. You may need to manage multiple cache paths to work
+    around this issue.
 
     References
     ----------
@@ -451,6 +474,60 @@ class Stamen(GoogleWTS):
         x, y, z = tile
         return 'http://tile.stamen.com/' + \
             f'{self.style}/{z}/{x}/{y}.{self.extension}'
+
+
+class ThunderforestTiles(GoogleWTS):
+    """
+    Retrieves tiles from https://www.thunderforest.com.
+
+    For a full reference on the styles available please see
+    https://www.thunderforest.com/maps/.
+
+    Parameters
+    ----------
+    apikey : str, required
+        The authentication key provided by Thunderforest to query their APIs
+    style : str, optional
+        Name of the desired style. Defaults to "atlas". See
+        https://www.thunderforest.com/maps/ for a full list of styles.
+    resolution : str, optional
+        Resolution of the images to return. Defaults to an empty string,
+        standard resolution (256x256). You can also specify "@2x" for high
+        resolution (512x512) tiles.
+    cache : bool or str, optional
+        If True, the default cache directory is used. If False, no cache is
+        used. If a string, the string is used as the path to the cache.
+
+    Notes
+    -----
+    Currently, the ``GoogleWTS`` class does not use either ``resolution`` or
+    ``style`` when determining the local file path in the cache. Therefore, if a
+    tile already exists for the same ``(x, y, z)`` then it will be blindly used
+    even if the resolution or style is not what was asked for. You may need to
+    manage multiple cache paths to work around this issue.
+    """
+
+    def __init__(self,
+                    apikey,
+                    style="atlas",
+                    resolution="",
+                    cache=False):
+        super().__init__(cache=cache, desired_tile_form="RGBA")
+        self.apikey = apikey
+        self.resolution = resolution
+        self.extension = "png"
+
+        if style not in ("atlas", "cycle", "landscape", "mobile-atlas",
+                         "neighbourhood", "outdoors", "pioneer", "spinal-map",
+                         "transport", "transport-dark"):
+            raise ValueError(f'Invalid style {style}')
+        self.style = style
+
+    def _image_url(self, tile):
+        x, y, z = tile
+        return ("https://tile.thunderforest.com/"
+                f"{self.style}/{z}/{x}/{y}{self.resolution}.{self.extension}"
+                f"?apikey={self.apikey}")
 
 
 class MapboxTiles(GoogleWTS):
@@ -663,6 +740,14 @@ class OrdnanceSurvey(GoogleWTS):
             - https://apidocs.os.uk/docs/map-styles
         desired_tile_form: optional
             Defaults to 'RGB'.
+
+        Notes
+        -----
+        Currently, the ``GoogleWTS`` class does not use ``layer`` when
+        determining the local file path in the cache. Therefore, if a tile
+        already exists for the same ``(x, y, z)`` then it will be blindly used
+        even if the layer is not what was asked for. You may need to manage
+        multiple cache paths to work around this issue.
         """
         super().__init__(desired_tile_form=desired_tile_form,
                          cache=cache)


### PR DESCRIPTION
## Rationale

I wanted to use Thunderforest tiles in my own projects and I wanted an easy way to add them to my Cartopy projects. Looking at the Cartopy source code for other third-party tile resources, such as "Stamen", it did not look too daunting to add another one.

## Implications

There are no implications to this change - no pre-existing features are affected in any way. This Pull Request simply adds another third-party tile resource.

Here is an example map using "landscape" tiles at "@2x" scale (with a higher-than-default value of `regrid_shape`) using my own personal Thunderforest API key (it shows four day hikes emanating from Finse train station, coloured by walking speed):

<img width="2160" height="2160" alt="norway-aug-2024" src="https://github.com/user-attachments/assets/daa6a5d5-221d-4763-ac18-391d70560411" />
