### PR TITLE
DOC: new example, recreation of The Simpsons Monorail Map

### DIFF
--- a/examples/miscellanea/simpsons-monorail-map.py
+++ b/examples/miscellanea/simpsons-monorail-map.py
@@ -112,7 +112,7 @@ def main():
     # Add the bottom left 'compass' legend in spirit of the original map.
     map_ax.text(
         0.14,
-        0.0,
+        0.10,
         leg_text,
         transform=map_ax.transAxes,
         fontsize=11,

--- a/examples/miscellanea/simpsons-monorail-map.py
+++ b/examples/miscellanea/simpsons-monorail-map.py
@@ -25,9 +25,11 @@ import cartopy.io.shapereader as shpreader
 
 # Define choices for projection and locations to plot
 GEOM_PROJ = ccrs.PlateCarree()
-# Not real places, so locations pulled from location on map in still image
-# First value 2-tuple is the dot placemap location, second is where to write
-# the text label relative to that dot, to best match the map from the show.
+# Not real places, so locations pulled from location on map in still image.
+# The items in order correspond to:
+# * an x-y 2-tuple for where to plot the location dot on the map
+# * an x-y 2-tuple for where to write the text label relative to the dot above
+# * an integer for how much to rotate the text to best match the map text.
 LOCATIONS_TO_PLOT = {
     "Ogdenville": [(-111.8, 35.5), (1.5, -2.2), -6],
     "North\nHaverbrook": [(-99.0, 43.5), (2.8, -0.5), -1],

--- a/examples/miscellanea/simpsons-monorail-map.py
+++ b/examples/miscellanea/simpsons-monorail-map.py
@@ -18,11 +18,9 @@ https://simpsons.fandom.com/wiki/Brockway.
 """
 
 import matplotlib.pyplot as plt
-from matplotlib.transforms import offset_copy
 
 import cartopy.crs as ccrs
 import cartopy.io.shapereader as shpreader
-from matplotlib.patches import Rectangle
 
 
 # Define choices for projection and locations to plot

--- a/examples/miscellanea/simpsons-monorail-map.py
+++ b/examples/miscellanea/simpsons-monorail-map.py
@@ -22,6 +22,7 @@ from matplotlib.transforms import offset_copy
 
 import cartopy.crs as ccrs
 import cartopy.io.shapereader as shpreader
+from matplotlib.patches import Rectangle
 
 
 # Define choices for projection and locations to plot
@@ -37,10 +38,16 @@ LOCATIONS_TO_PLOT = {
 
 
 def main():
-    # Set up a plot with a thin light blue/white border to make the map inside
-    #     Note: for proportions of land mass, font size and border to be as
-    #     intended, need to keep 'figsize' and 'dpi' (4:3 ratio) as below.
-    fig = plt.figure(figsize=(9, 7.5), dpi=125, facecolor="#AFCBBD")
+    # Set up a plot with a light blue background and a white overall border.
+    # For proportions of land mass, font size and border to be as
+    # intended, need to keep 'figsize' and 'dpi' (4:3 ratio) as below.
+    fig = plt.figure(
+        figsize=(9, 7.5),
+        dpi=125,
+        facecolor="#AFCBBD",
+        edgecolor="white",  # sets up white border without need for another axes
+        linewidth=30,  # makes the border thicker as per original map
+    )
     map_ax = fig.add_axes(
         [0.035, 0.035, 0.93, 0.93], projection=ccrs.LambertConformal(), frameon=False
     )
@@ -66,10 +73,8 @@ def main():
         edgecolor="black",
     )
 
-    # From/see example:
-    # https://scitools.org.uk/cartopy/docs/latest/gallery/
-    # scalar_data/eyja_volcano.html
-    # Now add the location labels
+    # Now add the location labels. The general approach is that covered in
+    # the 'Map tile acquisition' Catopy example, including the comment below.
     #
     # Use the cartopy interface to create a matplotlib transform object
     # for the Geodetic coordinate system. We will use this along with
@@ -111,10 +116,10 @@ def main():
         "(recreation of map at\nsimpsons.fandom.com/\nwiki/Brockway)"
     )
 
-    # Add the 'compass' legend
+    # Add the bottom left 'compass' legend in spirit of the original map.
     map_ax.text(
         0.14,
-        0.10,
+        0.0,
         leg_text,
         transform=map_ax.transAxes,
         fontsize=11,

--- a/examples/miscellanea/simpsons-monorail-map.py
+++ b/examples/miscellanea/simpsons-monorail-map.py
@@ -1,13 +1,8 @@
-import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 from matplotlib.transforms import offset_copy
 
-import shapely.geometry as sgeom
-
-import cartopy
 import cartopy.crs as ccrs
 import cartopy.io.shapereader as shpreader
-import cartopy.feature as cfeature
 
 
 # Define choices for projection and locations to plot
@@ -28,8 +23,7 @@ def main():
     #     intended, need to keep 'figsize' and 'dpi' (4:3 ratio) as below.
     fig, ax = plt.subplots(figsize=(9, 7.5), dpi=125, facecolor="white")
     ax.set_facecolor("#AFCBBD")
-    ax = fig.add_subplot(
-        111, projection=ccrs.LambertConformal(), frameon=False)
+    ax = fig.add_subplot(111, projection=ccrs.LambertConformal(), frameon=False)
     plt.setp(plt.gcf().get_axes(), xticks=[], yticks=[])  # no axes or labels
     ax.set_extent([-120, -72.5, 20, 50], crs=ccrs.Geodetic())  # center on USA
 
@@ -39,7 +33,8 @@ def main():
     )
     countries = shpreader.Reader(shpfilename).records()
     usa_border = [
-        country.geometry for country in countries
+        country.geometry
+        for country in countries
         if (country.attributes["NAME"] == "United States of America")
     ]
     ax.add_geometries(
@@ -89,7 +84,6 @@ def main():
             rotation=text_rot,  # slightly wonky text for handwritten effect
         )
 
-
     leg_text = (
         "Pre-Springfield Lanley\nMonorail locations in TV's\nThe Simpsons\n"
         "(recreation of map at\nsimpsons.fandom.com/\nwiki/Brockway)"
@@ -97,9 +91,14 @@ def main():
 
     # Add the 'compass' legend
     ax.text(
-        0.14, 0.10, leg_text, transform=ax.transAxes, fontsize=11,
+        0.14,
+        0.10,
+        leg_text,
+        transform=ax.transAxes,
+        fontsize=11,
         horizontalalignment="center",
-        verticalalignment="center", style="italic",
+        verticalalignment="center",
+        style="italic",
         bbox=dict(facecolor="#A5B5CE"),
     )
 

--- a/examples/miscellanea/simpsons-monorail-map.py
+++ b/examples/miscellanea/simpsons-monorail-map.py
@@ -52,8 +52,7 @@ def main():
         [0.035, 0.035, 0.93, 0.93], projection=ccrs.LambertConformal(), frameon=False
     )
 
-    # Remove all axes ticks and labelling and center on location of USA
-    map_ax.set(xticks=[], yticks=[])
+    # Center on location of USA with a bit of space on all sides to pad
     map_ax.set_extent([-120, -72.5, 20, 50], crs=ccrs.Geodetic())
 
     # Plot only the USA landmass, in a fawn colour with a thin black border

--- a/examples/miscellanea/simpsons-monorail-map.py
+++ b/examples/miscellanea/simpsons-monorail-map.py
@@ -43,7 +43,7 @@ def main():
     # For proportions of land mass, font size and border to be as
     # intended, need to keep 'figsize' and 'dpi' (4:3 ratio) as below.
     fig = plt.figure(
-        figsize=(9, 7.5),
+        figsize=(8., 6.5),
         dpi=125,
         facecolor="#AFCBBD",
         edgecolor="white",  # sets up white border without need for another axes
@@ -107,8 +107,8 @@ def main():
 
     # Add the bottom left 'compass' legend in spirit of the original map.
     map_ax.text(
-        0.14,
-        0.10,
+        0.15,
+        0.02,
         leg_text,
         transform=map_ax.transAxes,
         fontsize=11,
@@ -119,7 +119,6 @@ def main():
     )
 
     plt.show()
-    fig.savefig("monorail-dec-new.png")  # SLB: REMOVE BEFORE COMMITTING
 
 
 if __name__ == "__main__":

--- a/examples/miscellanea/simpsons-monorail-map.py
+++ b/examples/miscellanea/simpsons-monorail-map.py
@@ -16,6 +16,7 @@ taken in likeness from the screen grab available at:
 https://simpsons.fandom.com/wiki/Brockway.
 
 """
+
 import matplotlib.pyplot as plt
 from matplotlib.transforms import offset_copy
 
@@ -39,11 +40,14 @@ def main():
     # Set up a plot with a thin light blue/white border to make the map inside
     #     Note: for proportions of land mass, font size and border to be as
     #     intended, need to keep 'figsize' and 'dpi' (4:3 ratio) as below.
-    fig, ax = plt.subplots(figsize=(9, 7.5), dpi=125, facecolor="white")
-    ax.set_facecolor("#AFCBBD")
-    ax = fig.add_subplot(111, projection=ccrs.LambertConformal(), frameon=False)
-    plt.setp(plt.gcf().get_axes(), xticks=[], yticks=[])  # no axes or labels
-    ax.set_extent([-120, -72.5, 20, 50], crs=ccrs.Geodetic())  # center on USA
+    fig = plt.figure(figsize=(9, 7.5), dpi=125, facecolor="#AFCBBD")
+    map_ax = fig.add_axes(
+        [0.035, 0.035, 0.93, 0.93], projection=ccrs.LambertConformal(), frameon=False
+    )
+
+    # Remove all axes ticks and labelling and center on location of USA
+    plt.setp(map_ax, xticks=[], yticks=[])
+    map_ax.set_extent([-120, -72.5, 20, 50], crs=ccrs.Geodetic())
 
     # Plot only the USA landmass, in a fawn colour with a thin black border
     shpfilename = shpreader.natural_earth(
@@ -55,7 +59,7 @@ def main():
         for country in countries
         if (country.attributes["NAME"] == "United States of America")
     ]
-    ax.add_geometries(
+    map_ax.add_geometries(
         usa_border,
         GEOM_PROJ,
         facecolor="#C39B6A",
@@ -71,11 +75,11 @@ def main():
     # for the Geodetic coordinate system. We will use this along with
     # matplotlib's offset_copy function to define a coordinate system which
     # translates the text by 25 pixels to the left.
-    geodetic_transform = GEOM_PROJ._as_mpl_transform(ax)
+    geodetic_transform = GEOM_PROJ._as_mpl_transform(map_ax)
     text_transform = offset_copy(geodetic_transform, units="dots", x=-25)
     for loc_name, loc_details in LOCATIONS_TO_PLOT.items():
         loc_coords, rel_text_pos, text_rot = loc_details
-        ax.plot(
+        map_ax.plot(
             *loc_coords,
             marker="o",
             color="black",
@@ -90,7 +94,7 @@ def main():
         )
         # Text in uppercase, very bold handwriting-like font, as per the
         # screen grab of the map from the show
-        ax.text(
+        map_ax.text(
             *text_loc_coords,
             loc_name.upper(),
             verticalalignment="center",
@@ -108,11 +112,11 @@ def main():
     )
 
     # Add the 'compass' legend
-    ax.text(
+    map_ax.text(
         0.14,
         0.10,
         leg_text,
-        transform=ax.transAxes,
+        transform=map_ax.transAxes,
         fontsize=11,
         horizontalalignment="center",
         verticalalignment="center",
@@ -120,9 +124,6 @@ def main():
         bbox=dict(facecolor="#A5B5CE"),
     )
 
-    # Make border symmetrical since default 'rc' file has asymmetric side pad
-    fig.tight_layout()
-    fig.subplots_adjust(left=0.035, bottom=0.035, right=0.965, top=0.965)
     plt.show()
 
 

--- a/examples/miscellanea/simpsons-monorail-map.py
+++ b/examples/miscellanea/simpsons-monorail-map.py
@@ -53,7 +53,7 @@ def main():
     )
 
     # Remove all axes ticks and labelling and center on location of USA
-    plt.setp(map_ax, xticks=[], yticks=[])
+    map_ax.set(xticks=[], yticks=[])
     map_ax.set_extent([-120, -72.5, 20, 50], crs=ccrs.Geodetic())
 
     # Plot only the USA landmass, in a fawn colour with a thin black border

--- a/examples/miscellanea/simpsons-monorail-map.py
+++ b/examples/miscellanea/simpsons-monorail-map.py
@@ -72,15 +72,7 @@ def main():
         edgecolor="black",
     )
 
-    # Now add the location labels. The general approach is that covered in
-    # the 'Map tile acquisition' Catopy example, including the comment below.
-    #
-    # Use the cartopy interface to create a matplotlib transform object
-    # for the Geodetic coordinate system. We will use this along with
-    # matplotlib's offset_copy function to define a coordinate system which
-    # translates the text by 25 pixels to the left.
-    geodetic_transform = GEOM_PROJ._as_mpl_transform(map_ax)
-    text_transform = offset_copy(geodetic_transform, units="dots", x=-25)
+    # Now add the location labels one by one
     for loc_name, loc_details in LOCATIONS_TO_PLOT.items():
         loc_coords, rel_text_pos, text_rot = loc_details
         map_ax.plot(
@@ -98,12 +90,14 @@ def main():
         )
         # Text in uppercase, very bold handwriting-like font, as per the
         # screen grab of the map from the show
-        map_ax.text(
-            *text_loc_coords,
+        map_ax.annotate(
             loc_name.upper(),
+            xy=text_loc_coords,
+            transform=ccrs.Geodetic(),
+            xytext=(-25, 0),  # shift text closer to point as per reference
+            textcoords="offset pixels",
             verticalalignment="center",
             horizontalalignment="left",
-            transform=text_transform,
             fontname="Charcoal",  # ensure you have this font available
             fontweight="black",
             fontsize=28,

--- a/examples/miscellanea/simpsons-monorail-map.py
+++ b/examples/miscellanea/simpsons-monorail-map.py
@@ -124,7 +124,6 @@ def main():
     fig.tight_layout()
     fig.subplots_adjust(left=0.035, bottom=0.035, right=0.965, top=0.965)
     plt.show()
-    fig.savefig("monorail_map.png")
 
 
 if __name__ == "__main__":

--- a/examples/miscellanea/simpsons-monorail-map.py
+++ b/examples/miscellanea/simpsons-monorail-map.py
@@ -1,0 +1,114 @@
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+from matplotlib.transforms import offset_copy
+
+import shapely.geometry as sgeom
+
+import cartopy
+import cartopy.crs as ccrs
+import cartopy.io.shapereader as shpreader
+import cartopy.feature as cfeature
+
+
+# Define choices for projection and locations to plot
+GEOM_PROJ = ccrs.PlateCarree()
+# Not real places, so locations pulled from location on map in still image
+# First value 2-tuple is the dot placemap location, second is where to write
+# the text label relative to that dot, to best match the map from the show.
+LOCATIONS_TO_PLOT = {
+    "Ogdenville": [(-111.8, 35.5), (1.5, -2.2), -6],
+    "North\nHaverbrook": [(-99.0, 43.5), (2.8, -0.5), -1],
+    "Brockway": [(-80.4, 33.6), (-3.4, -1.5), 3],
+}
+
+
+def main():
+    # Set up a plot with a thin light blue/white border to make the map inside
+    #     Note: for proportions of land mass, font size and border to be as
+    #     intended, need to keep 'figsize' and 'dpi' (4:3 ratio) as below.
+    fig, ax = plt.subplots(figsize=(9, 7.5), dpi=125, facecolor="white")
+    ax.set_facecolor("#AFCBBD")
+    ax = fig.add_subplot(
+        111, projection=ccrs.LambertConformal(), frameon=False)
+    plt.setp(plt.gcf().get_axes(), xticks=[], yticks=[])  # no axes or labels
+    ax.set_extent([-120, -72.5, 20, 50], crs=ccrs.Geodetic())  # center on USA
+
+    # Plot only the USA landmass, in a fawn colour with a thin black border
+    shpfilename = shpreader.natural_earth(
+        resolution="110m", category="cultural", name="admin_0_countries"
+    )
+    countries = shpreader.Reader(shpfilename).records()
+    usa_border = [
+        country.geometry for country in countries
+        if (country.attributes["NAME"] == "United States of America")
+    ]
+    ax.add_geometries(
+        usa_border,
+        GEOM_PROJ,
+        facecolor="#C39B6A",
+        edgecolor="black",
+    )
+
+    # From/see example:
+    # https://scitools.org.uk/cartopy/docs/latest/gallery/
+    # scalar_data/eyja_volcano.html
+    # Now add the location labels
+    #
+    # Use the cartopy interface to create a matplotlib transform object
+    # for the Geodetic coordinate system. We will use this along with
+    # matplotlib's offset_copy function to define a coordinate system which
+    # translates the text by 25 pixels to the left.
+    geodetic_transform = GEOM_PROJ._as_mpl_transform(ax)
+    text_transform = offset_copy(geodetic_transform, units="dots", x=-25)
+    for loc_name, loc_details in LOCATIONS_TO_PLOT.items():
+        loc_coords, rel_text_pos, text_rot = loc_details
+        ax.plot(
+            *loc_coords,
+            marker="o",
+            color="black",
+            markersize=6,
+            transform=GEOM_PROJ,
+        )
+
+        # Adjust position of location name text relative to location marker
+        text_loc_coords = (
+            loc_coords[0] + rel_text_pos[0],
+            loc_coords[1] + rel_text_pos[1],
+        )
+        # Text in uppercase, very bold handwriting-like font, as per the
+        # screengrab
+        ax.text(
+            *text_loc_coords,
+            loc_name.upper(),
+            verticalalignment="center",
+            horizontalalignment="left",
+            transform=text_transform,
+            fontname="Charcoal",  # ensure you have this font available
+            fontweight="black",
+            fontsize=28,
+            rotation=text_rot,  # slightly wonky text for handwritten effect
+        )
+
+
+    leg_text = (
+        "Pre-Springfield Lanley\nMonorail locations in TV's\nThe Simpsons\n"
+        "(recreation of map at\nsimpsons.fandom.com/\nwiki/Brockway)"
+    )
+
+    # Add the 'compass' legend
+    ax.text(
+        0.14, 0.10, leg_text, transform=ax.transAxes, fontsize=11,
+        horizontalalignment="center",
+        verticalalignment="center", style="italic",
+        bbox=dict(facecolor="#A5B5CE"),
+    )
+
+    # Make border symmetrical since default 'rc' file has asymmetric side pad
+    fig.tight_layout()
+    fig.subplots_adjust(left=0.035, bottom=0.035, right=0.965, top=0.965)
+    plt.show()
+    fig.savefig("monorail_map.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/miscellanea/simpsons-monorail-map.py
+++ b/examples/miscellanea/simpsons-monorail-map.py
@@ -1,3 +1,21 @@
+"""
+Recreation of the Monorail Map from The Simpsons
+------------------------------------------------
+
+This example demonstrates how to create a minimal outline map of a
+defined area of land such as a continent, with optional labels at
+specified locations within the region, in the form of a recreation of the
+Monorail Map from The Simpsons with humorously oversized labelling (to
+imitate handwriting/scribbles) and sparsity of marked locations
+(which are all fictional).
+
+Specifically, it aims to recreate to best likeness using Cartopy
+the map of pre-Springfield Lyle Lanley Monorail locations from the
+iconic episode 'Marge vs. the Monorail' (1993) of the TV Series, as
+taken in likeness from the screen grab available at:
+https://simpsons.fandom.com/wiki/Brockway.
+
+"""
 import matplotlib.pyplot as plt
 from matplotlib.transforms import offset_copy
 
@@ -71,7 +89,7 @@ def main():
             loc_coords[1] + rel_text_pos[1],
         )
         # Text in uppercase, very bold handwriting-like font, as per the
-        # screengrab
+        # screen grab of the map from the show
         ax.text(
             *text_loc_coords,
             loc_name.upper(),

--- a/examples/miscellanea/simpsons-monorail-map.py
+++ b/examples/miscellanea/simpsons-monorail-map.py
@@ -27,13 +27,14 @@ import cartopy.io.shapereader as shpreader
 GEOM_PROJ = ccrs.PlateCarree()
 # Not real places, so locations pulled from location on map in still image.
 # The items in order correspond to:
-# * an x-y 2-tuple for where to plot the location dot on the map
+# * an x-y 2-tuple for where to plot the location dot on the map;
 # * an x-y 2-tuple for where to write the text label relative to the dot above
+#   with units of points;
 # * an integer for how much to rotate the text to best match the map text.
 LOCATIONS_TO_PLOT = {
-    "Ogdenville": [(-111.8, 35.5), (1.5, -2.2), -6],
-    "North\nHaverbrook": [(-99.0, 43.5), (2.8, -0.5), -1],
-    "Brockway": [(-80.4, 33.6), (-3.4, -1.5), 3],
+    "Ogdenville": [(-111.8, 35.5), (-10.0, -50.0), -6],
+    "North\nHaverbrook": [(-99.0, 43.5), (15.0, -15.0), -1],
+    "Brockway": [(-80.4, 33.6), (-100.0, -40.0), 3],
 }
 
 
@@ -83,18 +84,13 @@ def main():
             transform=GEOM_PROJ,
         )
 
-        # Adjust position of location name text relative to location marker
-        text_loc_coords = (
-            loc_coords[0] + rel_text_pos[0],
-            loc_coords[1] + rel_text_pos[1],
-        )
         # Text in uppercase, very bold handwriting-like font, as per the
         # screen grab of the map from the show
         map_ax.annotate(
             loc_name.upper(),
-            xy=text_loc_coords,
+            xy=loc_coords,
             transform=ccrs.Geodetic(),
-            xytext=(-25, 0),  # shift text closer to point as per reference
+            xytext=rel_text_pos,  # shift text relative to marker as in map
             textcoords="offset pixels",
             verticalalignment="center",
             horizontalalignment="left",
@@ -123,6 +119,7 @@ def main():
     )
 
     plt.show()
+    fig.savefig("monorail-dec-new.png")  # SLB: REMOVE BEFORE COMMITTING
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Rationale

For fun (and love of said TV Series), I have recreated the Monorail Map from The Simpsons using Cartopy - the challenge was to get as close to likeness as I could using the standard Python visualisation ecosystem - matplotlib etc, in a small-ish script, and Cartopy made this simple. 

Whist I did this mostly with the motivation of making high-res print outs for myself, I think it would make a good example for your examples gallery. As I summarise in the top-level docstring:

> This example demonstrates how to create a minimal outline map of a defined area of land such as a continent, with optional labels at specified locations within the region,

Moreover, other vis libraries with examples galleries have humorous examples - notably the XKCD examples - so I think i is nice to add (another) one to the Cartopy examples gallery.

From other PRs adding new examples I have found from a quick search, it seems that I just need to add the new script in the appropriate place under 'cartopy/examples/` and the relevant subdirectory to categorise - I think 'miscellanea' is most suitable, but happy to move it if you wish.

Please let me know if you would like me to adjust it in any way if you would accept it for the gallery - either codewise or output-wise.

## Implications

A new example recipe will be added to the docs and maybe somebody will find it useful and/or amusing. 🙂 

## Notes

The output (with Python 3.12) is:

Original from when PR opened:

<img width="1125" height="778" alt="504936792-10f33258-e212-484b-9eb1-57b190c940e0" src="https://github.com/user-attachments/assets/0d87c13a-6ce8-4312-9b0a-e33feeca9699" />


Updated output after feedback response and tweaks, at a8baf8af1b21190b7015c462ea386f1e0ac0331c:

<img width="1124" height="782" alt="new_simpsons_map" src="https://github.com/user-attachments/assets/d3cdb8dd-419d-4fcb-812e-a9ba71a6470c" />


For reference, the original [looks like this](https://simpsons.fandom.com/wiki/Brockway?file=S04E12_Marge_vs._the_Monorail_-_Maps.jpg).