### PR TITLE
Alternative fix for Proj 9.8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,10 +13,6 @@ dependencies:
   - shapely>=2.0
   - pyshp>=2.3.1
   - pyproj>=3.6.0
-  # PROJ 9.8 changes the way equicylindrical projections (PlateCarree)
-  # are transformed, which causes some issues. Temporary pin PROJ < 9.8
-  # to avoid these for now.
-  - proj<9.8
   # The testing label has the proper version of freetype included
   - conda-forge/label/testing::matplotlib-base>=3.6
 

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -1353,9 +1353,8 @@ class PlateCarree(_CylindricalProjection):
     def __init__(self, central_longitude=0.0, globe=None):
         globe = globe or Globe(semimajor_axis=WGS84_SEMIMAJOR_AXIS)
         proj4_params = [('proj', 'eqc'), ('lon_0', central_longitude),
-                        ('to_meter', math.radians(1) * (
-                            globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS)),
-                        ('vto_meter', 1)]
+                        ('to_meter', math.radians(1) * WGS84_SEMIMAJOR_AXIS),
+                        ('vto_meter', 1), ('R', WGS84_SEMIMAJOR_AXIS)]
         x_max = 180
         y_max = 90
         # Set the threshold around 0.5 if the x max is 180.

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 import numpy as np
 import pytest
-from shapely.geos import geos_version
+from shapely import geos_version
 
 import cartopy.crs as ccrs
 from cartopy.mpl.geoaxes import GeoAxes


### PR DESCRIPTION
Alternative to #2653. Here I've forced the use of a spherical datum with the equidistant cyindrical projection, which causes our scaling to work properly again.

This does result in one test failure, caused by the fact that the forced R parameter means the datum for the projection is always spherical, which flows downstream into all calls of `PlateCarree.to_geodetic()`.

While this is a smaller change, my personal opinion is in favor of #2653 because we finally get rid of all the hacks we have been doing to try to make PlateCarree work using the eqc projection.