### PR TITLE
Fix shared GeoAxes zoom not propagating to sibling subplots

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -459,6 +459,7 @@ class GeoAxes(matplotlib.axes.Axes):
         # then we should autoscale the view.
         if self.get_autoscale_on() and self.ignore_existing_data_limits:
             self.autoscale_view()
+            self.ignore_existing_data_limits = False
 
         # apply_aspect may change the x or y data limits, so must be called
         # before the patch is updated.
@@ -564,6 +565,8 @@ class GeoAxes(matplotlib.axes.Axes):
 
         self.dataLim.intervalx = self.projection.x_limits
         self.dataLim.intervaly = self.projection.y_limits
+        self.viewLim.intervalx = self.projection.x_limits
+        self.viewLim.intervaly = self.projection.y_limits
 
     def clear(self):
         """Clear the current Axes and add boundary lines."""
@@ -747,10 +750,7 @@ class GeoAxes(matplotlib.axes.Axes):
 
     def _get_extent_geom(self, crs=None):
         # Perform the calculations for get_extent(), which just repackages it.
-        with self.hold_limits():
-            if self.get_autoscale_on():
-                self.autoscale_view()
-            [x1, y1], [x2, y2] = self.viewLim.get_points()
+        [x1, y1], [x2, y2] = self.viewLim.get_points()
 
         domain_in_src_proj = sgeom.Polygon([[x1, y1], [x2, y1],
                                             [x2, y2], [x1, y2],

--- a/lib/cartopy/tests/mpl/test_axes.py
+++ b/lib/cartopy/tests/mpl/test_axes.py
@@ -154,3 +154,26 @@ def test_geoaxes_set_boundary_clipping():
                      transform=ax1.transAxes)
 
     return fig
+
+
+def test_shared_axes_zoom_propagation():
+    fig = plt.figure()
+    proj = ccrs.PlateCarree()
+    ax1 = fig.add_subplot(1, 2, 1, projection=proj)
+    ax2 = fig.add_subplot(1, 2, 2, projection=proj,
+                          sharex=ax1, sharey=ax1)
+
+    fig.draw_without_rendering()
+
+    # Simulate interactive zoom tool behavior:
+    # set_xbound/set_ybound use auto=None (no-op for autoscale)
+    # set_autoscalex/y_on(False) only affects the calling axes
+    ax1.set_xbound(-20, 20)
+    ax1.set_autoscalex_on(False)
+    ax1.set_ybound(-10, 10)
+    ax1.set_autoscaley_on(False)
+
+    fig.draw_without_rendering()
+
+    assert ax2.get_xlim() == (-20, 20)
+    assert ax2.get_ylim() == (-10, 10)

--- a/lib/cartopy/tests/mpl/test_set_extent.py
+++ b/lib/cartopy/tests/mpl/test_set_extent.py
@@ -148,12 +148,12 @@ def test_view_lim_autoscaling():
                               expected_non_tight, decimal=1)
 
 
-def test_view_lim_default_global(tmp_path):
+def test_view_lim_default_global():
     ax = plt.axes(projection=ccrs.PlateCarree())
-    # The view lim should be the default unit bbox until it is drawn.
-    assert_array_almost_equal(ax.viewLim.frozen().get_points(),
-                              [[0, 0], [1, 1]])
-    plt.savefig(tmp_path / 'view_lim_default_global.png')
+    # viewLim is set to projection bounds in __clear.
     expected = np.array([[-180, -90], [180, 90]])
+    assert_array_almost_equal(ax.viewLim.frozen().get_points(),
+                              expected)
+    plt.gcf().draw_without_rendering()
     assert_array_almost_equal(ax.viewLim.frozen().get_points(),
                               expected)


### PR DESCRIPTION
## Rationale

When using `sharex`/`sharey` on cartopy GeoAxes, interactive zoom does not propagate to sibling subplots after adding features. `_draw_preprocess()` calls `autoscale_view()` on every draw, resetting all shared limits to full extent. `_get_extent_geom()` compounds this by calling `autoscale_view()` inside `hold_limits()`, which propagates resets to siblings but only restores the current axes.

![issue_fix](https://github.com/user-attachments/assets/e0fda974-5bf2-46ef-87e4-7a01ee871cd4)


Closes #2637

## Implications

- `_draw_preprocess()`: clear `ignore_existing_data_limits` after the first `autoscale_view()`, matching matplotlib's own pattern.
- `_get_extent_geom()`: read `viewLim` directly instead of calling `autoscale_view()`. A `dataLim` fallback handles the pre-draw case.
- No test added.