### PR TITLE
Fix gridline labels ignoring side visibility on curved projections

### DIFF
--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -942,6 +942,15 @@ class Gridliner(matplotlib.artist.Artist):
                     # Is this kind label allowed to be drawn?
                     if not self._draw_this_label(xylabel, loc):
                         visible = False
+                    # For "geo" labels, also check against the
+                    # angle-derived side so that e.g.
+                    # right_labels=False is respected on curved
+                    # projections where labels cannot be classified
+                    # via spine geometry.
+                    elif loc == 'geo' and not getattr(
+                            self, self._get_loc_from_angle(
+                                segment_angle) + '_labels'):
+                        visible = False
 
                     elif x_inline or y_inline:
                         # Check that it does not overlap the map.

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -605,3 +605,20 @@ def test_gridliner_with_globe():
     fig.draw_without_rendering()
 
     assert gl in ax.artists
+
+
+def test_gridliner_geo_labels_respect_side_visibility():
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.Robinson())
+    ax.set_global()
+    gl = ax.gridlines(draw_labels=True)
+    gl.ylocator = mticker.FixedLocator([-60, -30, 0, 30, 60])
+
+    fig.draw_without_rendering()
+    labels = [a.get_text() for a in gl.geo_label_artists if a.get_visible()]
+    assert labels == ['60°S', '60°S', '60°N', '60°N']
+
+    gl.right_labels = False
+    fig.draw_without_rendering()
+    labels = [a.get_text() for a in gl.geo_label_artists if a.get_visible()]
+    assert labels == ['60°S', '60°N']


### PR DESCRIPTION
## Rationale

On non-rectangular projections (e.g. Robinson), gridline labels on the curved boundary get classified as `"geo"` instead of a named side, bypassing `right_labels=False` (or equivalent). 

For example, 60°N and 60°S still appear on the right even when `gl.right_labels = False`.

Closes #2607

**After fix sample:**
<img width="2255" height="1803" alt="image" src="https://github.com/user-attachments/assets/f23b1acf-5cab-4440-8a87-3ef8a5c8051d" />


## Implications

- Single condition expanded in `_draw_gridliner`: when a label's `loc` is `"geo"`, also check the angle-derived side attribute. Uses `is False` to avoid changing default behavior for users who haven't explicitly disabled a side.
- No additional tests added.