### PR TITLE
Quality: Unreachable code after return statement in lines_intersect function

### DIFF
--- a/lib/cartopy/mpl/clip_path.py
+++ b/lib/cartopy/mpl/clip_path.py
@@ -55,9 +55,6 @@ def lines_intersect(p0, p1, p2, p3):
     x_4, y_4 = p3
 
     return (x_1 - x_2) * (y_3 - y_4) - (y_1 - y_2) * (x_3 - x_4) != 0
-    cp1 = np.cross(p1 - p0, p2 - p0)
-    cp2 = np.cross(p1 - p0, p3 - p0)
-    return np.sign(cp1) == np.sign(cp2) and cp1 != 0
 
 
 def bbox_to_path(bbox):


### PR DESCRIPTION
## Summary

Quality: Unreachable code after return statement in lines_intersect function

## Problem

**Severity**: `High` | **File**: `lib/cartopy/mpl/clip_path.py:L89`

In the `lines_intersect` function in `lib/cartopy/mpl/clip_path.py`, there is a `return` statement on line 89 that causes all subsequent code to be unreachable. The code after the return (lines 90-91) defines variables `cp1` and `cp2` and attempts another return, but this will never execute. This appears to be a merge conflict or incomplete edit where two different implementations were left in place.

## Solution

Remove the unreachable code and decide on the correct implementation. The first return on line 89 checks if lines are parallel (div != 0), while the code after uses cross products to check orientation. Determine which logic is correct and remove the other. If the cross product approach is preferred, remove the `return` on line 89 and keep lines 90-91.

## Changes

- `lib/cartopy/mpl/clip_path.py` (modified)