### PR TITLE
Fix deprecation warnings with NumPy 2.5.0

### DIFF
--- a/lib/cartopy/img_transform.py
+++ b/lib/cartopy/img_transform.py
@@ -298,7 +298,7 @@ def regrid(array, source_x_coords, source_y_coords, source_proj, target_proj,
         new_array[mask] = np.ma.masked
     else:
         new_array = temp_array[indices]
-    new_array.shape = (desired_ny, desired_nx) + (array.shape[2:])
+    new_array = new_array.reshape((desired_ny, desired_nx, *array.shape[2:]))
 
     # Do double transform to clip points that do not map back and forth
     # to the same point to within a fixed fractional offset.


### PR DESCRIPTION
## Rationale

Some deprecation warnings are raised when running tests against NumPy 2.5; I just followed the suggestion from the message.

## Implications

This fixes the following 21 warnings in the test suite with latest NumPy:
```
lib/cartopy/tests/mpl/test_images.py: 5 warnings
lib/cartopy/tests/mpl/test_examples.py: 1 warning
lib/cartopy/tests/mpl/test_img_transform.py: 1 warning
lib/cartopy/tests/test_img_transform.py: 4 warnings
  /home/elliott/code/cartopy/venv/lib64/python3.14/site-packages/numpy/ma/core.py:3505: DeprecationWarning: Setting the shape on a NumPy array has been deprecated in NumPy 2.5.
  As an alternative, you can create a new view using np.reshape (with copy=False if needed).
    super(MaskedArray, type(self)).shape.__set__(self, shape)

lib/cartopy/tests/mpl/test_images.py: 6 warnings
lib/cartopy/tests/mpl/test_features.py: 1 warning
lib/cartopy/tests/mpl/test_img_transform.py: 1 warning
lib/cartopy/tests/test_img_transform.py: 2 warnings
  /home/elliott/code/cartopy/lib/cartopy/img_transform.py:301: DeprecationWarning: Setting the shape on a NumPy array has been deprecated in NumPy 2.5.
  As an alternative, you can create a new view using np.reshape (with copy=False if needed).
    new_array.shape = (desired_ny, desired_nx) + (array.shape[2:])
```