### PR TITLE
add sphinx_copybutton extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,9 +47,15 @@ extensions = [
               'sphinx.ext.autosummary',
               'matplotlib.sphinxext.plot_directive',
               'matplotlib.sphinxext.roles',
+              'sphinx_copybutton',
               'sphinx_gallery.gen_gallery',
-              'sphinx.ext.napoleon'
+              'sphinx.ext.napoleon',
               ]
+
+
+# enable regular expression for the sphinx_copybutton extension
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
 
 # generate autosummary even if no references
 autosummary_generate = True

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
   # Documentation
   - pydata-sphinx-theme
   - sphinx
+  - sphinx-copybutton
   - sphinx-gallery
   # Extras
   - pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-doc = ["pydata-sphinx-theme", "sphinx", "sphinx-gallery"]
+doc = ["pydata-sphinx-theme", "sphinx", "sphinx-copybutton", "sphinx-gallery"]
 speedups = ["pykdtree", "fiona"]
 ows = ["OWSLib>=0.27.0", "pillow>=9.1"]
 plotting = ["pillow>=9.1", "scipy>=1.9"]


### PR DESCRIPTION
[x] closes #2591 

This PR adds the `sphinx_copybutton` extension to the cartopy documentation.

See the extension in action after local build:


https://github.com/user-attachments/assets/917cb4da-56b2-4360-995d-9b56204412b1

