### PR TITLE
MNT: Remove checks for old Shapely

### DIFF
--- a/lib/cartopy/tests/test_line_string.py
+++ b/lib/cartopy/tests/test_line_string.py
@@ -8,7 +8,6 @@ import time
 
 import numpy as np
 import pytest
-import shapely
 import shapely.geometry as sgeom
 
 import cartopy.crs as ccrs
@@ -74,8 +73,6 @@ class TestLineString:
         tgt_proj.project_geometry(line_string, src_proj)
         assert time.time() < cutoff_time, 'Projection took too long'
 
-    @pytest.mark.skipif(shapely.__version__ < "2",
-                        reason="Shapely <2 has an incorrect geom_type ")
     def test_multi_linestring_return_type(self):
         # Check that the return type of project_geometry is a MultiLineString
         # and not an empty list

--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -247,13 +247,7 @@ cdef State get_state(const Point &point, object gp_domain, bool geom_fully_insid
         # Fast-path return because the geometry is fully inside
         return POINT_IN
     if isfinite(point.x) and isfinite(point.y):
-        if shapely.__version__ >= "2":
-            # Shapely 2.0 doesn't need to create/destroy a point
-            state = POINT_IN if shapely.intersects_xy(gp_domain.context, point.x, point.y) else POINT_OUT
-        else:
-            g_point = sgeom.Point((point.x, point.y))
-            state = POINT_IN if gp_domain.covers(g_point) else POINT_OUT
-            del g_point
+        state = POINT_IN if shapely.intersects_xy(gp_domain.context, point.x, point.y) else POINT_OUT
     else:
         state = POINT_NAN
     return state


### PR DESCRIPTION
## Rationale

We already require Shapely 2.0, so no longer need to maintain compatibility code for older versions.

## Implications

Less code.