### PR TITLE
fix: grid labels hidden on false overlap at rotation=90

### DIFF
--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -987,6 +987,7 @@ class Gridliner(matplotlib.artist.Artist):
                     # Updates
                     label.set_visible(visible)
                     label.path = this_path
+                    label.extents = this_path.get_extents()
                     label.xy = xylabel
                     label.loc = loc
                     self._labels.append(label)
@@ -1287,6 +1288,10 @@ class Label:
         return self.artist.get_visible()
 
     def check_overlapping(self, label):
+        # NOTE: Workaround for intersects_path() false positives on collinear edges.
+        # See https://github.com/matplotlib/matplotlib/issues/6076
+        if not self.extents.overlaps(label.extents):
+            return False
         overlapping = self.path.intersects_path(label.path)
         if overlapping:
             self.set_visible(False)

--- a/lib/cartopy/tests/mpl/test_gridliner.py
+++ b/lib/cartopy/tests/mpl/test_gridliner.py
@@ -519,6 +519,25 @@ def test_gridliner_save_tight_bbox():
     fig.savefig(io.BytesIO(), bbox_inches='tight')
 
 
+def test_gridliner_ylabel_rotation_90_tight_bbox():
+    # Regression test for ylabel rotation=90 with bbox_inches=tight (gh2394).
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
+    ax.set_extent([80, 170, -45, 30], crs=ccrs.PlateCarree())
+    gl = ax.gridlines(
+        draw_labels={"left": "y"},
+        ylabel_style={"rotation": 90},
+    )
+
+    fig.draw_without_rendering()
+    n_before = sum(1 for a in gl.label_artists if a.get_visible())
+    assert n_before > 0
+
+    fig.savefig(io.BytesIO(), bbox_inches='tight')
+    n_after = sum(1 for a in gl.label_artists if a.get_visible())
+
+    assert n_after == n_before
+
 @pytest.mark.natural_earth
 @pytest.mark.mpl_image_compare(filename='gridliner_labels_title_adjust.png',
                                tolerance=grid_label_tol)


### PR DESCRIPTION
## Rationale

Gridline labels hidden at `rotation=90°` due to `intersects_path()` false positives on collinear edges.

Fixes #2394.


## Implications

Adds a `bbox` pre-check before `intersects_path()`; if `bboxes` don't overlap, skip the path check. Tilted geo labels unaffected.