### PR TITLE
update LatitudeLocator following upstream changes

### DIFF
--- a/lib/cartopy/mpl/ticker.py
+++ b/lib/cartopy/mpl/ticker.py
@@ -513,7 +513,8 @@ class LongitudeLocator(MaxNLocator):
     """
 
     def __init__(self, nbins=8, *, dms=False, **kwargs):
-        super().__init__(nbins=nbins, dms=dms, **kwargs)
+        super().__init__(nbins=nbins, **kwargs)
+        self._dms = dms
 
     def set_params(self, **kwargs):
         """Set parameters within this locator."""


### PR DESCRIPTION
## Rationale

A recent upstream change in Matplotlib made the `MaxNLocator` keywords explicit, which broke the current implementation of `LatitudeLocator` in Cartopy.  Following the change, it fails with a TypeError from an unexpected keyword argument (i.e. `dms`).  This is caught by the Cartopy test suite if you install the Matplotlib nightly build.   

## Implications

This proposed change adapts the `LatitudeLocator` constructor so it doesn't rely upon the constructor from the parent class to handle the `dms` kwarg.  It's been tested locally with a fresh Cartopy dev environment and one with the nightly build of Matplotlib (including the changes causing the issue).

That said, I'm not familiar the original implementation so may be missing something here.

Closes #2689 
<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
