### PR TITLE
TST: filter warnings from tests

### DIFF
--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -155,7 +155,7 @@ def _target_extents(extent, requested_projection, available_projection):
     # the entire output requested_projection domain, then we erode the request
     # area to avoid re-projection instabilities near the projection boundary.
     buffered_target_box = target_box.buffer(requested_projection.threshold,
-                                            resolution=1)
+                                            quad_segs=1)
     fudge_mode = buffered_target_box.contains(requested_projection.domain)
     if fudge_mode:
         target_box = requested_projection.domain.buffer(
@@ -174,7 +174,7 @@ def _target_extents(extent, requested_projection, available_projection):
             # need to re-inflate.
             radius = min(max_x - min_x, max_y - min_y) / 5.0
             radius = min(radius, available_projection.threshold * 15)
-            poly = poly.buffer(radius, resolution=1)
+            poly = poly.buffer(radius, quad_segs=1)
             # Prevent the expanded request going beyond the
             # limits of the requested_projection.
             poly = available_projection.domain.intersection(poly)

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 import numpy as np
 import pytest
-from shapely.geos import geos_version
+from shapely import geos_version
 
 import cartopy.crs as ccrs
 from cartopy.mpl.geoaxes import GeoAxes

--- a/lib/cartopy/tests/mpl/test_mpl_integration.py
+++ b/lib/cartopy/tests/mpl/test_mpl_integration.py
@@ -657,7 +657,8 @@ def test_pcolormesh_wrap_gouraud_shading_failing_mask_creation():
 
     fig = plt.figure(figsize=(10, 6))
     ax = fig.add_subplot(1, 1, 1, projection=ccrs.Mercator())
-    ax.pcolormesh(x, y, data, transform=ccrs.PlateCarree(), shading='gouraud')
+    with pytest.warns(UserWarning, match="Handling wrapped coordinates with gouraud"):
+        ax.pcolormesh(x, y, data, transform=ccrs.PlateCarree(), shading='gouraud')
 
 
 def test_pcolormesh_diagonal_wrap():

--- a/lib/cartopy/tests/mpl/test_plots.py
+++ b/lib/cartopy/tests/mpl/test_plots.py
@@ -7,6 +7,7 @@ from io import BytesIO
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 
 import cartopy.crs as ccrs
 
@@ -19,6 +20,9 @@ def test_empty_plot():
     fig.savefig(BytesIO())
 
 
+@pytest.mark.filterwarnings(
+    "ignore:invalid value encountered in linestrings:RuntimeWarning"
+)
 def test_triplot_bbox_tight():
     """Test triplot with a tight bbox (#1060)."""
     x = np.degrees([-0.101, -0.090, -0.069])

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -57,9 +57,6 @@ class TestCRS:
                 Path(pyproj.datadir.get_user_data_dir(), grid_name).exists()
             )
             if not available:
-                import warnings
-                warnings.warn(f'{grid_name} is unavailable; '
-                              'testing OSGB at reduced precision')
                 precision = -1
 
         ll = ccrs.Geodetic()

--- a/lib/cartopy/tests/test_line_string.py
+++ b/lib/cartopy/tests/test_line_string.py
@@ -203,6 +203,9 @@ class TestBisect:
                 assert not any(np.isnan(coord)), \
                     'Unexpected NaN in projected coords.'
 
+    @pytest.mark.filterwarnings(
+        "ignore:invalid value encountered in linestrings:RuntimeWarning"
+    )
     def test_nan_rectangular(self):
         # Make sure rectangular projections can handle invalid geometries
         projection = ccrs.Robinson()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,10 @@ ignore = [
 addopts = "--mpl"
 testpaths = ["lib"]
 python_files = ["test_*.py"]
+filterwarnings = [
+    # owslib uses lxml element truth-testing which is deprecated
+    "ignore:Truth-testing of elements:FutureWarning",
+]
 
 [tool.ruff]
 lint.select = ["E", "F", "I", "UP", "W"]


### PR DESCRIPTION
We want to be notified of actual warnings/notes from upstream libraries, so this makes a few fixes that were being warned about while hiding other warnings that are out of our control.

With this I was able to get to no warnings locally.

Shapely:
* `resolution` was deprecated in favor of  `quad_segs` in buffer calls now.
* move geos_version import up a level to avoid warnings
* some of our nan tests emit shapely warnings which are expected

owslib:
* Lots of external warnings for lxml parsing which we have no control over, so just ignore those throughout the test runs.

Cartopy:
* we are warning about Gouraud shading, so we can assert against that warning
* remove OSGB precision warning. I personally don't think we need to warn what test precision we are working with and it clutters the log because I don't have that grid locally. I decided to remove the warning message, but can add it back if people feel strongly the other way. Note that the tests are seemingly more testing pyproj at this point since we are using pyproj for the transforms rather than our direct use of the PROJ library, so we have kind of punted those tests to pyproj IMO.
