### PR TITLE
FIX: Image tiles crossing the dateline need special handling

### DIFF
--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -125,6 +125,13 @@ class GoogleWTS(metaclass=ABCMeta):
         # Recursively drill down to the images at the target zoom.
         x0, x1, y0, y1 = self._tileextent(start_tile)
         domain = sgeom.box(x0, y0, x1, y1)
+
+        if hasattr(target_domain, 'geoms') and len(target_domain.geoms) > 1:
+            # For MultiPolygon, create a unified coverage area that includes
+            # the space between disconnected parts. This ensures tiles spanning
+            # across dateline discontinuities are included.
+            target_domain = sgeom.box(*target_domain.bounds)
+
         if domain.intersects(target_domain):
             if start_tile[2] == target_z:
                 yield start_tile


### PR DESCRIPTION
When image tile requests crossing a dateline happen, there is a multipolygon extent that gets passed to the find images function. We don't necessarily want just the tiles that are within those geometries, but also the ones that could be between them.

closes #2579