### PR TITLE
MNT: Temporarily add an upper pin to PROJ

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,10 @@ dependencies:
   - shapely>=2.0
   - pyshp>=2.3.1
   - pyproj>=3.6.0
+  # PROJ 9.8 changes the way equicylindrical projections (PlateCarree)
+  # are transformed, which causes some issues. Temporary pin PROJ < 9.8
+  # to avoid these for now.
+  - proj<9.8
   # The testing label has the proper version of freetype included
   - conda-forge/label/testing::matplotlib-base>=3.6
 


### PR DESCRIPTION
This is a shot in the dark to see if pinning `PROJ<9.8` will fix the doc build issue (and also the conda test images too).