### PR TITLE
TST: explicitly add pip in conda environment

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Install Cartopy
         # All test and extra dependencies should come from the environment.yml file
         run: |
-          pip install -e .
+          python -m pip install -e .
           python -c "import cartopy; print('Version ', cartopy.__version__)"
 
       - name: Testing

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - cython>=3.0
   - numpy>=1.26
   - shapely>=2.0
+  - pip
   - pyshp>=2.3.1
   - pyproj>=3.6.0
   # PROJ 9.8 changes the way equicylindrical projections (PlateCarree)


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
Recently the conda tests have been failing in the Cartopy install step.  I notice that `pip` is not in the conda list in these runs, and the dependencies are getting pip-installed in the Cartopy install step.  Perhaps we are using the wrong `pip`, so this PR is an attempt to make sure we get `pip` in the conda environment and use it.

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->


<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
