### PR TITLE
MNT: don't access Formatter.locs

### DIFF
--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -145,10 +145,13 @@ class _PlateCarreeFormatter(Formatter):
         self._target_projection = ccrs.PlateCarree(globe=self._source_projection.globe)
 
     def set_locs(self, locs):
-        Formatter.set_locs(self, locs)
+        super().set_locs(locs)
         if not self._auto_hide:
             return
-        self.locs, degs, mins, secs = self._get_dms(self.locs)
+        locs, degs, mins, secs = self._get_dms(locs)
+
+        # locs dtype may have changed.
+        super().set_locs(locs)
         secs = np.round(secs, self._precision - 3).astype('i')
         secs0 = secs == 0
         mins0 = mins == 0


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->

## Rationale

The `Formatter.locs` attribute will be [deprecated at Matplotlib 3.11](https://matplotlib.org/devdocs/api/next_api_changes/deprecations/31416-TH.html).  Since [`Formatter.set_locs` only assigns the variable we pass it](https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/ticker.py#L291-L298) we can just use the variable we already have hold of.



<!-- Please provide detail as to *why* you are making this change. -->


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
