### PR TITLE
FIX: Handle empty points in geometry projection

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -833,6 +833,8 @@ class Projection(CRS, metaclass=ABCMeta):
         return getattr(self, method_name)(geometry, src_crs)
 
     def _project_point(self, point, src_crs):
+        if point.is_empty:
+            return point
         return sgeom.Point(*self.transform_point(point.x, point.y, src_crs))
 
     def _project_line_string(self, geometry, src_crs):

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -314,6 +314,11 @@ def test_transform_points_empty():
     assert_array_equal(result, np.array([], dtype=np.float64).reshape(0, 3))
 
 
+def test_project_geometry_empty_point():
+    """Test with an empty shapely point."""
+    assert ccrs.PlateCarree().project_geometry(sgeom.Point()).is_empty
+
+
 def test_transform_points_outside_domain():
     """Test CRS.transform_points with out of domain arrays."""
     # Length-1 arrays error out with a bad status code, while


### PR DESCRIPTION
It looks like we didn't have a check for an empty `shapely.Point()`, but did have an empty array check on the `transform_points()` method. The error is in the attribute look-up, which we can avoid by just returning the empty point directly since it can't be transformed anyways.

closes #2635
