### PR TITLE
CI: add python 3.14 tests

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -21,8 +21,8 @@ jobs:
         use-network: [true]
         include:
           - os: ubuntu-latest
-            # switch to py 3.14 when fiona wheels are available https://github.com/Toblerity/Fiona/issues/1504
-            python-version: '3.13'
+            # do not use the version we use for coverage
+            python-version: '3.12'
             use-network: false
 
     steps:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -17,10 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
         use-network: [true]
         include:
           - os: ubuntu-latest
+            # switch to py 3.14 when fiona wheels are available https://github.com/Toblerity/Fiona/issues/1504
             python-version: '3.13'
             use-network: false
 
@@ -46,6 +47,7 @@ jobs:
       - name: Coverage packages
         id: coverage
         # only want the coverage to be run on the latest ubuntu and for code changes i.e. push and pr
+        # switch to py 3.14 when fiona wheels are available https://github.com/Toblerity/Fiona/issues/1504
         if: |
           matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest' &&
           (github.event_name == 'push' || github.event_name == 'pull_request')
@@ -68,7 +70,14 @@ jobs:
           if [ ${{ steps.minimum-packages.conclusion }} == 'skipped' ]; then
               # Default is to install just the minimum testing requirements,
               # but we want to get as much coverage as possible.
-              EXTRA_PACKAGES=',ows,plotting,speedups'
+              if [ ${{ matrix.python-version }} == '3.14' ]; then
+                  # remove this if loop when fiona wheels are available for py3.14
+                  # https://github.com/Toblerity/Fiona/issues/1504
+                  EXTRA_PACKAGES=',ows,plotting'
+                  pip install pykdtree
+              else
+                  EXTRA_PACKAGES=',ows,plotting,speedups'
+              fi
           fi
           pip install -e .[test${EXTRA_PACKAGES}]
           python -c "import cartopy; print('Version ', cartopy.__version__)"
@@ -157,7 +166,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          python-version: '3.13'
+          python-version: '3.14'
           activate-environment: cartopy-dev
           environment-file: environment.yml
 

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,7 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery
   # Extras
+  - fiona
   - pre-commit
   - pykdtree
   - ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Programming Language :: Python :: 3 :: Only',
     'Topic :: Scientific/Engineering',
     'Topic :: Scientific/Engineering :: GIS',


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
We have so far not added CI tests for python 3.14 because fiona has not yet published the relevant wheels.  This PR adds the CI tests with a temporary loop to skip asking for fiona.  Also bumped the Conda test to python 3.14 and added fiona to the environment.yml because conda-forge has everything!

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
