### PR TITLE
return valid (empty) path if path contains no polygons

### DIFF
--- a/lib/cartopy/mpl/path.py
+++ b/lib/cartopy/mpl/path.py
@@ -43,6 +43,9 @@ def _ensure_path_closed(path):
     finally:
         path.should_simplify = should_simplify
 
+    if len(polygons) == 0:
+        return Path(np.empty((0,2)))
+
     codes, vertices = [], []
     for poly in polygons:
         vertices.extend([poly[0], *poly])

--- a/lib/cartopy/tests/mpl/test_path.py
+++ b/lib/cartopy/tests/mpl/test_path.py
@@ -4,6 +4,7 @@
 # See LICENSE in the root of the repository for full licensing details.
 
 from matplotlib.path import Path
+import numpy as np
 import pytest
 import shapely.geometry as sgeom
 
@@ -90,3 +91,14 @@ class Test_path_to_shapely:
             assert len(geoms.geoms) == 2
             assert len(geoms.geoms[0].interiors) == 1
             assert len(geoms.geoms[1].interiors) == 0
+
+
+no_polygon_path = Path([[0,0], [1,1]], codes=[Path.MOVETO, Path.LINETO])
+empty_path = Path(np.empty((0, 2)))
+
+class Test_ensure_path_closed:
+    @pytest.mark.parametrize('path', [no_polygon_path, empty_path])
+    def test_non_polygon_path_closing(self, path):
+        closed_path = cpath._ensure_path_closed(path)
+        assert isinstance(closed_path, Path)
+        assert closed_path.vertices.size == 0


### PR DESCRIPTION
## Rationale

While playing around in [EOmaps](https://github.com/raphaelquast/EOmaps) with overlapping clipped axes that share limits, I noticed that in case one of the clip-paths is moved completely outside the field of view, the `_ensure_path_closed` method tries to initialize a path without vertices which raises the following error:
```
ValueError: 'vertices' must be 2D with shape (N, 2), but your input has shape (0,)
```

The fix ensures that a valid (empty) path is returned in case the path contains no polygons. 