### PR TITLE
MNT: Upgrade deprecated ruff precommit configurations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       - id: sort-all
         types: [file, python]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.14.10'
+    rev: 'v0.15.6'
     hooks:
-    - id: ruff
+    - id: ruff-check
       args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,9 +99,6 @@ python_files = ["test_*.py"]
 
 [tool.ruff]
 lint.select = ["E", "F", "I", "UP", "W"]
-lint.ignore = [
-    "UP038",  # deprecated rule that should be ignored
-]
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true


### PR DESCRIPTION
`ruff` goes to `ruff-check` in the naming, and the UP038 rule is now ignored by default so can be removed.