### PR TITLE
Drop use of backcompat modules

### DIFF
--- a/docs/source/whatsnew/v0.13.rst
+++ b/docs/source/whatsnew/v0.13.rst
@@ -10,7 +10,7 @@ Features
 * Peter Killick fixed the cartopy.crs.Mercator projection for non-zero central longitudes. (:pull:`633`)
 
 * Conversion between Matplotlib :class:`matplotlib.path.Path` and
-  :class:`shapely.geometry.Geometry <Shapely geometry>` using
+  :class:`shapely.Geometry <Shapely geometry>` using
   :func:`cartopy.mpl.patch.path_to_geos` and :func:`cartopy.mpl.patch.geos_to_path` now
   handles degenerate point paths.
 

--- a/examples/lines_and_polygons/effects_of_the_ellipse.py
+++ b/examples/lines_and_polygons/effects_of_the_ellipse.py
@@ -18,7 +18,7 @@ from matplotlib.lines import Line2D as Line
 from matplotlib.patheffects import Stroke
 import matplotlib.pyplot as plt
 import numpy as np
-import shapely.geometry as sgeom
+import shapely
 from shapely.ops import transform as geom_transform
 
 import cartopy.crs as ccrs
@@ -104,7 +104,7 @@ def main():
     # Add the land, coastlines and the extent of the Solomon Islands.
     sub_ax.add_feature(cfeature.LAND)
     sub_ax.coastlines()
-    extent_box = sgeom.box(extent[0], extent[2], extent[1], extent[3])
+    extent_box = shapely.box(extent[0], extent[2], extent[1], extent[3])
     sub_ax.add_geometries([extent_box], ccrs.PlateCarree(), facecolor='none',
                           edgecolor='blue', linewidth=2)
 

--- a/examples/lines_and_polygons/hurricane_katrina.py
+++ b/examples/lines_and_polygons/hurricane_katrina.py
@@ -8,7 +8,7 @@ have been significantly impacted by Hurricane Katrina.
 """
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
-import shapely.geometry as sgeom
+import shapely
 
 import cartopy.crs as ccrs
 import cartopy.io.shapereader as shpreader
@@ -57,7 +57,7 @@ def main():
                  'Hurricane Katrina (2005)')
 
     # turn the lons and lats into a shapely LineString
-    track = sgeom.LineString(zip(lons, lats))
+    track = shapely.LineString(zip(lons, lats))
 
     # buffer the linestring by two degrees (note: this is a non-physical
     # distance)

--- a/lib/cartopy/_epsg.py
+++ b/lib/cartopy/_epsg.py
@@ -6,14 +6,14 @@
 Provide support for converting EPSG codes to Projection instances.
 
 """
-from pyproj.crs import CRS as _CRS
+from pyproj.crs import CRS
 
 import cartopy.crs as ccrs
 
 
 class _EPSGProjection(ccrs.Projection):
     def __init__(self, code):
-        crs = _CRS.from_epsg(code)
+        crs = CRS.from_epsg(code)
         if not crs.is_projected:
             raise ValueError('EPSG code does not define a projection')
         if not crs.area_of_use:

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -20,6 +20,7 @@ import warnings
 import numpy as np
 import pyproj
 from pyproj import Transformer
+import pyproj.crs
 from pyproj.exceptions import ProjError
 import shapely
 import shapely.geometry as sgeom
@@ -27,12 +28,6 @@ from shapely.prepared import prep
 
 import cartopy.trace
 
-
-try:
-    # https://github.com/pyproj4/pyproj/pull/912
-    from pyproj.crs import CustomConstructorCRS as _CRS
-except ImportError:
-    from pyproj import CRS as _CRS
 
 __document_these__ = ['CRS', 'Geocentric', 'Geodetic', 'Globe']
 
@@ -125,7 +120,7 @@ class Globe:
         return OrderedDict((k, v) for k, v in proj4_params if v is not None)
 
 
-class CRS(_CRS):
+class CRS(pyproj.crs.CustomConstructorCRS):
     """
     Define a Coordinate Reference System using proj. The :class:`cartopy.crs.CRS`
     class is the very core of cartopy, all coordinate reference systems in cartopy

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -23,7 +23,6 @@ from pyproj import Transformer
 import pyproj.crs
 from pyproj.exceptions import ProjError
 import shapely
-import shapely.geometry as sgeom
 from shapely.prepared import prep
 
 import cartopy.trace
@@ -701,8 +700,7 @@ class Projection(CRS, metaclass=ABCMeta):
         if self.bounds is None:
             raise NotImplementedError
         x0, x1, y0, y1 = self.bounds
-        return sgeom.LineString([(x0, y0), (x0, y1), (x1, y1), (x1, y0),
-                                 (x0, y0)])
+        return shapely.LineString([(x0, y0), (x0, y1), (x1, y1), (x1, y0), (x0, y0)])
 
     @property
     def x_limits(self):
@@ -731,7 +729,7 @@ class Projection(CRS, metaclass=ABCMeta):
         try:
             boundary = self._cw_boundary
         except AttributeError:
-            boundary = sgeom.LinearRing(self.boundary)
+            boundary = shapely.LinearRing(self.boundary)
             self._cw_boundary = boundary
         return boundary
 
@@ -740,7 +738,7 @@ class Projection(CRS, metaclass=ABCMeta):
         try:
             boundary = self._ccw_boundary
         except AttributeError:
-            boundary = sgeom.LinearRing(self.boundary.coords[::-1])
+            boundary = shapely.LinearRing(self.boundary.coords[::-1])
             self._ccw_boundary = boundary
         return boundary
 
@@ -749,7 +747,7 @@ class Projection(CRS, metaclass=ABCMeta):
         try:
             domain = self._domain
         except AttributeError:
-            domain = self._domain = sgeom.Polygon(self.boundary)
+            domain = self._domain = shapely.Polygon(self.boundary)
         return domain
 
     def is_geodetic(self):
@@ -830,7 +828,7 @@ class Projection(CRS, metaclass=ABCMeta):
     def _project_point(self, point, src_crs):
         if point.is_empty:
             return point
-        return sgeom.Point(*self.transform_point(point.x, point.y, src_crs))
+        return shapely.Point(*self.transform_point(point.x, point.y, src_crs))
 
     def _project_line_string(self, geometry, src_crs):
         return cartopy.trace.project_linear(geometry, src_crs, self)
@@ -889,7 +887,7 @@ class Projection(CRS, metaclass=ABCMeta):
                             print(f'Joining together {i} and {j}.')
                         last_coords = list(line_strings[j].coords)
                         first_coords = list(line_strings[i].coords)[1:]
-                        combo = sgeom.LineString(last_coords + first_coords)
+                        combo = shapely.LineString(last_coords + first_coords)
                         if j < i:
                             i, j = j, i
                         del line_strings[j], line_strings[i]
@@ -902,7 +900,7 @@ class Projection(CRS, metaclass=ABCMeta):
                 if not modified:
                     i += 1
             if any_modified:
-                multi_line_string = sgeom.MultiLineString(line_strings)
+                multi_line_string = shapely.MultiLineString(line_strings)
 
         # 3) Check for rings that have been created by the projection stage.
         rings = []
@@ -911,21 +909,21 @@ class Projection(CRS, metaclass=ABCMeta):
             if len(line.coords) > 3 and np.allclose(line.coords[0],
                                                     line.coords[-1],
                                                     atol=threshold):
-                result_geometry = sgeom.LinearRing(line.coords[:-1])
+                result_geometry = shapely.LinearRing(line.coords[:-1])
                 rings.append(result_geometry)
             else:
                 line_strings.append(line)
         # If we found any rings, then we should re-create the multi-line str.
         if rings:
-            multi_line_string = sgeom.MultiLineString(line_strings)
+            multi_line_string = shapely.MultiLineString(line_strings)
 
-        return sgeom.GeometryCollection([*rings, multi_line_string])
+        return shapely.GeometryCollection([*rings, multi_line_string])
 
     def _project_multipoint(self, geometry, src_crs):
         geoms = []
         for geom in geometry.geoms:
             geoms.append(self._project_point(geom, src_crs))
-        return sgeom.MultiPoint(geoms)
+        return shapely.MultiPoint(geoms)
 
     def _project_multiline(self, geometry, src_crs):
         geoms = []
@@ -933,7 +931,7 @@ class Projection(CRS, metaclass=ABCMeta):
             r = self._project_line_string(geom, src_crs)
             if r:
                 geoms.extend(r.geoms)
-        return sgeom.MultiLineString(geoms)
+        return shapely.MultiLineString(geoms)
 
     def _project_multipolygon(self, geometry, src_crs):
         geoms = []
@@ -941,12 +939,11 @@ class Projection(CRS, metaclass=ABCMeta):
             r = self._project_polygon(geom, src_crs)
             if r:
                 geoms.extend(r.geoms)
-        return sgeom.MultiPolygon(geoms)
+        return shapely.MultiPolygon(geoms)
 
     def _project_geometry_collection(self, geometry, src_crs):
-        return sgeom.GeometryCollection(
+        return shapely.GeometryCollection(
             [self.project_geometry(geom, src_crs) for geom in geometry.geoms])
-
 
     def _project_polygon(self, polygon, src_crs):
         """
@@ -1003,7 +1000,7 @@ class Projection(CRS, metaclass=ABCMeta):
             boundary = self.cw_boundary
 
         def boundary_distance(xy):
-            return boundary.project(sgeom.Point(*xy))
+            return boundary.project(shapely.Point(*xy))
 
         # Squash all the LineStrings into a single list.
         line_strings = []
@@ -1023,7 +1020,7 @@ class Projection(CRS, metaclass=ABCMeta):
 
         # Record the positions of all the boundary vertices
         for xy in boundary.coords[:-1]:
-            point = sgeom.Point(*xy)
+            point = shapely.Point(*xy)
             dist = boundary.project(point)
             thing = _BoundaryPoint(dist, True, point)
             edge_things.append(thing)
@@ -1069,7 +1066,7 @@ class Projection(CRS, metaclass=ABCMeta):
                 print('   ', thing)
         if debug_plot_edges:
             for thing in edge_things:
-                if isinstance(thing.data, sgeom.Point):
+                if isinstance(thing.data, shapely.Point):
                     ax.plot(*thing.data.xy, marker='o')
                 else:
                     ax.plot(*thing.data[2], marker='o')
@@ -1117,7 +1114,7 @@ class Projection(CRS, metaclass=ABCMeta):
                     boundary_point = next_thing.data
                     combined_coords = (list(current_ls.coords) +
                                        [(boundary_point.x, boundary_point.y)])
-                    current_ls = sgeom.LineString(combined_coords)
+                    current_ls = shapely.LineString(combined_coords)
 
                 elif next_thing.data[0] == i:
                     # We've gone all the way around and are now back at the
@@ -1137,11 +1134,10 @@ class Projection(CRS, metaclass=ABCMeta):
                     line_to_append = line_strings[j]
                     if j in remaining_ls:
                         remaining_ls.pop(j)
-                    coords_to_append = list(line_to_append.coords)
 
                     # Build up the linestring.
-                    current_ls = sgeom.LineString(list(current_ls.coords) +
-                                                  coords_to_append)
+                    current_ls = shapely.LineString([*current_ls.coords,
+                                                     *line_to_append.coords])
 
                     # Catch getting stuck in an infinite loop by checking that
                     # linestring only added once.
@@ -1157,7 +1153,7 @@ class Projection(CRS, metaclass=ABCMeta):
         # filter out any non-valid linear rings
         def makes_valid_ring(line_string):
             if len(line_string.coords) == 3:
-                # When sgeom.LinearRing is passed a LineString of length 3,
+                # When shapely.LinearRing is passed a LineString of length 3,
                 # if the first and last coordinate are equal, a LinearRing
                 # with 3 coordinates will be created. This object will cause
                 # a segfault when evaluated.
@@ -1167,7 +1163,7 @@ class Projection(CRS, metaclass=ABCMeta):
                 return len(line_string.coords) > 3 and line_string.is_valid
 
         linear_rings = [
-            sgeom.LinearRing(line_string)
+            shapely.LinearRing(line_string)
             for line_string in processed_ls
             if makes_valid_ring(line_string)]
 
@@ -1200,7 +1196,7 @@ class Projection(CRS, metaclass=ABCMeta):
         # Turn all the exterior rings into polygon definitions,
         # "slurping up" any interior rings they contain.
         for exterior_ring in exterior_rings:
-            polygon = sgeom.Polygon(exterior_ring)
+            polygon = shapely.Polygon(exterior_ring)
             prep_polygon = prep(polygon)
             holes = []
             for interior_ring in interior_rings[:]:
@@ -1230,17 +1226,17 @@ class Projection(CRS, metaclass=ABCMeta):
             interior_polys = []
 
             for ring in interior_rings:
-                polygon = shapely.make_valid(sgeom.Polygon(ring))
+                polygon = shapely.make_valid(shapely.Polygon(ring))
                 if not polygon.is_empty:
-                    if isinstance(polygon, sgeom.Polygon):
+                    if isinstance(polygon, shapely.Polygon):
                         interior_polys.append(polygon)
-                    elif isinstance(polygon, sgeom.MultiPolygon):
+                    elif isinstance(polygon, shapely.MultiPolygon):
                         interior_polys.extend(polygon.geoms)
-                    elif isinstance(polygon, sgeom.GeometryCollection):
+                    elif isinstance(polygon, shapely.GeometryCollection):
                         for geom in polygon.geoms:
-                            if isinstance(geom, sgeom.Polygon):
+                            if isinstance(geom, shapely.Polygon):
                                 interior_polys.append(geom)
-                            elif isinstance(geom, sgeom.MultiPolygon):
+                            elif isinstance(geom, shapely.MultiPolygon):
                                 interior_polys.extend(geom.geoms)
                     else:
                         # make_valid may produce some linestrings.  Ignore these
@@ -1259,23 +1255,23 @@ class Projection(CRS, metaclass=ABCMeta):
                     y3 = min(y1, y3)
                     y4 = max(y2, y4)
 
-            box = sgeom.box(x3, y3, x4, y4, ccw=is_ccw)
+            box = shapely.box(x3, y3, x4, y4, ccw=is_ccw)
 
             if interior_polys:
                 # Invert any valid interior polygons
-                multi_poly = shapely.make_valid(sgeom.MultiPolygon(interior_polys))
+                multi_poly = shapely.make_valid(shapely.MultiPolygon(interior_polys))
                 polygon = box.difference(multi_poly)
 
                 # Intersect the inverted polygon with the boundary
                 polygon = boundary_poly.intersection(polygon)
 
                 if not polygon.is_empty:
-                    if isinstance(polygon, sgeom.MultiPolygon):
+                    if isinstance(polygon, shapely.MultiPolygon):
                         polygon_bits.extend(polygon.geoms)
                     else:
                         polygon_bits.append(polygon)
 
-        return sgeom.MultiPolygon(polygon_bits)
+        return shapely.MultiPolygon(polygon_bits)
 
     def quick_vertices_transform(self, vertices, src_crs):
         """
@@ -1320,7 +1316,7 @@ class _RectangularProjection(Projection, metaclass=ABCMeta):
     @property
     def boundary(self):
         w, h = self._half_width, self._half_height
-        return sgeom.LinearRing([(-w, -h), (-w, h), (w, h), (w, -h), (-w, -h)])
+        return shapely.LinearRing([(-w, -h), (-w, h), (w, h), (w, -h), (-w, -h)])
 
     @property
     def x_limits(self):
@@ -1495,9 +1491,9 @@ class TransverseMercator(Projection):
     def boundary(self):
         x0, x1 = self.x_limits
         y0, y1 = self.y_limits
-        return sgeom.LinearRing([(x0, y0), (x0, y1),
-                                 (x1, y1), (x1, y0),
-                                 (x0, y0)])
+        return shapely.LinearRing([(x0, y0), (x0, y1),
+                                   (x1, y1), (x1, y0),
+                                   (x0, y0)])
 
     @property
     def x_limits(self):
@@ -1520,7 +1516,7 @@ class OSGB(TransverseMercator):
     def boundary(self):
         w = self.x_limits[1] - self.x_limits[0]
         h = self.y_limits[1] - self.y_limits[0]
-        return sgeom.LinearRing([(0, 0), (0, h), (w, h), (w, 0), (0, 0)])
+        return shapely.LinearRing([(0, 0), (0, h), (w, h), (w, 0), (0, 0)])
 
     @property
     def x_limits(self):
@@ -1544,7 +1540,7 @@ class OSNI(TransverseMercator):
     def boundary(self):
         w = self.x_limits[1] - self.x_limits[0]
         h = self.y_limits[1] - self.y_limits[0]
-        return sgeom.LinearRing([(0, 0), (0, h), (w, h), (w, 0), (0, 0)])
+        return shapely.LinearRing([(0, 0), (0, h), (w, h), (w, 0), (0, 0)])
 
     @property
     def x_limits(self):
@@ -1587,9 +1583,9 @@ class UTM(Projection):
     def boundary(self):
         x0, x1 = self.x_limits
         y0, y1 = self.y_limits
-        return sgeom.LinearRing([(x0, y0), (x0, y1),
-                                 (x1, y1), (x1, y0),
-                                 (x0, y0)])
+        return shapely.LinearRing([(x0, y0), (x0, y1),
+                                   (x1, y1), (x1, y0),
+                                   (x0, y0)])
 
     @property
     def x_limits(self):
@@ -1713,9 +1709,9 @@ class Mercator(Projection):
     def boundary(self):
         x0, x1 = self.x_limits
         y0, y1 = self.y_limits
-        return sgeom.LinearRing([(x0, y0), (x0, y1),
-                                 (x1, y1), (x1, y0),
-                                 (x0, y0)])
+        return shapely.LinearRing([(x0, y0), (x0, y1),
+                                   (x1, y1), (x1, y0),
+                                   (x0, y0)])
 
     @property
     def x_limits(self):
@@ -1827,7 +1823,7 @@ class LambertConformal(Projection):
 
         points = self.transform_points(self.as_geodetic(), lons, lats)
 
-        self._boundary = sgeom.LinearRing(points)
+        self._boundary = shapely.LinearRing(points)
         mins = np.min(points, axis=0)
         maxs = np.max(points, axis=0)
         self._x_limits = mins[0], maxs[0]
@@ -1919,7 +1915,7 @@ class LambertAzimuthalEqualArea(Projection):
 
         coords = _ellipse_boundary(a * 1.9999, max_y - false_northing,
                                    false_easting, false_northing, 61)
-        self._boundary = sgeom.polygon.LinearRing(coords.T)
+        self._boundary = shapely.LinearRing(coords.T)
         mins = np.min(coords, axis=1)
         maxs = np.max(coords, axis=1)
         self._x_limits = mins[0], maxs[0]
@@ -2011,7 +2007,7 @@ class Gnomonic(Projection):
 
     @property
     def boundary(self):
-        return sgeom.Point(0, 0).buffer(self._max).exterior
+        return shapely.Point(0, 0).buffer(self._max).exterior
 
     @property
     def x_limits(self):
@@ -2066,7 +2062,7 @@ class Stereographic(Projection):
                           b * y_axis_offset + false_northing)
         coords = _ellipse_boundary(self._x_limits[1], self._y_limits[1],
                                    false_easting, false_northing, 91)
-        self._boundary = sgeom.LinearRing(coords.T)
+        self._boundary = shapely.LinearRing(coords.T)
         self.threshold = np.diff(self._x_limits)[0] * 1e-3
 
     @property
@@ -2122,7 +2118,7 @@ class Orthographic(Projection):
         # To stabilise the projection of geometries, we reduce the boundary by
         # a tiny fraction at the cost of the extreme edges.
         coords = _ellipse_boundary(a * 0.99999, a * 0.99999, n=61)
-        self._boundary = sgeom.polygon.LinearRing(coords.T)
+        self._boundary = shapely.LinearRing(coords.T)
         mins = np.min(coords, axis=1)
         maxs = np.max(coords, axis=1)
         self._x_limits = mins[0], maxs[0]
@@ -2166,7 +2162,7 @@ class _WarpedRectangularProjection(Projection, metaclass=ABCMeta):
         lat[-1] = -90
         points = self.transform_points(self.as_geodetic(), lon, lat)
 
-        self._boundary = sgeom.LinearRing(points)
+        self._boundary = shapely.LinearRing(points)
 
         mins = np.min(points, axis=0)
         maxs = np.max(points, axis=0)
@@ -2649,7 +2645,7 @@ class InterruptedGoodeHomolosine(Projection):
         lats[-1] = -90
 
         points = self.transform_points(self.as_geodetic(), lons, lats)
-        self._boundary = sgeom.LinearRing(points)
+        self._boundary = shapely.LinearRing(points)
 
         mins = np.min(points, axis=0)
         maxs = np.max(points, axis=0)
@@ -2685,7 +2681,7 @@ class _Satellite(Projection):
         super().__init__(proj4_params, globe=globe)
 
     def _set_boundary(self, coords):
-        self._boundary = sgeom.LinearRing(coords.T)
+        self._boundary = shapely.LinearRing(coords.T)
         mins = np.min(coords, axis=1)
         maxs = np.max(coords, axis=1)
         self._x_limits = mins[0], maxs[0]
@@ -2922,7 +2918,7 @@ class AlbersEqualArea(Projection):
 
         points = self.transform_points(self.as_geodetic(), lons, lats)
 
-        self._boundary = sgeom.LinearRing(points)
+        self._boundary = shapely.LinearRing(points)
         mins = np.min(points, axis=0)
         maxs = np.max(points, axis=0)
         self._x_limits = mins[0], maxs[0]
@@ -2984,7 +2980,7 @@ class AzimuthalEquidistant(Projection):
 
         coords = _ellipse_boundary(a * np.pi, b * np.pi,
                                    false_easting, false_northing, 61)
-        self._boundary = sgeom.LinearRing(coords.T)
+        self._boundary = shapely.LinearRing(coords.T)
         mins = np.min(coords, axis=1)
         maxs = np.max(coords, axis=1)
         self._x_limits = mins[0], maxs[0]
@@ -3049,7 +3045,7 @@ class Sinusoidal(Projection):
         lat[-1] = -90
         points = self.transform_points(self.as_geodetic(), lon, lat)
 
-        self._boundary = sgeom.LinearRing(points)
+        self._boundary = shapely.LinearRing(points)
         mins = np.min(points, axis=0)
         maxs = np.max(points, axis=0)
         self._x_limits = mins[0], maxs[0]
@@ -3137,7 +3133,7 @@ class EquidistantConic(Projection):
 
         points = self.transform_points(self.as_geodetic(), lons, lats)
 
-        self._boundary = sgeom.LinearRing(points)
+        self._boundary = shapely.LinearRing(points)
         mins = np.min(points, axis=0)
         maxs = np.max(points, axis=0)
         self._x_limits = mins[0], maxs[0]
@@ -3224,9 +3220,9 @@ class ObliqueMercator(Projection):
     def boundary(self):
         x0, x1 = self.x_limits
         y0, y1 = self.y_limits
-        return sgeom.LinearRing([(x0, y0), (x0, y1),
-                                 (x1, y1), (x1, y0),
-                                 (x0, y0)])
+        return shapely.LinearRing([(x0, y0), (x0, y1),
+                                   (x1, y1), (x1, y0),
+                                   (x0, y0)])
 
     @property
     def x_limits(self):
@@ -3235,6 +3231,7 @@ class ObliqueMercator(Projection):
     @property
     def y_limits(self):
         return self._y_limits
+
 
 class Spilhaus(Projection):
     """

--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -23,7 +23,6 @@ from pyproj import Transformer
 import pyproj.crs
 from pyproj.exceptions import ProjError
 import shapely
-from shapely.prepared import prep
 
 import cartopy.trace
 
@@ -1197,10 +1196,10 @@ class Projection(CRS, metaclass=ABCMeta):
         # "slurping up" any interior rings they contain.
         for exterior_ring in exterior_rings:
             polygon = shapely.Polygon(exterior_ring)
-            prep_polygon = prep(polygon)
+            shapely.prepare(polygon)
             holes = []
             for interior_ring in interior_rings[:]:
-                if prep_polygon.contains(interior_ring):
+                if polygon.contains(interior_ring):
                     holes.append(interior_ring)
                     interior_rings.remove(interior_ring)
                 elif polygon.crosses(interior_ring):

--- a/lib/cartopy/feature/__init__.py
+++ b/lib/cartopy/feature/__init__.py
@@ -17,7 +17,7 @@ above images and patches, but below lines and text.
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
-import shapely.geometry as sgeom
+import shapely
 
 import cartopy.crs
 import cartopy.io.shapereader as shapereader
@@ -107,8 +107,7 @@ class Feature(metaclass=ABCMeta):
         # shapely 2.0 returns tuple of NaNs instead of None for empty geometry
         # -> check for both
         if extent is not None and not np.isnan(extent[0]):
-            extent_geom = sgeom.box(extent[0], extent[2],
-                                    extent[1], extent[3])
+            extent_geom = shapely.box(extent[0], extent[2], extent[1], extent[3])
             return (geom for geom in self.geometries() if
                     geom is not None and extent_geom.intersects(geom))
         else:
@@ -223,7 +222,7 @@ class ShapelyFeature(Feature):
 
         """
         super().__init__(crs, **kwargs)
-        if isinstance(geometries, sgeom.base.BaseGeometry):
+        if isinstance(geometries, shapely.geometry.base.BaseGeometry):
             geometries = [geometries]
         self._geoms = tuple(geometries)
 
@@ -417,8 +416,7 @@ class GSHHSFeature(Feature):
             scale = self._scale[0]
 
         if extent is not None:
-            extent_geom = sgeom.box(extent[0], extent[2],
-                                    extent[1], extent[3])
+            extent_geom = shapely.box(extent[0], extent[2], extent[1], extent[3])
         for level in self._levels:
             geoms = GSHHSFeature._geometries_cache.get((scale, level))
             if geoms is None:

--- a/lib/cartopy/feature/nightshade.py
+++ b/lib/cartopy/feature/nightshade.py
@@ -6,7 +6,7 @@
 import datetime
 
 import numpy as np
-import shapely.geometry as sgeom
+import shapely
 
 from .. import crs as ccrs
 from . import ShapelyFeature
@@ -93,7 +93,7 @@ class Nightshade(ShapelyFeature):
         kwargs.setdefault('facecolor', color)
         kwargs.setdefault('alpha', alpha)
 
-        geom = sgeom.Polygon(np.column_stack((x, y)))
+        geom = shapely.Polygon(np.column_stack((x, y)))
         return super().__init__(
             [geom], rotated_pole, **kwargs)
 

--- a/lib/cartopy/geodesic.py
+++ b/lib/cartopy/geodesic.py
@@ -13,7 +13,7 @@ for more background information.
 """
 import numpy as np
 import pyproj
-import shapely.geometry as sgeom
+import shapely
 
 
 class Geodesic:
@@ -202,7 +202,7 @@ class Geodesic:
 
         Parameters
         ----------
-        geometry : `shapely.geometry.BaseGeometry`
+        geometry : `shapely.geometry.base.BaseGeometry`
             The Shapely geometry to compute the length of. For polygons, the
             exterior length will be calculated. For multi-part geometries, the
             sum of the parts will be computed.
@@ -217,8 +217,7 @@ class Geodesic:
             # Polygon.
             result = self.geometry_length(geometry.exterior)
 
-        elif (hasattr(geometry, 'coords') and
-                not isinstance(geometry, sgeom.Point)):
+        elif hasattr(geometry, 'coords') and not isinstance(geometry, shapely.Point):
             coords = np.array(geometry.coords)
             result = self.geometry_length(coords)
 

--- a/lib/cartopy/io/img_nest.py
+++ b/lib/cartopy/io/img_nest.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import numpy as np
 from PIL import Image
-import shapely.geometry as sgeom
+import shapely
 
 
 _img_class_attrs = ['filename', 'extent', 'origin', 'pixel_size']
@@ -67,14 +67,10 @@ class Img(collections.namedtuple('Img', _img_class_attrs)):
         return self.__dict__
 
     def bbox(self):
-        """
-        Return a :class:`~shapely.geometry.polygon.Polygon` instance for
-        this image's extents.
-
-        """
+        """Return a :class:`~shapely.Polygon` instance for this image's extents."""
         if self._bbox is None:
             x0, x1, y0, y1 = self.extent
-            self._bbox = sgeom.box(x0, y0, x1, y1)
+            self._bbox = shapely.box(x0, y0, x1, y1)
         return self._bbox
 
     @staticmethod
@@ -321,9 +317,8 @@ class NestedImageCollection:
         Parameters
         ----------
         target_domain
-            A :class:`~shapely.geometry.linestring.LineString`
-            instance that specifies the target location requiring image
-            coverage.
+            A :class:`~shapely.LineString` instance that specifies the target location
+            requiring image coverage.
         target_z
             The name of the target :class`~cartopy.io.img_nest.ImageCollection`
             which specifies the target zoom level (resolution) of the required
@@ -371,8 +366,8 @@ class NestedImageCollection:
         Parameters
         ----------
         target_domain
-            A :class:`~shapely.geometry.linestring.LineString` instance that
-            specifies the target location requiring image coverage.
+            A :class:`~shapely.LineString` instance that specifies the target location
+            requiring image coverage.
 
         target_z
             The name of the target

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -25,7 +25,7 @@ import warnings
 
 import numpy as np
 from PIL import Image
-import shapely.geometry as sgeom
+import shapely
 
 import cartopy
 import cartopy.crs as ccrs
@@ -164,7 +164,7 @@ class GoogleWTS(metaclass=ABCMeta):
 
         # Recursively drill down to the images at the target zoom.
         x0, x1, y0, y1 = self._tileextent(start_tile)
-        domain = sgeom.box(x0, y0, x1, y1)
+        domain = shapely.box(x0, y0, x1, y1)
         if domain.intersects(target_domain):
             if start_tile[2] == target_z:
                 yield start_tile

--- a/lib/cartopy/io/ogc_clients.py
+++ b/lib/cartopy/io/ogc_clients.py
@@ -26,7 +26,7 @@ from xml.etree import ElementTree
 
 import numpy as np
 from PIL import Image
-import shapely.geometry as sgeom
+import shapely
 
 import cartopy
 
@@ -149,7 +149,7 @@ def _target_extents(extent, requested_projection, available_projection):
     """
     # Start with the requested area.
     min_x, max_x, min_y, max_y = extent
-    target_box = sgeom.box(min_x, min_y, max_x, max_y)
+    target_box = shapely.box(min_x, min_y, max_x, max_y)
 
     # If the requested area (i.e. target_box) is bigger (or nearly bigger) than
     # the entire output requested_projection domain, then we erode the request
@@ -923,17 +923,14 @@ class WFSGeometrySource:
                         data = self._find_polygon_coords(node, find_str)
                         points_data.extend(data)
 
-        geoms_by_srs = {}
+        geoms_by_srs = collections.defaultdict(list)
         for srs, x, y in linear_rings_data:
-            geoms_by_srs.setdefault(srs, []).append(
-                sgeom.LinearRing(zip(x, y)))
+            geoms_by_srs[srs].append(shapely.LinearRing(zip(x, y)))
         for srs, x, y in linestrings_data:
-            geoms_by_srs.setdefault(srs, []).append(
-                sgeom.LineString(zip(x, y)))
+            geoms_by_srs[srs].append(shapely.LineString(zip(x, y)))
         for srs, x, y in points_data:
-            geoms_by_srs.setdefault(srs, []).append(
-                sgeom.Point(zip(x, y)))
-        return geoms_by_srs
+            geoms_by_srs[srs].append(shapely.Point(zip(x, y)))
+        return dict(geoms_by_srs)
 
     def _find_polygon_coords(self, node, find_str):
         """

--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -33,7 +33,7 @@ import matplotlib.spines as mspines
 import matplotlib.transforms as mtransforms
 import numpy as np
 import numpy.ma as ma
-import shapely.geometry as sgeom
+import shapely
 
 from cartopy import config
 import cartopy.crs as ccrs
@@ -669,7 +669,7 @@ class GeoAxes(matplotlib.axes.Axes):
 
         for lon, lat in zip(lons, lats):
             circle = geod.circle(lon, lat, rad_km * 1e3, n_samples=n_samples)
-            geoms.append(sgeom.Polygon(circle))
+            geoms.append(shapely.Polygon(circle))
 
         feature = cartopy.feature.ShapelyFeature(geoms, ccrs.Geodetic(),
                                                  **kwargs)
@@ -754,9 +754,9 @@ class GeoAxes(matplotlib.axes.Axes):
         # Perform the calculations for get_extent(), which just repackages it.
         [x1, y1], [x2, y2] = self.viewLim.get_points()
 
-        domain_in_src_proj = sgeom.Polygon([[x1, y1], [x2, y1],
-                                            [x2, y2], [x1, y2],
-                                            [x1, y1]])
+        domain_in_src_proj = shapely.Polygon([[x1, y1], [x2, y1],
+                                              [x2, y2], [x1, y2],
+                                              [x1, y1]])
 
         # Determine target projection based on requested CRS.
         if crs is None:
@@ -780,7 +780,7 @@ class GeoAxes(matplotlib.axes.Axes):
                                  f' coordinate system {crs!r}')
 
         # Calculate intersection with boundary and project if necessary.
-        boundary_poly = sgeom.Polygon(self.projection.boundary)
+        boundary_poly = shapely.Polygon(self.projection.boundary)
         if proj != self.projection:
             # Erode boundary by threshold to avoid transform issues.
             # This is a workaround for numerical issues at the boundary.
@@ -811,9 +811,9 @@ class GeoAxes(matplotlib.axes.Axes):
         # plt.ylim - allowing users to set None for a minimum and/or
         # maximum value
         x1, x2, y1, y2 = extents
-        domain_in_crs = sgeom.polygon.LineString([[x1, y1], [x2, y1],
-                                                  [x2, y2], [x1, y2],
-                                                  [x1, y1]])
+        domain_in_crs = shapely.LineString([[x1, y1], [x2, y1],
+                                            [x2, y2], [x1, y2],
+                                            [x1, y1]])
 
         projected = None
 

--- a/lib/cartopy/mpl/gridliner.py
+++ b/lib/cartopy/mpl/gridliner.py
@@ -22,7 +22,6 @@ import matplotlib.ticker as mticker
 import matplotlib.transforms as mtrans
 import numpy as np
 import shapely
-import shapely.geometry as sgeom
 
 import cartopy
 from cartopy.crs import PlateCarree, Projection, _RectangularProjection
@@ -758,7 +757,7 @@ class Gridliner(matplotlib.artist.Artist):
         self.axes.spines["geo"].get_window_extent(renderer)  # update coords
         map_boundary_path = self.axes.spines["geo"].get_path().transformed(
             self.axes.spines["geo"].get_transform())
-        map_boundary = sgeom.Polygon(map_boundary_path.vertices)
+        map_boundary = shapely.Polygon(map_boundary_path.vertices)
 
         if self.x_inline:
             y_midpoints = self._find_midpoints(lat_lim, lat_ticks)
@@ -795,14 +794,14 @@ class Gridliner(matplotlib.artist.Artist):
                 line_coords = line_coords.compress(~infs, axis=0)
                 if line_coords.size == 0:
                     continue
-                line = sgeom.LineString(line_coords)
+                line = shapely.LineString(line_coords)
                 if not line.intersects(map_boundary):
                     continue
                 intersection = line.intersection(map_boundary)
                 del line
                 if intersection.is_empty:
                     continue
-                if isinstance(intersection, sgeom.MultiPoint):
+                if isinstance(intersection, shapely.MultiPoint):
                     if len(intersection) < 2:
                         continue
                     n2 = min(len(intersection), 3)
@@ -810,20 +809,20 @@ class Gridliner(matplotlib.artist.Artist):
                               for pt in intersection[:n2:n2 - 1]]]
                     heads = [[(pt.x, pt.y)
                               for pt in intersection[-1:-n2 - 1:-n2 + 1]]]
-                elif isinstance(intersection, (sgeom.LineString,
-                                               sgeom.MultiLineString)):
+                elif isinstance(intersection, (shapely.LineString,
+                                               shapely.MultiLineString)):
                     orig_intersection = intersection
-                    if isinstance(intersection, sgeom.MultiLineString):
+                    if isinstance(intersection, shapely.MultiLineString):
                         # Sometimes Shapely produces multiple lines where the end points
                         # coincide, so try to combine them into longer but fewer ones.
                         intersection = shapely.line_merge(intersection)
-                    if isinstance(intersection, sgeom.LineString):
+                    if isinstance(intersection, shapely.LineString):
                         intersection = [intersection]
                     elif len(intersection.geoms) > 4:
                         # If lines are parallel, there will be many intersections
                         # merge them to get only one for the calculations below
                         merged_line = shapely.line_merge(intersection)
-                        if isinstance(merged_line, sgeom.MultiLineString):
+                        if isinstance(merged_line, shapely.MultiLineString):
                             # our merge still produced a multilinestring, so
                             # manually concatenate the original coordinates
                             xy = np.concatenate(
@@ -843,7 +842,7 @@ class Gridliner(matplotlib.artist.Artist):
                         heads.append(inter.coords[-1:-n2 - 1:-n2 + 1])
                     if not tails:
                         continue
-                elif isinstance(intersection, sgeom.GeometryCollection):
+                elif isinstance(intersection, shapely.GeometryCollection):
                     # This is a collection of Point and LineString that
                     # represent the same gridline.  We only consider the first
                     # geometries, merge their coordinates and keep first two

--- a/lib/cartopy/mpl/patch.py
+++ b/lib/cartopy/mpl/patch.py
@@ -16,7 +16,7 @@ import warnings
 
 from matplotlib.path import Path
 import numpy as np
-import shapely.geometry as sgeom
+import shapely
 
 import cartopy.mpl.path as cpath
 
@@ -32,16 +32,17 @@ def geos_to_path(shape):
     Parameters
     ----------
     shape
-        A list, tuple or single instance of any of the following
-        types: :class:`shapely.geometry.point.Point`,
-        :class:`shapely.geometry.linestring.LineString`,
-        :class:`shapely.geometry.polygon.LinearRing`,
-        :class:`shapely.geometry.polygon.Polygon`,
-        :class:`shapely.geometry.multipoint.MultiPoint`,
-        :class:`shapely.geometry.multipolygon.MultiPolygon`,
-        :class:`shapely.geometry.multilinestring.MultiLineString`,
-        :class:`shapely.geometry.collection.GeometryCollection`,
-        or any type with a _as_mpl_path() method.
+        A list, tuple or single instance of any of the following types:
+
+        - :class:`shapely.Point`,
+        - :class:`shapely.LineString`,
+        - :class:`shapely.LinearRing`,
+        - :class:`shapely.Polygon`,
+        - :class:`shapely.MultiPoint`,
+        - :class:`shapely.MultiPolygon`,
+        - :class:`shapely.MultiLineString`,
+        - :class:`shapely.GeometryCollection`,
+        - or any type with a _as_mpl_path() method.
 
     Returns
     -------
@@ -58,11 +59,11 @@ def geos_to_path(shape):
             paths.extend(geos_to_path(shp))
         return paths
 
-    if isinstance(shape, sgeom.LinearRing):
+    if isinstance(shape, shapely.LinearRing):
         return [Path(np.column_stack(shape.xy), closed=True)]
-    elif isinstance(shape, (sgeom.LineString, sgeom.Point)):
+    elif isinstance(shape, (shapely.LineString, shapely.Point)):
         return [Path(np.column_stack(shape.xy))]
-    elif isinstance(shape, sgeom.Polygon):
+    elif isinstance(shape, shapely.Polygon):
         def poly_codes(poly):
             codes = np.ones(len(poly.xy[0])) * Path.LINETO
             codes[0] = Path.MOVETO
@@ -76,8 +77,8 @@ def geos_to_path(shape):
         codes = np.concatenate([poly_codes(shape.exterior)] +
                                [poly_codes(ring) for ring in shape.interiors])
         return [Path(vertices, codes)]
-    elif isinstance(shape, (sgeom.MultiPolygon, sgeom.GeometryCollection,
-                            sgeom.MultiLineString, sgeom.MultiPoint)):
+    elif isinstance(shape, (shapely.MultiPolygon, shapely.GeometryCollection,
+                            shapely.MultiLineString, shapely.MultiPoint)):
         paths = []
         for geom in shape.geoms:
             paths.extend(geos_to_path(geom))
@@ -143,10 +144,12 @@ def path_to_geos(path, force_ccw=False):
 
     Returns
     -------
-    A list of instances of the following type(s):
-        :class:`shapely.geometry.polygon.Polygon`,
-        :class:`shapely.geometry.linestring.LineString` and/or
-        :class:`shapely.geometry.multilinestring.MultiLineString`.
+    list
+        A list of instances of the following type(s):
+
+        - :class:`shapely.Polygon`,
+        - :class:`shapely.LineString` and/or
+        - :class:`shapely.MultiLineString`.
 
     """
     warnings.warn("path_to_geos is deprecated and will be removed in a future release."
@@ -179,11 +182,11 @@ def path_to_geos(path, force_ccw=False):
                                                     axis=1)
 
         if all(verts_same_as_first):
-            geom = sgeom.Point(path_verts[0, :])
+            geom = shapely.Point(path_verts[0, :])
         elif path_verts.shape[0] >= 4 and path_codes[-1] == Path.CLOSEPOLY:
-            geom = sgeom.Polygon(path_verts[:-1, :])
+            geom = shapely.Polygon(path_verts[:-1, :])
         else:
-            geom = sgeom.LineString(path_verts)
+            geom = shapely.LineString(path_verts)
 
         # If geom is a Polygon and is contained within the last geom in
         # collection, it usually needs to be an interior to that geom (e.g. a
@@ -193,14 +196,14 @@ def path_to_geos(path, force_ccw=False):
         if geom.is_empty:
             pass
         elif (len(collection) > 0 and
-                isinstance(collection[-1][0], sgeom.Polygon) and
-                isinstance(geom, sgeom.Polygon) and
+                isinstance(collection[-1][0], shapely.Polygon) and
+                isinstance(geom, shapely.Polygon) and
                 collection[-1][0].contains(geom.exterior)):
             if any(internal.contains(geom) for internal in collection[-1][1]):
                 collection.append((geom, []))
             else:
                 collection[-1][1].append(geom)
-        elif isinstance(geom, sgeom.Point):
+        elif isinstance(geom, shapely.Point):
             other_result_geoms.append(geom)
         else:
             collection.append((geom, []))
@@ -212,28 +215,28 @@ def path_to_geos(path, force_ccw=False):
     for external_geom, internal_polys in collection:
         if internal_polys:
             exteriors = [geom.exterior for geom in internal_polys]
-            geom = sgeom.Polygon(external_geom.exterior, exteriors)
+            geom = shapely.Polygon(external_geom.exterior, exteriors)
         else:
             geom = external_geom
 
         # Correctly orientate the polygon (ccw)
-        if isinstance(geom, sgeom.Polygon):
+        if isinstance(geom, shapely.Polygon):
             if force_ccw and not geom.exterior.is_ccw:
-                geom = sgeom.polygon.orient(geom)
+                geom = shapely.geometry.polygon.orient(geom)
 
         geom_collection.append(geom)
 
     # If the geom_collection only contains LineStrings combine them
     # into a single MultiLinestring.
-    if geom_collection and all(isinstance(geom, sgeom.LineString) for
+    if geom_collection and all(isinstance(geom, shapely.LineString) for
                                geom in geom_collection):
-        geom_collection = [sgeom.MultiLineString(geom_collection)]
+        geom_collection = [shapely.MultiLineString(geom_collection)]
 
     # Remove any zero area Polygons
     def not_zero_poly(geom):
-        return ((isinstance(geom, sgeom.Polygon) and not geom.is_empty and
+        return ((isinstance(geom, shapely.Polygon) and not geom.is_empty and
                  geom.area != 0) or
-                not isinstance(geom, sgeom.Polygon))
+                not isinstance(geom, shapely.Polygon))
 
     result = list(filter(not_zero_poly, geom_collection))
 

--- a/lib/cartopy/mpl/path.py
+++ b/lib/cartopy/mpl/path.py
@@ -15,7 +15,6 @@ and `Matplotlib Path API <https://matplotlib.org/stable/api/path_api.html>`_.
 from matplotlib.path import Path
 import numpy as np
 import shapely
-import shapely.geometry as sgeom
 
 
 def _ensure_path_closed(path):
@@ -89,14 +88,16 @@ def shapely_to_path(shape):
     Parameters
     ----------
     shape
-        :class:`shapely.Point`,
-        :class:`shapely.LineString`,
-        :class:`shapely.LinearRing`,
-        :class:`shapely.Polygon`,
-        :class:`shapely.MultiPoint`,
-        :class:`shapely.MultiPolygon`,
-        :class:`shapely.MultiLineString`,
-        :class:`shapely.GeometryCollection`.
+        One of the following Shapely objects:
+
+        - :class:`shapely.Point`,
+        - :class:`shapely.LineString`,
+        - :class:`shapely.LinearRing`,
+        - :class:`shapely.Polygon`,
+        - :class:`shapely.MultiPoint`,
+        - :class:`shapely.MultiPolygon`,
+        - :class:`shapely.MultiLineString`,
+        - :class:`shapely.GeometryCollection`.
 
     Returns
     -------
@@ -106,11 +107,11 @@ def shapely_to_path(shape):
     """
     if shape.is_empty:
         return Path(np.empty([0, 2]))
-    elif isinstance(shape, sgeom.LinearRing):
+    elif isinstance(shape, shapely.LinearRing):
         return Path(shapely.get_coordinates(shape), closed=True)
-    elif isinstance(shape, (sgeom.LineString, sgeom.Point)):
+    elif isinstance(shape, (shapely.LineString, shapely.Point)):
         return Path(shapely.get_coordinates(shape))
-    elif isinstance(shape, sgeom.Polygon):
+    elif isinstance(shape, shapely.Polygon):
         rings = [shape.exterior, *shape.interiors]
         # Shapely rings include the closing duplicate point, so len(ring.coords)
         # gives the number of vertices contributed by each ring.
@@ -122,8 +123,8 @@ def shapely_to_path(shape):
         codes[starts] = Path.MOVETO
         codes[starts + counts - 1] = Path.CLOSEPOLY
         return Path(vertices, codes)
-    elif isinstance(shape, (sgeom.MultiPolygon, sgeom.GeometryCollection,
-                            sgeom.MultiLineString, sgeom.MultiPoint)):
+    elif isinstance(shape, (shapely.MultiPolygon, shapely.GeometryCollection,
+                            shapely.MultiLineString, shapely.MultiPoint)):
         return Path.make_compound_path(*[shapely_to_path(geom) for geom in shape.geoms])
     else:
         raise ValueError(f'Unsupported shape type {type(shape)}.')
@@ -140,15 +141,16 @@ def path_to_shapely(path):
 
     Returns
     -------
-    One of the following Shapely objects:
+    Geometry
+        One of the following Shapely objects:
 
-        :class:`shapely.Polygon`,
-        :class:`shapely.LineString`
-        :class:`shapely.Point`,
-        :class:`shapely.MultiPolygon`
-        :class:`shapely.MultiLineString`
-        :class:`shapely.MultiPoint`
-        :class:`shapely.GeometryCollection`.
+        - :class:`shapely.Polygon`,
+        - :class:`shapely.LineString`
+        - :class:`shapely.Point`,
+        - :class:`shapely.MultiPolygon`
+        - :class:`shapely.MultiLineString`
+        - :class:`shapely.MultiPoint`
+        - :class:`shapely.GeometryCollection`.
 
     """
     # Convert path into numpy array of vertices (and associated codes)
@@ -180,11 +182,11 @@ def path_to_shapely(path):
                                                     axis=1)
 
         if all(verts_same_as_first):
-            points.append(sgeom.Point(path_verts[0, :]))
-        elif not(path_verts.shape[0] >= 4 and path_codes[-1] == Path.CLOSEPOLY):
-            linestrings.append(sgeom.LineString(path_verts))
+            points.append(shapely.Point(path_verts[0, :]))
+        elif not (path_verts.shape[0] >= 4 and path_codes[-1] == Path.CLOSEPOLY):
+            linestrings.append(shapely.LineString(path_verts))
         else:
-            geom = sgeom.Polygon(path_verts[:-1, :])
+            geom = shapely.Polygon(path_verts[:-1, :])
             # If geom is a Polygon and is contained within the last geom in
             # polygon_bits, it usually needs to be an interior to that geom (e.g. a
             # lake within a land mass).  Sometimes there is a further geom within
@@ -204,7 +206,7 @@ def path_to_shapely(path):
     for external_poly, internal_polys in polygon_bits:
         if internal_polys:
             exteriors = [geom.exterior for geom in internal_polys]
-            geom = sgeom.Polygon(external_poly.exterior, exteriors)
+            geom = shapely.Polygon(external_poly.exterior, exteriors)
         else:
             geom = external_poly
 
@@ -221,23 +223,23 @@ def path_to_shapely(path):
         if not linestrings:
             if not points:
                 # No geometries.  Return an empty point
-                return sgeom.Point()
+                return shapely.Point()
             elif len(points) > 1:
-                return sgeom.MultiPoint(points)
+                return shapely.MultiPoint(points)
             else:
                 return points[0]
         elif not points:
             if len(linestrings) > 1:
-                return sgeom.MultiLineString(linestrings)
+                return shapely.MultiLineString(linestrings)
             else:
                 return linestrings[0]
     else:
         if not linestrings and not points:
             if len(polygons) > 1:
-                return sgeom.MultiPolygon(polygons)
+                return shapely.MultiPolygon(polygons)
             else:
                 return polygons[0]
 
     # If we got to here, we have at least two types of geometry, so return
     # a geometry collection.
-    return sgeom.GeometryCollection(polygons + linestrings + points)
+    return shapely.GeometryCollection(polygons + linestrings + points)

--- a/lib/cartopy/tests/mpl/test_feature_artist.py
+++ b/lib/cartopy/tests/mpl/test_feature_artist.py
@@ -9,7 +9,7 @@ import matplotlib.path as mpath
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-import shapely.geometry as sgeom
+import shapely
 
 import cartopy.crs as ccrs
 from cartopy.feature import ShapelyFeature
@@ -32,9 +32,9 @@ def test_freeze(source, expected):
 
 @pytest.fixture
 def feature():
-    circle1 = sgeom.Point(0, 0).buffer(1)
-    circle2 = sgeom.Point(0, 0).buffer(10)
-    square = sgeom.Polygon([(30, 0), (50, 0), (50, 20), (30, 20), (30, 0)])
+    circle1 = shapely.Point(0, 0).buffer(1)
+    circle2 = shapely.Point(0, 0).buffer(10)
+    square = shapely.Polygon([(30, 0), (50, 0), (50, 20), (30, 20), (30, 0)])
     geoms = [circle1, circle2, square]
     feature = ShapelyFeature(geoms, ccrs.PlateCarree())
     return feature
@@ -137,7 +137,7 @@ def test_feature_artist_autolim(autolim):
     plot_crs = ccrs.PlateCarree(central_longitude=180)
     fig, ax = plt.subplots(subplot_kw={'projection': plot_crs})
 
-    square = sgeom.Polygon([(30, 0), (50, 0), (50, 20), (30, 20), (30, 0)])
+    square = shapely.Polygon([(30, 0), (50, 0), (50, 20), (30, 20), (30, 0)])
     ax.add_geometries([square], crs=ccrs.PlateCarree(), autolim=autolim)
 
     if autolim:

--- a/lib/cartopy/tests/mpl/test_images.py
+++ b/lib/cartopy/tests/mpl/test_images.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from PIL import Image
 import pytest
-import shapely.geometry as sgeom
+import shapely
 
 from cartopy.mpl import _MPL_311
 from cartopy.tests.conftest import _HAS_PYKDTREE_OR_SCIPY
@@ -40,11 +40,11 @@ REGIONAL_IMG = (config['repo_data_dir'] / 'raster' / 'sample'
 @pytest.mark.mpl_image_compare(filename='web_tiles.png', tolerance=5.91)
 def test_web_tiles():
     extent = [-15, 0.1, 50, 60]
-    target_domain = sgeom.Polygon([[extent[0], extent[1]],
-                                   [extent[2], extent[1]],
-                                   [extent[2], extent[3]],
-                                   [extent[0], extent[3]],
-                                   [extent[0], extent[1]]])
+    target_domain = shapely.Polygon([[extent[0], extent[1]],
+                                     [extent[2], extent[1]],
+                                     [extent[2], extent[3]],
+                                     [extent[0], extent[3]],
+                                     [extent[0], extent[1]]])
     map_prj = cimgt.GoogleTiles().crs
     fig = plt.figure()
 

--- a/lib/cartopy/tests/mpl/test_path.py
+++ b/lib/cartopy/tests/mpl/test_path.py
@@ -7,7 +7,7 @@ from matplotlib.path import Path
 import numpy as np
 from numpy.testing import assert_array_equal
 import pytest
-import shapely.geometry as sgeom
+import shapely
 
 import cartopy.mpl.patch as cpatch
 import cartopy.mpl.path as cpath
@@ -30,11 +30,11 @@ class Test_path_to_shapely:
         if use_legacy_path_to_geos:
             with pytest.warns(DeprecationWarning, match="path_to_geos is deprecated"):
                 geoms = cpatch.path_to_geos(p)
-            assert [type(geom) for geom in geoms] == [sgeom.Point] * 4
+            assert [type(geom) for geom in geoms] == [shapely.Point] * 4
             assert len(geoms) == 4
         else:
             geoms = cpath.path_to_shapely(p)
-            assert isinstance(geoms, sgeom.MultiPoint)
+            assert isinstance(geoms, shapely.MultiPoint)
             assert len(geoms.geoms) == 4
 
     def test_non_polygon_loop(self, use_legacy_path_to_geos):
@@ -44,11 +44,11 @@ class Test_path_to_shapely:
             with pytest.warns(DeprecationWarning, match="path_to_geos is deprecated"):
                 geoms = cpatch.path_to_geos(p)
 
-            assert [type(geom) for geom in geoms] == [sgeom.MultiLineString]
+            assert [type(geom) for geom in geoms] == [shapely.MultiLineString]
             assert len(geoms) == 1
         else:
             geoms = cpath.path_to_shapely(p)
-            assert isinstance(geoms, sgeom.LineString)
+            assert isinstance(geoms, shapely.LineString)
 
     def test_polygon_with_interior_and_singularity(self, use_legacy_path_to_geos):
         # A geometry with two interiors, one a single point.
@@ -60,12 +60,13 @@ class Test_path_to_shapely:
             with pytest.warns(DeprecationWarning, match="path_to_geos is deprecated"):
                 geoms = cpatch.path_to_geos(p)
 
-            assert [type(geom) for geom in geoms] == [sgeom.Polygon, sgeom.Point]
+            assert [type(geom) for geom in geoms] == [shapely.Polygon, shapely.Point]
             assert len(geoms[0].interiors) == 1
         else:
             geoms = cpath.path_to_shapely(p)
-            assert isinstance(geoms, sgeom.GeometryCollection)
-            assert [type(geom) for geom in geoms.geoms] == [sgeom.Polygon, sgeom.Point]
+            assert isinstance(geoms, shapely.GeometryCollection)
+            assert [type(geom) for geom in geoms.geoms] == [shapely.Polygon,
+                                                            shapely.Point]
             assert len(geoms.geoms[0].interiors) == 1
 
     def test_closed_triangle_is_polygon(self, use_legacy_path_to_geos):
@@ -76,11 +77,11 @@ class Test_path_to_shapely:
         if use_legacy_path_to_geos:
             with pytest.warns(DeprecationWarning, match="path_to_geos is deprecated"):
                 geoms = cpatch.path_to_geos(p)
-            assert [type(geom) for geom in geoms] == [sgeom.Polygon]
+            assert [type(geom) for geom in geoms] == [shapely.Polygon]
             assert geoms[0].area == pytest.approx(0.5)
         else:
             geom = cpath.path_to_shapely(p)
-            assert isinstance(geom, sgeom.Polygon)
+            assert isinstance(geom, shapely.Polygon)
             assert geom.area == pytest.approx(0.5)
 
     def test_degenerate_closed_path_is_linestring(self, use_legacy_path_to_geos):
@@ -92,10 +93,10 @@ class Test_path_to_shapely:
             with pytest.warns(DeprecationWarning, match="path_to_geos is deprecated"):
                 geoms = cpatch.path_to_geos(p)
             # A single LineString result is wrapped in a MultiLineString.
-            assert [type(geom) for geom in geoms] == [sgeom.MultiLineString]
+            assert [type(geom) for geom in geoms] == [shapely.MultiLineString]
         else:
             geom = cpath.path_to_shapely(p)
-            assert isinstance(geom, sgeom.LineString)
+            assert isinstance(geom, shapely.LineString)
 
     def test_nested_polygons(self, use_legacy_path_to_geos):
         # A geometry with three nested squares.
@@ -112,12 +113,12 @@ class Test_path_to_shapely:
                 geoms = cpatch.path_to_geos(p)
 
             assert len(geoms) == 2
-            assert all(isinstance(geom, sgeom.Polygon) for geom in geoms)
+            assert all(isinstance(geom, shapely.Polygon) for geom in geoms)
             assert len(geoms[0].interiors) == 1
             assert len(geoms[1].interiors) == 0
         else:
             geoms = cpath.path_to_shapely(p)
-            assert isinstance(geoms, sgeom.MultiPolygon)
+            assert isinstance(geoms, shapely.MultiPolygon)
             assert len(geoms.geoms) == 2
             assert len(geoms.geoms[0].interiors) == 1
             assert len(geoms.geoms[1].interiors) == 0
@@ -126,15 +127,16 @@ class Test_path_to_shapely:
 def test_triangle_shapely_path_round_trip():
     # A triangle Polygon should survive a round trip through
     # shapely_to_path and back through path_to_shapely.
-    triangle = sgeom.Polygon([(0, 0), (1, 0), (0, 1)])
+    triangle = shapely.Polygon([(0, 0), (1, 0), (0, 1)])
     path = cpath.shapely_to_path(triangle)
     geom = cpath.path_to_shapely(path)
-    assert isinstance(geom, sgeom.Polygon)
+    assert isinstance(geom, shapely.Polygon)
     assert geom.equals(triangle)
 
 
 no_polygon_path = Path([[0,0], [1,1]], codes=[Path.MOVETO, Path.LINETO])
 empty_path = Path(np.empty((0, 2)))
+
 
 class Test_ensure_path_closed:
     @pytest.mark.parametrize('path', [no_polygon_path, empty_path])
@@ -146,11 +148,11 @@ class Test_ensure_path_closed:
 
 class Test_shapely_to_path:
     def test_polygon_with_multiple_interiors(self):
-        exterior = sgeom.box(0, 0, 12, 12).exterior.coords
-        interiors = [sgeom.box(1, 1, 2, 2, ccw=False).exterior.coords,
-                     sgeom.box(4, 4, 5, 6, ccw=False).exterior.coords,
-                     sgeom.box(8, 8, 9, 10, ccw=False).exterior.coords]
-        poly = sgeom.Polygon(exterior, interiors)
+        exterior = shapely.box(0, 0, 12, 12).exterior.coords
+        interiors = [shapely.box(1, 1, 2, 2, ccw=False).exterior.coords,
+                     shapely.box(4, 4, 5, 6, ccw=False).exterior.coords,
+                     shapely.box(8, 8, 9, 10, ccw=False).exterior.coords]
+        poly = shapely.Polygon(exterior, interiors)
 
         path = cpath.shapely_to_path(poly)
 
@@ -169,5 +171,5 @@ class Test_shapely_to_path:
 
         # The path should round-trip back to an equivalent geometry.
         result = cpath.path_to_shapely(path)
-        assert isinstance(result, sgeom.Polygon)
+        assert isinstance(result, shapely.Polygon)
         assert result.equals(poly)

--- a/lib/cartopy/tests/mpl/test_shapely_to_mpl.py
+++ b/lib/cartopy/tests/mpl/test_shapely_to_mpl.py
@@ -9,7 +9,7 @@ from matplotlib.path import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-import shapely.geometry as sgeom
+import shapely
 
 import cartopy.crs as ccrs
 import cartopy.mpl.patch as cpatch
@@ -48,7 +48,7 @@ def test_polygon_interiors(use_legacy_geos_funcs):
                         patches_native.append(mpatches.PathPatch(pth))
     else:
         geom = cpath.path_to_shapely(pth)
-        assert isinstance(geom, sgeom.Polygon)
+        assert isinstance(geom, shapely.Polygon)
         path = cpath.shapely_to_path(geom)
         patches = [mpatches.PathPatch(path)]
 
@@ -71,10 +71,10 @@ def test_polygon_interiors(use_legacy_geos_funcs):
                          xlim=[-5, 15], ylim=[-5, 15])
     ax.coastlines(resolution="110m")
 
-    exterior = np.array(sgeom.box(0, 0, 12, 12).exterior.coords)
-    interiors = [np.array(sgeom.box(1, 1, 2, 2, ccw=False).exterior.coords),
-                 np.array(sgeom.box(1, 8, 2, 9, ccw=False).exterior.coords)]
-    poly = sgeom.Polygon(exterior, interiors)
+    exterior = np.array(shapely.box(0, 0, 12, 12).exterior.coords)
+    interiors = [np.array(shapely.box(1, 1, 2, 2, ccw=False).exterior.coords),
+                 np.array(shapely.box(1, 8, 2, 9, ccw=False).exterior.coords)]
+    poly = shapely.Polygon(exterior, interiors)
 
     if use_legacy_geos_funcs:
         patches = []

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -15,7 +15,7 @@ from numpy.testing import assert_almost_equal, assert_array_equal
 from numpy.testing import assert_array_almost_equal as assert_arr_almost_eq
 import pyproj
 import pytest
-import shapely.geometry as sgeom
+import shapely
 
 import cartopy.crs as ccrs
 
@@ -212,8 +212,8 @@ class TestCRS:
         assert_arr_almost_eq(footy_pt, (155657, 193479), decimal=0)
 
     def test_project_point(self):
-        point = sgeom.Point([0, 45])
-        multi_point = sgeom.MultiPoint([point, sgeom.Point([180, 45])])
+        point = shapely.Point([0, 45])
+        multi_point = shapely.MultiPoint([point, shapely.Point([180, 45])])
 
         pc = ccrs.PlateCarree()
         pc_rotated = ccrs.PlateCarree(central_longitude=180)
@@ -222,7 +222,7 @@ class TestCRS:
         assert_arr_almost_eq(result.xy, [[-180.], [45.]])
 
         result = pc_rotated.project_geometry(multi_point, pc)
-        assert isinstance(result, sgeom.MultiPoint)
+        assert isinstance(result, shapely.MultiPoint)
         assert len(result.geoms) == 2
         assert_arr_almost_eq(result.geoms[0].xy, [[-180.], [45.]])
         assert_arr_almost_eq(result.geoms[1].xy, [[0], [45.]])
@@ -313,7 +313,7 @@ def test_transform_points_empty():
 
 def test_project_geometry_empty_point():
     """Test with an empty shapely point."""
-    assert ccrs.PlateCarree().project_geometry(sgeom.Point()).is_empty
+    assert ccrs.PlateCarree().project_geometry(shapely.Point()).is_empty
 
 
 def test_transform_points_outside_domain():

--- a/lib/cartopy/tests/test_geodesic.py
+++ b/lib/cartopy/tests/test_geodesic.py
@@ -6,7 +6,7 @@
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
 import pytest
-import shapely.geometry as sgeom
+import shapely
 
 from cartopy import geodesic
 
@@ -132,36 +132,36 @@ def test_geometry_length_ndarray():
 
 def test_geometry_length_linestring():
     geod = geodesic.Geodesic()
-    geom = sgeom.LineString(np.array([lhr, jfk, lhr]))
+    geom = shapely.LineString(np.array([lhr, jfk, lhr]))
     expected = pytest.approx(lhr_to_jfk * 2, abs=1)
     assert geod.geometry_length(geom) == expected
 
 
 def test_geometry_length_multilinestring():
     geod = geodesic.Geodesic()
-    geom = sgeom.MultiLineString(
-        [sgeom.LineString(np.array([lhr, jfk])),
-         sgeom.LineString(np.array([tul, jfk]))])
+    geom = shapely.MultiLineString(
+        [shapely.LineString(np.array([lhr, jfk])),
+         shapely.LineString(np.array([tul, jfk]))])
     expected = pytest.approx(lhr_to_jfk + jfk_to_tul, abs=1)
     assert geod.geometry_length(geom) == expected
 
 
 def test_geometry_length_linearring():
     geod = geodesic.Geodesic()
-    geom = sgeom.LinearRing(np.array([lhr, jfk, tul]))
+    geom = shapely.LinearRing(np.array([lhr, jfk, tul]))
     expected = pytest.approx(lhr_to_jfk + jfk_to_tul + tul_to_lhr, abs=1)
     assert geod.geometry_length(geom) == expected
 
 
 def test_geometry_length_polygon():
     geod = geodesic.Geodesic()
-    geom = sgeom.Polygon(np.array([lhr, jfk, tul]))
+    geom = shapely.Polygon(np.array([lhr, jfk, tul]))
     expected = pytest.approx(lhr_to_jfk + jfk_to_tul + tul_to_lhr, abs=1)
     assert geod.geometry_length(geom) == expected
 
 
 def test_geometry_length_point():
     geod = geodesic.Geodesic()
-    geom = sgeom.Point(lhr)
+    geom = shapely.Point(lhr)
     with pytest.raises(TypeError):
         geod.geometry_length(geom)

--- a/lib/cartopy/tests/test_img_nest.py
+++ b/lib/cartopy/tests/test_img_nest.py
@@ -14,7 +14,7 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from PIL import Image
 import pytest
-import shapely.geometry as sgeom
+import shapely
 
 from cartopy import config
 import cartopy.io.img_nest as cimg_nest
@@ -150,9 +150,9 @@ def test_intersect(tmp_path):
         assert image_names == fnames
 
     # Check image retrieval for specific domain.
-    items = [(sgeom.box(20, 20, 80, 80), 3),
-             (sgeom.box(20, 20, 75, 75), 1),
-             (sgeom.box(40, 40, 85, 85), 3)]
+    items = [(shapely.box(20, 20, 80, 80), 3),
+             (shapely.box(20, 20, 75, 75), 1),
+             (shapely.box(40, 40, 85, 85), 3)]
     for domain, expected in items:
         result = [image for image in nic.find_images(domain, 'dummy-z-2')]
         assert len(result) == expected

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -11,7 +11,7 @@ import warnings
 import numpy as np
 from numpy.testing import assert_array_almost_equal as assert_arr_almost
 import pytest
-import shapely.geometry as sgeom
+import shapely
 
 from cartopy.tests.conftest import _HAS_PYKDTREE_OR_SCIPY
 
@@ -99,7 +99,7 @@ def test_google_tile_styles():
 def test_google_wts():
     gt = cimgt.GoogleTiles()
 
-    ll_target_domain = sgeom.box(-15, 50, 0, 60)
+    ll_target_domain = shapely.box(-15, 50, 0, 60)
     multi_poly = gt.crs.project_geometry(ll_target_domain, ccrs.PlateCarree())
     target_domain = multi_poly.geoms[0]
 
@@ -136,7 +136,7 @@ def test_tile_bbox_y0_at_south_pole():
 def test_tile_find_images():
     gt = cimgt.GoogleTiles()
     # Test the find_images method on a GoogleTiles instance.
-    ll_target_domain = sgeom.box(-10, 50, 10, 60)
+    ll_target_domain = shapely.box(-10, 50, 10, 60)
     multi_poly = gt.crs.project_geometry(ll_target_domain, ccrs.PlateCarree())
     target_domain = multi_poly.geoms[0]
 
@@ -149,7 +149,7 @@ def test_image_for_domain():
     gt = cimgt.GoogleTiles()
     gt._image_url = types.MethodType(GOOGLE_IMAGE_URL_REPLACEMENT, gt)
 
-    ll_target_domain = sgeom.box(-10, 50, 10, 60)
+    ll_target_domain = shapely.box(-10, 50, 10, 60)
     multi_poly = gt.crs.project_geometry(ll_target_domain, ccrs.PlateCarree())
     target_domain = multi_poly.geoms[0]
 
@@ -166,7 +166,7 @@ def test_image_for_domain():
 def test_quadtree_wts():
     qt = cimgt.QuadtreeTiles()
 
-    ll_target_domain = sgeom.box(-15, 50, 0, 60)
+    ll_target_domain = shapely.box(-15, 50, 0, 60)
     multi_poly = qt.crs.project_geometry(ll_target_domain, ccrs.PlateCarree())
     target_domain = multi_poly.geoms[0]
 
@@ -430,7 +430,7 @@ def test_cache(cache_dir, tmp_path):
         gt = cimgt.GoogleTiles(cache=tmpdir_str)
     gt._image_url = types.MethodType(GOOGLE_IMAGE_URL_REPLACEMENT, gt)
 
-    ll_target_domain = sgeom.box(-10, 50, 10, 60)
+    ll_target_domain = shapely.box(-10, 50, 10, 60)
     multi_poly = gt.crs.project_geometry(ll_target_domain, ccrs.PlateCarree())
     target_domain = multi_poly.geoms[0]
 

--- a/lib/cartopy/tests/test_line_string.py
+++ b/lib/cartopy/tests/test_line_string.py
@@ -8,7 +8,7 @@ import time
 
 import numpy as np
 import pytest
-import shapely.geometry as sgeom
+import shapely
 
 import cartopy.crs as ccrs
 
@@ -26,7 +26,7 @@ class TestLineString:
 
         # Try all four combinations of valid/NaN vs valid/NaN.
         for start, end in itertools.product(start_points, end_points):
-            line_string = sgeom.LineString([start, end])
+            line_string = shapely.LineString([start, end])
             multi_line_string = projection.project_geometry(line_string)
             if start[0] == 130 and end[0] == 120:
                 expected = 0
@@ -46,7 +46,7 @@ class TestLineString:
         ]
 
         for coords, pieces in tests:
-            line_string = sgeom.LineString(coords)
+            line_string = shapely.LineString(coords)
             multi_line_string = projection.project_geometry(line_string)
             # from cartopy.tests.mpl import show
             # show(projection, multi_line_string)
@@ -54,7 +54,7 @@ class TestLineString:
 
     def test_split(self):
         projection = ccrs.Robinson(170.5)
-        line_string = sgeom.LineString([(-10, 30), (10, 60)])
+        line_string = shapely.LineString([(-10, 30), (10, 60)])
         multi_line_string = projection.project_geometry(line_string)
         # from cartopy.tests.mpl import show
         # show(projection, multi_line_string)
@@ -66,7 +66,7 @@ class TestLineString:
         # Because the south pole projects to an *enormous* circle
         # (radius ~ 1e23) this will take a *long* time to project if the
         # within-domain exactness criteria are used.
-        line_string = sgeom.LineString([(0, -90), (2, -90)])
+        line_string = shapely.LineString([(0, -90), (2, -90)])
         tgt_proj = ccrs.NorthPolarStereo()
         src_proj = ccrs.PlateCarree()
         cutoff_time = time.time() + 1
@@ -77,8 +77,8 @@ class TestLineString:
         # Check that the return type of project_geometry is a MultiLineString
         # and not an empty list
         multi_line_string = ccrs.Mercator().project_geometry(
-            sgeom.MultiLineString(), ccrs.PlateCarree())
-        assert isinstance(multi_line_string, sgeom.MultiLineString)
+            shapely.MultiLineString(), ccrs.PlateCarree())
+        assert isinstance(multi_line_string, shapely.MultiLineString)
 
 
 class FakeProjection(ccrs.PlateCarree):
@@ -94,11 +94,11 @@ class FakeProjection(ccrs.PlateCarree):
     def boundary(self):
         # XXX Should this be a LinearRing?
         w, h = self._half_width, self._half_height
-        return sgeom.LineString([(-w + self.left_offset, -h),
-                                 (-w + self.left_offset, h),
-                                 (w - self.right_offset, h),
-                                 (w - self.right_offset, -h),
-                                 (-w + self.left_offset, -h)])
+        return shapely.LineString([(-w + self.left_offset, -h),
+                                   (-w + self.left_offset, h),
+                                   (w - self.right_offset, h),
+                                   (w - self.right_offset, -h),
+                                   (-w + self.left_offset, -h)])
 
 
 class TestBisect:
@@ -107,48 +107,48 @@ class TestBisect:
 
     def test_repeated_point(self):
         projection = FakeProjection()
-        line_string = sgeom.LineString([(10, 0), (10, 0)])
+        line_string = shapely.LineString([(10, 0), (10, 0)])
         multi_line_string = projection.project_geometry(line_string)
         assert len(multi_line_string.geoms) == 1
         assert len(multi_line_string.geoms[0].coords) == 2
 
     def test_interior_repeated_point(self):
         projection = FakeProjection()
-        line_string = sgeom.LineString([(0, 0), (10, 0), (10, 0), (20, 0)])
+        line_string = shapely.LineString([(0, 0), (10, 0), (10, 0), (20, 0)])
         multi_line_string = projection.project_geometry(line_string)
         assert len(multi_line_string.geoms) == 1
         assert len(multi_line_string.geoms[0].coords) == 4
 
     def test_circular_repeated_point(self):
         projection = FakeProjection()
-        line_string = sgeom.LineString([(0, 0), (360, 0)])
+        line_string = shapely.LineString([(0, 0), (360, 0)])
         multi_line_string = projection.project_geometry(line_string)
         assert len(multi_line_string.geoms) == 1
         assert len(multi_line_string.geoms[0].coords) == 2
 
     def test_short(self):
         projection = FakeProjection()
-        line_string = sgeom.LineString([(0, 0), (1e-12, 0)])
+        line_string = shapely.LineString([(0, 0), (1e-12, 0)])
         multi_line_string = projection.project_geometry(line_string)
         assert len(multi_line_string.geoms) == 1
         assert len(multi_line_string.geoms[0].coords) == 2
 
     def test_empty(self):
         projection = FakeProjection(right_offset=10)
-        line_string = sgeom.LineString([(175, 0), (175, 10)])
+        line_string = shapely.LineString([(175, 0), (175, 10)])
         multi_line_string = projection.project_geometry(line_string)
         assert len(multi_line_string.geoms) == 0
 
     def test_simple_run_in(self):
         projection = FakeProjection(right_offset=10)
-        line_string = sgeom.LineString([(160, 0), (175, 0)])
+        line_string = shapely.LineString([(160, 0), (175, 0)])
         multi_line_string = projection.project_geometry(line_string)
         assert len(multi_line_string.geoms) == 1
         assert len(multi_line_string.geoms[0].coords) == 2
 
     def test_simple_wrap(self):
         projection = FakeProjection()
-        line_string = sgeom.LineString([(160, 0), (-160, 0)])
+        line_string = shapely.LineString([(160, 0), (-160, 0)])
         multi_line_string = projection.project_geometry(line_string)
         assert len(multi_line_string.geoms) == 2
         assert len(multi_line_string.geoms[0].coords) == 2
@@ -156,14 +156,14 @@ class TestBisect:
 
     def test_simple_run_out(self):
         projection = FakeProjection(left_offset=10)
-        line_string = sgeom.LineString([(-175, 0), (-160, 0)])
+        line_string = shapely.LineString([(-175, 0), (-160, 0)])
         multi_line_string = projection.project_geometry(line_string)
         assert len(multi_line_string.geoms) == 1
         assert len(multi_line_string.geoms[0].coords) == 2
 
     def test_point_on_boundary(self):
         projection = FakeProjection()
-        line_string = sgeom.LineString([(180, 0), (-160, 0)])
+        line_string = shapely.LineString([(180, 0), (-160, 0)])
         multi_line_string = projection.project_geometry(line_string)
         assert len(multi_line_string.geoms) == 1
         assert len(multi_line_string.geoms[0].coords) == 2
@@ -171,7 +171,7 @@ class TestBisect:
         # Add a small offset to the left-hand boundary to make things
         # even more pathological.
         projection = FakeProjection(left_offset=5)
-        line_string = sgeom.LineString([(180, 0), (-160, 0)])
+        line_string = shapely.LineString([(180, 0), (-160, 0)])
         multi_line_string = projection.project_geometry(line_string)
         assert len(multi_line_string.geoms) == 1
         assert len(multi_line_string.geoms[0].coords) == 2
@@ -179,7 +179,7 @@ class TestBisect:
     def test_nan_start(self):
         projection = ccrs.TransverseMercator(central_longitude=-90,
                                              approx=False)
-        line_string = sgeom.LineString([(10, 50), (-10, 30)])
+        line_string = shapely.LineString([(10, 50), (-10, 30)])
         multi_line_string = projection.project_geometry(line_string)
         assert len(multi_line_string.geoms) == 1
         for line_string in multi_line_string.geoms:
@@ -190,7 +190,7 @@ class TestBisect:
     def test_nan_end(self):
         projection = ccrs.TransverseMercator(central_longitude=-90,
                                              approx=False)
-        line_string = sgeom.LineString([(-10, 30), (10, 50)])
+        line_string = shapely.LineString([(-10, 30), (10, 50)])
         multi_line_string = projection.project_geometry(line_string)
         # from cartopy.tests.mpl import show
         # show(projection, multi_line_string)
@@ -206,8 +206,8 @@ class TestBisect:
     def test_nan_rectangular(self):
         # Make sure rectangular projections can handle invalid geometries
         projection = ccrs.Robinson()
-        line_string = sgeom.LineString([(0, 0), (1, 1), (np.nan, np.nan),
-                                        (2, 2), (3, 3)])
+        line_string = shapely.LineString([(0, 0), (1, 1), (np.nan, np.nan),
+                                          (2, 2), (3, 3)])
         multi_line_string = projection.project_geometry(line_string,
                                                         ccrs.PlateCarree())
         assert len(multi_line_string.geoms) == 2
@@ -217,7 +217,7 @@ class TestMisc:
     def test_misc(self):
         projection = ccrs.TransverseMercator(central_longitude=-90,
                                              approx=False)
-        line_string = sgeom.LineString([(10, 50), (-10, 30)])
+        line_string = shapely.LineString([(10, 50), (-10, 30)])
         multi_line_string = projection.project_geometry(line_string)
         # from cartopy.tests.mpl import show
         # show(projection, multi_line_string)
@@ -229,14 +229,14 @@ class TestMisc:
     def test_something(self):
         projection = ccrs.RotatedPole(pole_longitude=177.5,
                                       pole_latitude=37.5)
-        line_string = sgeom.LineString([(0, 0), (1e-14, 0)])
+        line_string = shapely.LineString([(0, 0), (1e-14, 0)])
         multi_line_string = projection.project_geometry(line_string)
         assert len(multi_line_string.geoms) == 1
         assert len(multi_line_string.geoms[0].coords) == 2
 
     def test_global_boundary(self):
-        linear_ring = sgeom.LineString([(-180, -180), (-180, 180),
-                                        (180, 180), (180, -180)])
+        linear_ring = shapely.LineString([(-180, -180), (-180, 180),
+                                          (180, 180), (180, -180)])
         pc = ccrs.PlateCarree()
         merc = ccrs.Mercator()
         multi_line_string = pc.project_geometry(linear_ring, merc)
@@ -253,11 +253,11 @@ class TestSymmetry:
         # Obtain a simple, curved path.
         projection = ccrs.PlateCarree()
         coords = [(-0.08, 51.53), (132.00, 43.17)]  # London to Vladivostock
-        line_string = sgeom.LineString(coords)
+        line_string = shapely.LineString(coords)
         multi_line_string = projection.project_geometry(line_string)
 
         # Compute the reverse path.
-        line_string = sgeom.LineString(coords[::-1])
+        line_string = shapely.LineString(coords[::-1])
         multi_line_string2 = projection.project_geometry(line_string)
 
         # Make sure that they generated the same points.

--- a/lib/cartopy/tests/test_linear_ring.py
+++ b/lib/cartopy/tests/test_linear_ring.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pytest
-import shapely.geometry as sgeom
+import shapely
 
 import cartopy.crs as ccrs
 
@@ -14,7 +14,7 @@ class TestBoundary:
     def test_cuts(self):
         # Check that fragments do not start or end with one of the
         # original ... ?
-        linear_ring = sgeom.LinearRing([(-10, 30), (10, 60), (10, 50)])
+        linear_ring = shapely.LinearRing([(-10, 30), (10, 60), (10, 50)])
         projection = ccrs.Robinson(170.5)
         *rings, multi_line_string = projection.project_geometry(linear_ring).geoms
 
@@ -26,7 +26,7 @@ class TestBoundary:
             # Are we close to the boundary, which we are considering within
             # a fraction of the x domain limits
             limit = (projection.x_limits[1] - projection.x_limits[0]) / 1e4
-            assert sgeom.Point(*xy).distance(projection.boundary) < limit, \
+            assert shapely.Point(*xy).distance(projection.boundary) < limit, \
                 'Bad topology near boundary'
 
         # Each line resulting from the split should be close to the boundary.
@@ -57,7 +57,7 @@ class TestBoundary:
 
         # Try all four combinations of valid/NaN vs valid/NaN.
         for coords, expected_n_lines in rings:
-            linear_ring = sgeom.LinearRing(coords)
+            linear_ring = shapely.LinearRing(coords)
             *rings, mlinestr = projection.project_geometry(linear_ring).geoms
             if expected_n_lines == -1:
                 assert rings
@@ -73,14 +73,14 @@ class TestMisc:
         # What happens when a small (i.e. < threshold) feature crosses the
         # boundary?
         projection = ccrs.Mercator()
-        linear_ring = sgeom.LinearRing([
+        linear_ring = shapely.LinearRing([
             (-179.9173693847652942, -16.5017831356493616),
             (-180.0000000000000000, -16.0671326636424396),
             (-179.7933201090486079, -16.0208822567412312),
         ])
         *rings, multi_line_string = projection.project_geometry(linear_ring).geoms
         # There should be one, and only one, returned ring.
-        assert isinstance(multi_line_string, sgeom.MultiLineString)
+        assert isinstance(multi_line_string, shapely.MultiLineString)
         assert len(multi_line_string.geoms) == 0
         assert len(rings) == 1
 
@@ -98,7 +98,7 @@ class TestMisc:
                   (0.000727869825138, -45.0),
                   (0.0, -45.000105851567454),
                   (0.0, -45.0)]
-        linear_ring = sgeom.LinearRing(coords)
+        linear_ring = shapely.LinearRing(coords)
         src_proj = ccrs.PlateCarree()
         target_proj = ccrs.PlateCarree(180.0)
         try:
@@ -128,13 +128,13 @@ class TestMisc:
         src_proj = ccrs.PlateCarree()
         target_proj = ccrs.Stereographic(80)
 
-        linear_ring = sgeom.LinearRing(coords)
+        linear_ring = shapely.LinearRing(coords)
         *rings, mlinestr = target_proj.project_geometry(linear_ring, src_proj).geoms
         assert len(mlinestr.geoms) == 1
         assert len(rings) == 0
 
         # Check the stitch works in either direction.
-        linear_ring = sgeom.LinearRing(coords[::-1])
+        linear_ring = shapely.LinearRing(coords[::-1])
         *rings, mlinestr = target_proj.project_geometry(linear_ring, src_proj).geoms
         assert len(mlinestr.geoms) == 1
         assert len(rings) == 0
@@ -157,7 +157,7 @@ class TestMisc:
              [183., -86.],
              [183., -78.],
              [177.5, -79.912]])
-        tring = sgeom.LinearRing(exterior)
+        tring = shapely.LinearRing(exterior)
 
         tcrs = ccrs.PlateCarree()
         scrs = ccrs.PlateCarree()

--- a/lib/cartopy/tests/test_polygon.py
+++ b/lib/cartopy/tests/test_polygon.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pytest
-import shapely.geometry as sgeom
+import shapely
 import shapely.wkt
 
 import cartopy.crs as ccrs
@@ -17,7 +17,7 @@ class TestBoundary:
         # ordering when they are attached to the boundary.
         # Failure to do so will result in invalid polygons (their boundaries
         # cross-over).
-        polygon = sgeom.Polygon([(-10, 30), (10, 60), (10, 50)])
+        polygon = shapely.Polygon([(-10, 30), (10, 60), (10, 50)])
         projection = ccrs.Robinson(170.5)
         multi_polygon = projection.project_geometry(polygon)
         for polygon in multi_polygon.geoms:
@@ -27,7 +27,7 @@ class TestBoundary:
         # Check the polygon is attached to the boundary even when no
         # intermediate point for one of the crossing segments would normally
         # exist.
-        polygon = sgeom.Polygon([(-10, 30), (10, 60), (10, 50)])
+        polygon = shapely.Polygon([(-10, 30), (10, 60), (10, 50)])
         projection = ccrs.Robinson(170.6)
         # This will raise an exception if the polygon/boundary intersection
         # fails.
@@ -51,7 +51,7 @@ class TestBoundary:
 
         # Try all four combinations of valid/NaN vs valid/NaN.
         for coords, expected_polys in polys:
-            polygon = sgeom.Polygon(coords)
+            polygon = shapely.Polygon(coords)
             multi_polygon = projection.project_geometry(polygon)
             assert len(multi_polygon.geoms) == expected_polys
 
@@ -60,12 +60,12 @@ class TestMisc:
     def test_misc(self):
         projection = ccrs.TransverseMercator(central_longitude=-90,
                                              approx=False)
-        polygon = sgeom.Polygon([(-10, 30), (10, 60), (10, 50)])
+        polygon = shapely.Polygon([(-10, 30), (10, 60), (10, 50)])
         projection.project_geometry(polygon)
 
     def test_small(self):
         projection = ccrs.Mercator()
-        polygon = sgeom.Polygon([
+        polygon = shapely.Polygon([
             (-179.7933201090486079, -16.0208822567412312),
             (-180.0000000000000000, -16.0671326636424396),
             (-179.9173693847652942, -16.5017831356493616),
@@ -81,7 +81,7 @@ class TestMisc:
                   (360.0, 77.76848175458498), (0.0, 88.79068047337279),
                   (210.0, 90.0), (135.0, 88.79068047337279),
                   (260.625, 68.90383337092122)]
-        geom = sgeom.Polygon(coords)
+        geom = shapely.Polygon(coords)
 
         target_projection = ccrs.PlateCarree()
         source_crs = ccrs.Geodetic()
@@ -141,7 +141,7 @@ class TestMisc:
             left,
             bottom,
         ])
-        bad_path = sgeom.Polygon(verts)
+        bad_path = shapely.Polygon(verts)
 
         target = proj()
         source = ccrs.PlateCarree()
@@ -168,9 +168,9 @@ class TestMisc:
 
     def test_3pt_poly(self):
         projection = ccrs.OSGB(approx=True)
-        polygon = sgeom.Polygon([(-1000, -1000),
-                                 (-1000, 200000),
-                                 (200000, -1000)])
+        polygon = shapely.Polygon([(-1000, -1000),
+                                   (-1000, 200000),
+                                   (200000, -1000)])
         multi_polygon = projection.project_geometry(polygon,
                                                     ccrs.OSGB(approx=True))
         assert len(multi_polygon.geoms) == 1
@@ -229,8 +229,8 @@ class TestMisc:
         source = ccrs.PlateCarree()
         target = ccrs.PlateCarree(central_longitude=180)
 
-        geom = sgeom.Polygon([(-20, -20), (20, -20), (20, 20), (-20, 20)],
-                             [[(-10, 0), (0, 20), (10, 0), (0, -20)]])
+        geom = shapely.Polygon([(-20, -20), (20, -20), (20, 20), (-20, 20)],
+                               [[(-10, 0), (0, 20), (10, 0), (0, -20)]])
         projected = target.project_geometry(geom, source)
 
         assert abs(1200 - projected.area) < 1e-5
@@ -239,9 +239,9 @@ class TestMisc:
         source = ccrs.PlateCarree()
         target = ccrs.PlateCarree(central_longitude=180)
 
-        geom = sgeom.Polygon([(-20, -20), (20, -20), (20, 20), (-20, 20)],
-                             [[(0, 0), (-10, 10), (0, 20), (10, 10)],
-                              [(0, 0), (10, -10), (0, -20), (-10, -10)]])
+        geom = shapely.Polygon([(-20, -20), (20, -20), (20, 20), (-20, 20)],
+                               [[(0, 0), (-10, 10), (0, 20), (10, 10)],
+                                [(0, 0), (10, -10), (0, -20), (-10, -10)]])
         projected = target.project_geometry(geom, source)
 
         assert abs(1200 - projected.area) < 1e-5
@@ -279,7 +279,7 @@ class TestMisc:
         target = ccrs.PlateCarree()
         # Before fixing, this would cause a segmentation fault.
         polygons = target.project_geometry(polygon, source)
-        assert isinstance(polygons, sgeom.MultiPolygon)
+        assert isinstance(polygons, shapely.MultiPolygon)
 
     def test_full_width_band_not_inverted(self):
         # A polygon spanning exactly ±180° longitude creates a projected ring
@@ -287,7 +287,7 @@ class TestMisc:
         # Shapely's is_ccw is unreliable for such rings; the shoelace signed
         # area must be used instead so the ring is classified correctly as an
         # interior (not an exterior) ring. See GH-2483.
-        north_tropic = sgeom.Polygon(
+        north_tropic = shapely.Polygon(
             [(-180, 0), (180, 0), (180, 20), (-180, 20)])
         proj = ccrs.Orthographic(central_longitude=0.0, central_latitude=90.0)
         result = proj.project_geometry(north_tropic, ccrs.PlateCarree())
@@ -295,8 +295,8 @@ class TestMisc:
         # Convert points we expect to be inside vs out and check the
         # containment of the result.
         src = ccrs.PlateCarree()
-        inside_band = sgeom.Point(proj.transform_point(0, 10, src))
-        outside_band = sgeom.Point(proj.transform_point(0, 45, src))
+        inside_band = shapely.Point(proj.transform_point(0, 10, src))
+        outside_band = shapely.Point(proj.transform_point(0, 45, src))
         assert result.contains(inside_band), \
             '(0°E, 10°N) should be inside the projected tropical band'
         assert not result.contains(outside_band), \
@@ -307,7 +307,7 @@ class TestQuality:
     def setup_class(self):
         projection = ccrs.RotatedPole(pole_longitude=177.5,
                                       pole_latitude=37.5)
-        polygon = sgeom.Polygon([
+        polygon = shapely.Polygon([
             (177.5, -57.38460319),
             (180.1, -57.445077),
             (175.0, -57.19913331),
@@ -364,7 +364,7 @@ class TestWrap(PolygonTests):
     # source data that extends outside the [-180, 180] range.
     def test_plate_carree_no_wrap(self):
         proj = ccrs.PlateCarree()
-        poly = sgeom.box(0, 0, 10, 10)
+        poly = shapely.box(0, 0, 10, 10)
         multi_polygon = proj.project_geometry(poly, proj)
         # Check the structure
         assert len(multi_polygon.geoms) == 1
@@ -374,7 +374,7 @@ class TestWrap(PolygonTests):
 
     def test_plate_carree_partial_wrap(self):
         proj = ccrs.PlateCarree()
-        poly = sgeom.box(170, 0, 190, 10)
+        poly = shapely.box(170, 0, 190, 10)
         multi_polygon = proj.project_geometry(poly, proj)
         # Check the structure
         assert len(multi_polygon.geoms) == 2
@@ -389,7 +389,7 @@ class TestWrap(PolygonTests):
 
     def test_plate_carree_wrap(self):
         proj = ccrs.PlateCarree()
-        poly = sgeom.box(200, 0, 220, 10)
+        poly = shapely.box(200, 0, 220, 10)
         multi_polygon = proj.project_geometry(poly, proj)
         # Check the structure
         assert len(multi_polygon.geoms) == 1
@@ -399,15 +399,15 @@ class TestWrap(PolygonTests):
 
 
 def ring(minx, miny, maxx, maxy, ccw):
-    box = sgeom.box(minx, miny, maxx, maxy, ccw)
+    box = shapely.box(minx, miny, maxx, maxy, ccw=ccw)
     return np.array(box.exterior.coords)
 
 
 class TestHoles(PolygonTests):
     def test_simple(self):
         proj = ccrs.PlateCarree()
-        poly = sgeom.Polygon(ring(-40, -40, 40, 40, True),
-                             [ring(-20, -20, 20, 20, False)])
+        poly = shapely.Polygon(ring(-40, -40, 40, 40, True),
+                               [ring(-20, -20, 20, 20, False)])
         multi_polygon = proj.project_geometry(poly)
         # Check the structure
         assert len(multi_polygon.geoms) == 1
@@ -419,8 +419,8 @@ class TestHoles(PolygonTests):
 
     def test_wrapped_poly_simple_hole(self):
         proj = ccrs.PlateCarree(-150)
-        poly = sgeom.Polygon(ring(-40, -40, 40, 40, True),
-                             [ring(-20, -20, 20, 20, False)])
+        poly = shapely.Polygon(ring(-40, -40, 40, 40, True),
+                               [ring(-20, -20, 20, 20, False)])
         multi_polygon = proj.project_geometry(poly)
         # Check the structure
         assert len(multi_polygon.geoms) == 2
@@ -440,8 +440,8 @@ class TestHoles(PolygonTests):
 
     def test_wrapped_poly_wrapped_hole(self):
         proj = ccrs.PlateCarree(-180)
-        poly = sgeom.Polygon(ring(-40, -40, 40, 40, True),
-                             [ring(-20, -20, 20, 20, False)])
+        poly = shapely.Polygon(ring(-40, -40, 40, 40, True),
+                               [ring(-20, -20, 20, 20, False)])
         multi_polygon = proj.project_geometry(poly)
         # Check the structure
         assert len(multi_polygon.geoms) == 2
@@ -455,8 +455,8 @@ class TestHoles(PolygonTests):
 
     def test_inverted_poly_simple_hole(self):
         proj = ccrs.NorthPolarStereo()
-        poly = sgeom.Polygon([(0, 0), (-90, 0), (-180, 0), (-270, 0)],
-                             [[(0, -30), (90, -30), (180, -30), (270, -30)]])
+        poly = shapely.Polygon([(0, 0), (-90, 0), (-180, 0), (-270, 0)],
+                               [[(0, -30), (90, -30), (180, -30), (270, -30)]])
         multi_polygon = proj.project_geometry(poly)
         # Check the structure
         assert len(multi_polygon.geoms) == 1
@@ -471,8 +471,8 @@ class TestHoles(PolygonTests):
         # Adapted from 1149
         proj = ccrs.LambertAzimuthalEqualArea(
             central_latitude=45, central_longitude=-100)
-        poly = sgeom.Polygon([(-180, -80), (180, -80), (180, 90), (-180, 90)],
-                             [[(-50, -50), (-50, 0), (0, 0), (0, -50)]])
+        poly = shapely.Polygon([(-180, -80), (180, -80), (180, 90), (-180, 90)],
+                               [[(-50, -50), (-50, 0), (0, 0), (0, -50)]])
         multi_polygon = proj.project_geometry(poly)
         # Should project to single polygon with multiple holes
         assert len(multi_polygon.geoms) == 1
@@ -481,17 +481,16 @@ class TestHoles(PolygonTests):
     def test_inverted_poly_merged_holes(self):
         proj = ccrs.LambertAzimuthalEqualArea(central_latitude=-90)
         pc = ccrs.PlateCarree()
-        poly = sgeom.Polygon([(-180, -80), (180, -80), (180, 90), (-180, 90)],
-                             [[(-50, 60), (-50, 80), (0, 80), (0, 60)],
-                              [(-50, 81), (-50, 85), (0, 85), (0, 81)]])
+        poly = shapely.Polygon([(-180, -80), (180, -80), (180, 90), (-180, 90)],
+                               [[(-50, 60), (-50, 80), (0, 80), (0, 60)],
+                                [(-50, 81), (-50, 85), (0, 85), (0, 81)]])
         # Smoke test that nearby holes do not cause side location conflict
         proj.project_geometry(poly, pc)
 
     def test_inverted_poly_clipped_hole(self):
         proj = ccrs.NorthPolarStereo()
-        poly = sgeom.Polygon([(0, 0), (-90, 0), (-180, 0), (-270, 0)],
-                             [[(-135, -60), (-45, -60),
-                               (45, -60), (135, -60)]])
+        poly = shapely.Polygon([(0, 0), (-90, 0), (-180, 0), (-270, 0)],
+                               [[(-135, -60), (-45, -60), (45, -60), (135, -60)]])
         multi_polygon = proj.project_geometry(poly)
         # Check the structure
         assert len(multi_polygon.geoms) == 1
@@ -505,9 +504,8 @@ class TestHoles(PolygonTests):
 
     def test_inverted_poly_removed_hole(self):
         proj = ccrs.NorthPolarStereo(globe=ccrs.Globe(ellipse='WGS84'))
-        poly = sgeom.Polygon([(0, 0), (-90, 0), (-180, 0), (-270, 0)],
-                             [[(-135, -75), (-45, -75),
-                               (45, -75), (135, -75)]])
+        poly = shapely.Polygon([(0, 0), (-90, 0), (-180, 0), (-270, 0)],
+                               [[(-135, -75), (-45, -75), (45, -75), (135, -75)]])
         multi_polygon = proj.project_geometry(poly)
         # Check the structure
         assert len(multi_polygon.geoms) == 1
@@ -523,7 +521,7 @@ class TestHoles(PolygonTests):
         exterior = ring(0, 0, 12, 12, True)
         interiors = [ring(1, 1, 2, 2, False), ring(1, 8, 2, 9, False)]
 
-        poly = sgeom.Polygon(exterior, interiors)
+        poly = shapely.Polygon(exterior, interiors)
 
         target = ccrs.PlateCarree()
         source = ccrs.Geodetic()
@@ -538,17 +536,17 @@ class TestHoles(PolygonTests):
         # Test data from the original bug report - a tiny patch near Antarctica
         # that crosses the antimeridian
         coords = np.array([
-            [-180.00020734,  -63.5383884 ],
-            [-179.93611911,  -63.61745971],
-            [-179.77001049,  -63.62512738],
-            [-179.67109735,  -63.55616224],
-            [-179.74190981,  -63.49385818],
-            [-179.91362571,  -63.48807984],
-            [-180.00020734,  -63.5383884 ],
-            [-180.00020734,  -63.5383884 ],
+            [-180.00020734, -63.53838840],
+            [-179.93611911, -63.61745971],
+            [-179.77001049, -63.62512738],
+            [-179.67109735, -63.55616224],
+            [-179.74190981, -63.49385818],
+            [-179.91362571, -63.48807984],
+            [-180.00020734, -63.53838840],
+            [-180.00020734, -63.53838840],
         ])
 
-        patch = sgeom.Polygon(coords)
+        patch = shapely.Polygon(coords)
         proj = ccrs.PlateCarree()
 
         # Project the geometry

--- a/lib/cartopy/tests/test_polygon.py
+++ b/lib/cartopy/tests/test_polygon.py
@@ -6,7 +6,6 @@
 import numpy as np
 import pytest
 import shapely
-import shapely.wkt
 
 import cartopy.crs as ccrs
 
@@ -91,7 +90,7 @@ class TestMisc:
         assert not multi_polygon.is_empty
 
     def test_project_previous_infinite_loop(self):
-        mstring1 = shapely.wkt.loads(
+        mstring1 = shapely.from_wkt(
             'MULTILINESTRING ('
             '(-179.9999990464349651 -80.2000000000000171, '
             '-179.5000000001111005 -80.2000000000000171, '
@@ -107,7 +106,7 @@ class TestMisc:
             '179.5000000000000000 -80.0999999999999943, '
             '179.5000000000000000 -80.2000000000000171, '
             '179.9999990463256836 -80.2000000000000171))')
-        mstring2 = shapely.wkt.loads(
+        mstring2 = shapely.from_wkt(
             'MULTILINESTRING ('
             '(179.9999996185302678 -79.9999999904632659, '
             '179.5999999999999943 -79.9899999999999949, '
@@ -188,7 +187,7 @@ class TestMisc:
                '366.74765799 -9.019999500000001, '
                '366.5094086 -9.63175386, '
                '366.22000122 -9.692636309999999))')
-        geom = shapely.wkt.loads(wkt)
+        geom = shapely.from_wkt(wkt)
         source, target = ccrs.RotatedPole(198.0, 39.25), ccrs.EuroPP()
         projected = target.project_geometry(geom, source)
         # Before handling self intersecting interiors, the area would be
@@ -202,7 +201,7 @@ class TestMisc:
         wkt = ('POLYGON ((343 20, 345 23, 342 25, 343 22, '
                '340 25, 341 25, 340 25, 343 20), (343 21, '
                '343 22, 344 23, 343 21))')
-        geom = shapely.wkt.loads(wkt)
+        geom = shapely.from_wkt(wkt)
         source = target = ccrs.RotatedPole(193.0, 41.0)
         projected = target.project_geometry(geom, source)
         # Before handling self intersecting interiors, the area would be
@@ -214,7 +213,7 @@ class TestMisc:
         target = ccrs.Orthographic(0, -75)
         source = ccrs.PlateCarree()
         wkt = 'POLYGON ((132 -40, 133 -6, 125.3 1, 115 -6, 132 -40))'
-        geom = shapely.wkt.loads(wkt)
+        geom = shapely.from_wkt(wkt)
 
         target = ccrs.Orthographic(central_latitude=90., central_longitude=0)
         source = ccrs.PlateCarree()
@@ -248,7 +247,7 @@ class TestMisc:
 
     def test_attach_short_loop(self):
         # Geometry comes from a matplotlib contourf.
-        mstring = shapely.wkt.loads(
+        mstring = shapely.from_wkt(
             'MULTILINESTRING ('
             '(-179.9999982118607 71.87500000000001,'
             '-179.0625 71.87500000000001,'
@@ -266,7 +265,7 @@ class TestMisc:
         # This test calls only the public API, but will cause a
         # segmentation fault when it fails.
         # Geometry comes from a matplotlib contourf.
-        polygon = shapely.wkt.loads(
+        polygon = shapely.from_wkt(
             'POLYGON (('
             '178.9687499944748 70.625, '
             '179.0625 71.875, '

--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -6,10 +6,10 @@
 # cython: embedsignature=True
 
 """
-Trace pulls together proj, GEOS and ``_crs.pyx`` to implement a function
-to project a `~shapely.geometry.LinearRing` / `~shapely.geometry.LineString`.
-In general, this should never be called manually, instead leaving the
-processing to be done by the :class:`cartopy.crs.Projection` subclasses.
+Trace pulls together proj, GEOS and ``_crs.pyx`` to implement a function to project a
+`~shapely.LinearRing` / `~shapely.LineString`. In general, this should never be called
+manually, instead leaving the processing to be done by the
+:class:`cartopy.crs.Projection` subclasses.
 """
 from __future__ import print_function
 
@@ -27,11 +27,9 @@ import warnings
 
 import numpy as np
 import shapely
-import shapely.geometry as sgeom
 import shapely.prepared as sprep
 from pyproj import Geod, Transformer, proj_version_str
 from pyproj.exceptions import ProjError
-import shapely.geometry as sgeom
 
 import cartopy.crs as ccrs
 
@@ -95,9 +93,9 @@ cdef class LineAccumulator:
         geoms = []
         for ilines in self.lines:
             coords = [(ipoints.x, ipoints.y) for ipoints in ilines]
-            geoms.append(sgeom.LineString(coords))
+            geoms.append(shapely.LineString(coords))
 
-        geom = sgeom.MultiLineString(geoms)
+        geom = shapely.MultiLineString(geoms)
         return geom
 
     cdef size_t size(self):
@@ -361,7 +359,7 @@ cdef bool straightAndDomain(double t_start, const Point &p_start,
             # TODO: Re-use geometries, instead of create-destroy!
 
             # Create a LineString for the current end-point.
-            g_segment = sgeom.LineString([
+            g_segment = shapely.LineString([
                 (p_start.x, p_start.y),
                 (p_end.x, p_end.y)])
 
@@ -535,7 +533,7 @@ def project_linear(geometry not None, src_crs not None,
 
     Parameters
     ----------
-    geometry : `shapely.geometry.LineString` or `shapely.geometry.LinearRing`
+    geometry : `shapely.LineString` or `shapely.LinearRing`
         A geometry to be projected.
     src_crs : cartopy.crs.CRS
         The coordinate system of the line to be projected.
@@ -544,7 +542,7 @@ def project_linear(geometry not None, src_crs not None,
 
     Returns
     -------
-    `shapely.geometry.MultiLineString`
+    `shapely.MultiLineString`
         The result of projecting the given geometry from the source projection
         into the destination projection.
 
@@ -573,7 +571,7 @@ def project_linear(geometry not None, src_crs not None,
     # TODO: Handle projections other than rectangular
     cdef bool geom_fully_inside = False
     if isinstance(dest_projection, (ccrs._RectangularProjection, ccrs._WarpedRectangularProjection)):
-        dest_line = sgeom.LineString([(x[0], x[1]) for x in dest_coords])
+        dest_line = shapely.LineString([(x[0], x[1]) for x in dest_coords])
         if dest_line.is_valid:
             # We can only check for covers with valid geometries
             # some have nans/infs at this point still

--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -11,8 +11,6 @@ Trace pulls together proj, GEOS and ``_crs.pyx`` to implement a function to proj
 manually, instead leaving the processing to be done by the
 :class:`cartopy.crs.Projection` subclasses.
 """
-from __future__ import print_function
-
 from functools import lru_cache
 
 cimport cython

--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -27,7 +27,6 @@ import warnings
 
 import numpy as np
 import shapely
-import shapely.prepared as sprep
 from pyproj import Geod, Transformer, proj_version_str
 from pyproj.exceptions import ProjError
 
@@ -245,7 +244,7 @@ cdef State get_state(const Point &point, object gp_domain, bool geom_fully_insid
         # Fast-path return because the geometry is fully inside
         return POINT_IN
     if isfinite(point.x) and isfinite(point.y):
-        state = POINT_IN if shapely.intersects_xy(gp_domain.context, point.x, point.y) else POINT_OUT
+        state = POINT_IN if shapely.intersects_xy(gp_domain, point.x, point.y) else POINT_OUT
     else:
         state = POINT_NAN
     return state
@@ -553,16 +552,15 @@ def project_linear(geometry not None, src_crs not None,
         object g_domain
         double[:, :] src_coords, dest_coords
         unsigned int src_size, src_idx
-        object gp_domain
         LineAccumulator lines
 
     g_domain = dest_projection.domain
+    shapely.prepare(g_domain)
 
     interpolator = _interpolator(src_crs, dest_projection)
 
     src_coords = np.asarray(geometry.coords)
     dest_coords = interpolator.project_points(src_coords)
-    gp_domain = sprep.prep(g_domain)
 
     src_size = len(src_coords)  # check exceptions
 
@@ -575,16 +573,14 @@ def project_linear(geometry not None, src_crs not None,
         if dest_line.is_valid:
             # We can only check for covers with valid geometries
             # some have nans/infs at this point still
-            geom_fully_inside = gp_domain.covers(dest_line)
+            geom_fully_inside = g_domain.covers(dest_line)
 
     lines = LineAccumulator()
     for src_idx in range(1, src_size):
         _project_segment(src_coords[src_idx - 1, :2], src_coords[src_idx, :2],
                          dest_coords[src_idx - 1, :2], dest_coords[src_idx, :2],
-                         interpolator, gp_domain, threshold, lines,
+                         interpolator, g_domain, threshold, lines,
                          geom_fully_inside=geom_fully_inside);
-
-    del gp_domain
 
     multi_line_string = lines.as_geom()
 
@@ -603,10 +599,9 @@ class _Testing:
         # optimisations that are made in the real algorithm (in exchange for
         # a convenient signature).
 
-        cdef object gp_domain
-        gp_domain = sprep.prep(domain)
+        shapely.prepare(domain)
 
-        state = get_state(interpolator.project(l_start), gp_domain)
+        state = get_state(interpolator.project(l_start), domain)
         cdef bool p_start_inside_domain = state == POINT_IN
 
         # l_end and l_start should be un-projected.
@@ -618,9 +613,8 @@ class _Testing:
         valid = straightAndDomain(
             t_start, p0, t_end, p1,
             interpolator, threshold,
-            gp_domain, p_start_inside_domain)
+            domain, p_start_inside_domain)
 
-        del gp_domain
         return valid
 
     @staticmethod


### PR DESCRIPTION
## Rationale

See individual commits for details, but the main points are:
- pyproj made `CustomConstructorCRS` public in 3.2, and we depend on 3.6.
- Many symbols in deeper modules have been exposed at the top-level `shapely` level with 2.0. While the former haven't been removed, they are no longer documented.

## Implications

Keeping up with documented interfaces makes it easier to cross-references and follow along with upstream examples/documentation. This also _fixes_ the cross-references in Sphinx to `shapely` stuff.