### PR TITLE
FIX: ignore invisible gridliner labels in title adjustment

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -528,6 +528,8 @@ class GeoAxes(matplotlib.axes.Axes):
                 gl._draw_gridliner(renderer=renderer)
                 for label in (gl.top_label_artists +
                               gl.geo_label_artists):
+                    if not label.get_visible() or label.get_text() == "":
+                        continue
                     bb = label.get_tightbbox(renderer)
                     top = max(top, bb.ymax)
         if top < 0:


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->


## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Since https://github.com/matplotlib/matplotlib/pull/31285, `Text` objects return a null bbox if they are invisible or have an empty string.  This broke our title positioning logic, because we specifically look at the `ymax` of the Bbox rather than taking box unions.

The invalid title position gets incorporated into the axes tight bbox, which also becomes invalid and therefore messes up constrained layout and we get a plot like https://github.com/SciTools/cartopy/issues/2666#issuecomment-4273382421 where the titles have disappeared and the gridline labels overlap each other or go off the side of the plot.

This can all be avoided if we ignore the invisible or empty labels.  Running the relevant test locally with this branch and Elliot's branch from https://github.com/matplotlib/matplotlib/pull/31521, I got a sensible image

<img width="800" height="600" alt="result" src="https://github.com/user-attachments/assets/c42625a5-8888-4bfc-8817-16c77c2ad41e" />


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
This clearly won't help anyone who uses existing Cartopy releases with the new Matplotlib release.

<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
