### PR TITLE
MNT/TST: skip nsidc url's becuase they are failing

### DIFF
--- a/lib/cartopy/tests/io/test_ogc_clients.py
+++ b/lib/cartopy/tests/io/test_ogc_clients.py
@@ -211,6 +211,7 @@ class TestWMTSRasterSource:
 
 @pytest.mark.network
 @pytest.mark.skipif(not _OWSLIB_AVAILABLE, reason='OWSLib is unavailable.')
+@pytest.mark.skip(reason='NSIDC API url has changed and tests need to be updated')
 class TestWFSGeometrySource:
     URI = 'https://nsidc.org/cgi-bin/atlas_south?service=WFS'
     typename = 'land_excluding_antarctica'

--- a/lib/cartopy/tests/mpl/test_features.py
+++ b/lib/cartopy/tests/mpl/test_features.py
@@ -65,8 +65,7 @@ def test_gshhs():
 @pytest.mark.network
 @pytest.mark.skipif(not _HAS_PYKDTREE_OR_SCIPY or not _OWSLIB_AVAILABLE,
                     reason='OWSLib and at least one of pykdtree or scipy is required')
-@pytest.mark.xfail(raises=ParseError,
-                   reason="Bad XML returned from the URL")
+@pytest.mark.skip(reason='NSIDC API url has changed and tests need to be updated')
 @pytest.mark.mpl_image_compare(filename='wfs.png')
 def test_wfs():
     ax = plt.axes(projection=ccrs.OSGB(approx=True))


### PR DESCRIPTION
I chose to skip them (rather than xfail) because the urls currently timeout and cause unnecessary additional time to run (~2-3 minutes extra).