### PR TITLE
FIX: classify closed triangle paths as polygons in path_to_shapely

### DIFF
--- a/lib/cartopy/mpl/patch.py
+++ b/lib/cartopy/mpl/patch.py
@@ -180,7 +180,7 @@ def path_to_geos(path, force_ccw=False):
 
         if all(verts_same_as_first):
             geom = sgeom.Point(path_verts[0, :])
-        elif path_verts.shape[0] > 4 and path_codes[-1] == Path.CLOSEPOLY:
+        elif path_verts.shape[0] >= 4 and path_codes[-1] == Path.CLOSEPOLY:
             geom = sgeom.Polygon(path_verts[:-1, :])
         else:
             geom = sgeom.LineString(path_verts)

--- a/lib/cartopy/mpl/path.py
+++ b/lib/cartopy/mpl/path.py
@@ -180,7 +180,7 @@ def path_to_shapely(path):
 
         if all(verts_same_as_first):
             points.append(sgeom.Point(path_verts[0, :]))
-        elif not(path_verts.shape[0] > 4 and path_codes[-1] == Path.CLOSEPOLY):
+        elif not(path_verts.shape[0] >= 4 and path_codes[-1] == Path.CLOSEPOLY):
             linestrings.append(sgeom.LineString(path_verts))
         else:
             geom = sgeom.Polygon(path_verts[:-1, :])

--- a/lib/cartopy/tests/mpl/test_path.py
+++ b/lib/cartopy/tests/mpl/test_path.py
@@ -67,6 +67,35 @@ class Test_path_to_shapely:
             assert [type(geom) for geom in geoms.geoms] == [sgeom.Polygon, sgeom.Point]
             assert len(geoms.geoms[0].interiors) == 1
 
+    def test_closed_triangle_is_polygon(self, use_legacy_path_to_geos):
+        # A minimal closed triangle (3 distinct vertices plus the closing
+        # duplicate) should be classified as a Polygon, not a LineString.
+        p = Path([[0, 0], [1, 0], [0, 1], [0, 0]],
+                 codes=[Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY])
+        if use_legacy_path_to_geos:
+            with pytest.warns(DeprecationWarning, match="path_to_geos is deprecated"):
+                geoms = cpatch.path_to_geos(p)
+            assert [type(geom) for geom in geoms] == [sgeom.Polygon]
+            assert geoms[0].area == pytest.approx(0.5)
+        else:
+            geom = cpath.path_to_shapely(p)
+            assert isinstance(geom, sgeom.Polygon)
+            assert geom.area == pytest.approx(0.5)
+
+    def test_degenerate_closed_path_is_linestring(self, use_legacy_path_to_geos):
+        # A closed path with only 2 distinct vertices is degenerate and
+        # should remain a LineString.
+        p = Path([[0, 0], [1, 1], [0, 0]],
+                 codes=[Path.MOVETO, Path.LINETO, Path.CLOSEPOLY])
+        if use_legacy_path_to_geos:
+            with pytest.warns(DeprecationWarning, match="path_to_geos is deprecated"):
+                geoms = cpatch.path_to_geos(p)
+            # A single LineString result is wrapped in a MultiLineString.
+            assert [type(geom) for geom in geoms] == [sgeom.MultiLineString]
+        else:
+            geom = cpath.path_to_shapely(p)
+            assert isinstance(geom, sgeom.LineString)
+
     def test_nested_polygons(self, use_legacy_path_to_geos):
         # A geometry with three nested squares.
         vertices = [[0, 0], [0, 10], [10, 10], [10, 0], [0, 0],
@@ -91,6 +120,16 @@ class Test_path_to_shapely:
             assert len(geoms.geoms) == 2
             assert len(geoms.geoms[0].interiors) == 1
             assert len(geoms.geoms[1].interiors) == 0
+
+
+def test_triangle_shapely_path_round_trip():
+    # A triangle Polygon should survive a round trip through
+    # shapely_to_path and back through path_to_shapely.
+    triangle = sgeom.Polygon([(0, 0), (1, 0), (0, 1)])
+    path = cpath.shapely_to_path(triangle)
+    geom = cpath.path_to_shapely(path)
+    assert isinstance(geom, sgeom.Polygon)
+    assert geom.equals(triangle)
 
 
 no_polygon_path = Path([[0,0], [1,1]], codes=[Path.MOVETO, Path.LINETO])


### PR DESCRIPTION
A triangle path has 4 points with a CLOSEPOLY, so we need to include it in the polygon possible items, not classify it as a linestring.