### PR TITLE
Disable profiling/line tracing by default with flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if USE_CYTHON:
     # We need to explicitly cythonize the extension in order
     # to control the Cython compiler_directives.
     from Cython.Build import cythonize
-    compiler_directives = {"profile": CYTHON_COVERAGE, "linetrace": CYTHON_COVERAGE}
+    compiler_directives = {"profile": cython_coverage, "linetrace": cython_coverage}
     extensions = cythonize(extensions, compiler_directives=compiler_directives)
 
 


### PR DESCRIPTION
Only enable Cython profiling and line tracing if the (existing) CYTHON_COVERAGE environment flag is set to True

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

Closes #2577, since (as of Python 3.13) the profiling/line tracing functionality breaks the Visual Studio Code Python debugger (due to the use of sys.monitoring). See similar fix for another package here https://github.com/CoolProp/CoolProp/pull/2613.

## Implications

Shouldn't affect package users (other than fixing the VS Code debugger). Cartopy developers will need to explicitly set the CYTHON_COVERAGE variable when building the package if the profiling/line tracing functionality is needed.

<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
