### PR TITLE
TST: Update check for pykdtree/scipy in test images

### DIFF
--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -13,15 +13,16 @@ from PIL import Image
 import pytest
 import shapely.geometry as sgeom
 
-from cartopy import config
-import cartopy.crs as ccrs
-import cartopy.io.img_tiles as cimgt
 from cartopy.tests.conftest import _HAS_PYKDTREE_OR_SCIPY
-import cartopy.tests.test_img_tiles as ctest_tiles
 
 
 if not _HAS_PYKDTREE_OR_SCIPY:
     pytest.skip('pykdtree or scipy is required', allow_module_level=True)
+
+from cartopy import config
+import cartopy.crs as ccrs
+import cartopy.io.img_tiles as cimgt
+import cartopy.tests.test_img_tiles as ctest_tiles
 
 
 NATURAL_EARTH_IMG = (config["repo_data_dir"] / 'raster' / 'natural_earth'

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -13,6 +13,12 @@ from numpy.testing import assert_array_almost_equal as assert_arr_almost
 import pytest
 import shapely.geometry as sgeom
 
+from cartopy.tests.conftest import _HAS_PYKDTREE_OR_SCIPY
+
+
+if not _HAS_PYKDTREE_OR_SCIPY:
+    pytest.skip('pykdtree or scipy is required', allow_module_level=True)
+
 from cartopy import config
 import cartopy.crs as ccrs
 import cartopy.io.img_tiles as cimgt


### PR DESCRIPTION
When running tests without scipy installed, these modules can't be collected and cause the entire run to fail. Add the skip marker to the top level before any imports.

I created a new virtual environment and installed `.[test]` without the `speedups` and these modules caused failures, I must have missed these in https://github.com/SciTools/cartopy/pull/2282