### PR TITLE
Add ARM for manylinux to ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,8 @@ jobs:
         include:
           - os: ubuntu-latest
             cibw_archs: "x86_64"
+          - os: ubuntu-24.04-arm
+            cibw_archs: "aarch64"
           - os: windows-latest
             cibw_archs: "auto"
           - os: macos-latest


### PR DESCRIPTION
## Rationale

I'd like to run cartopy inside a linux docker container without compiling it myself.


## Implications

It will add another ~4m of actions usage per run.


## Tested 

https://github.com/JoshCu/cartopy/actions/runs/21694295704/job/62561123832



