### PR TITLE
Remove wheel from build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = [
-    "wheel",
     "setuptools >= 77.0.3",
     "Cython >= 3.0",
     # numpy requirement for wheel builds for distribution on PyPI - building


### PR DESCRIPTION
## Rationale

It's not necessary and hasn't been for a few years.

## Implications

Fewer extra packages installed for building.