### PR TITLE
Bugfix/avoid cache clashes

### DIFF
--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -186,7 +186,6 @@ class GoogleWTS(metaclass=ABCMeta):
 
     def tile_bbox(self, x, y, z, y0_at_north_pole=True):
         """The ``(x0, x1), (y0, y1)`` bounding box for the given tile position.
-        tile position.
 
         Parameters
         ----------


### PR DESCRIPTION
## Rationale

This Pull Request solves #2595.

## Implications

This Pull Request:

* Added `resolution`, `layer` and `style` optional keyword arguments, and corresponding attributes, to `GoogleWTS` (this means that when other classes set the `resolution`, `layer` and `style` attributes then they are merely populating a pre-existing attribute rather than creating a new one).
* Moved some docstrings from the top of the class definition to be in the `__init__` method instead (which is now consistent across all the classes).
* Added a docstring to `GoogleWTS`, including the new `resolution`, `layer` and `style` optional keyword arguments.
* The `_cache_dir()` method now uses the (always present) `resolution`, `layer`, `style` attributes if they are set (this is the actual change which fixes the issue - the rest is tidying and/or consistency and/or neatness).
* Renamed "map_id" to "style" in `MapboxTiles` and `MapboxStyleTiles` (this was a positional argument, not a keyword argument, so this should not break any users' scripts).
* Renamed "layer_id" to "layer" in `LINZMapsTiles` (this was also a positional argument, not a keyword argument, so this should not break any users' scripts).

Whilst `layer` and `style` now do the same thing functionally, I decided to *not* rename all usage of "layer" to "style" as that might upset people and/or break scripts.

Here is an example using the OSM tile provider (showing no change):

<img width="2160" height="2160" alt="norway-aug-2024" src="https://github.com/user-attachments/assets/411a1f78-e632-4415-93c4-fafa0d8d95e4" />

Here is an arbitrary example using a style of "outdoors" and a resolution of "@2x" using the Thunderforest tile provider:

<img width="2160" height="2160" alt="norway-aug-2024_outdoors_@2x" src="https://github.com/user-attachments/assets/9ba4b17b-651b-4d6a-a7e2-4e4711a3362a" />

Here is a list of the folders created during my own testing in my local cache:

```
redacted@redacted ~ % find ~/.local/share/cartopy_cache -type d | sort
/Users/redacted/.local/share/cartopy_cache
/Users/redacted/.local/share/cartopy_cache/OSM
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/atlas
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/atlas/@2x
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/cycle
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/cycle/@2x
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/landscape
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/landscape/@2x
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/mobile-atlas
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/mobile-atlas/@2x
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/neighbourhood
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/neighbourhood/@2x
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/outdoors
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/outdoors/@2x
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/pioneer
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/pioneer/@2x
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/spinal-map
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/spinal-map/@2x
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/transport
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/transport-dark
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/transport-dark/@2x
/Users/redacted/.local/share/cartopy_cache/ThunderforestTiles/transport/@2x
```