### PR TITLE
WHL: add Windows32 + musllinux wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
           - os: ubuntu-latest
             cibw_archs: "x86_64"
           - os: windows-latest
-            cibw_archs: "auto64"
+            cibw_archs: "auto"
           - os: macos-latest
             cibw_archs: "x86_64"
           - os: macos-latest
@@ -98,8 +98,7 @@ jobs:
         with:
           package-dir: dist/${{ needs.build_sdist.outputs.SDIST_NAME }}
         env:
-          # Skip 32 bit builds and musllinux due to lack of numpy wheels
-          CIBW_SKIP: "*-win32 *_i686 *-musllinux* cp3*t-*"
+          CIBW_SKIP: "*_i686 cp3*t-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - uses: actions/upload-artifact@v5


### PR DESCRIPTION
## Rationale

Maybe this won't work out of the box, but I noticed the documented reason for skipping these targets was obsolete; numpy in fact has wheels for both, so let's give it a spin


## Implications

More supported platforms.


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
