### PR TITLE
Update linting with prek, yamllint and zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    cooldown:
+      default-days: 7
     labels:
       - "🤖 Bot"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 # Reference:
 #   - https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot
 #   - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
+---
 version: 2
 updates:
 
@@ -10,5 +10,18 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    labels:
+      - "🤖 Bot"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      pre-commit:
+        patterns:
+          - "*"
     labels:
       - "🤖 Bot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 # Reference:
-#   - https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot
-#   - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 ---
 version: 2
 updates:

--- a/.github/workflows/ci-manifest.yml
+++ b/.github/workflows/ci-manifest.yml
@@ -1,6 +1,7 @@
 # Reference:
 #   - https://github.com/actions/checkout
 
+---
 name: ci-manifest
 
 on:

--- a/.github/workflows/ci-manifest.yml
+++ b/.github/workflows/ci-manifest.yml
@@ -15,6 +15,8 @@ on:
 
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -30,9 +32,10 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: "check-manifest"
         run: |

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -1,3 +1,4 @@
+---
 name: Tests
 
 on:
@@ -42,7 +43,8 @@ jobs:
           (github.event_name == 'push' || github.event_name == 'pull_request')
         id: minimum-packages
         run: |
-          pip install cython==3.0 matplotlib==3.8 numpy==1.26 owslib==0.29 pyproj==3.6 scipy==1.11 shapely==2.0 pyshp==2.3.1
+          pip install cython==3.0 matplotlib==3.8 numpy==1.26 owslib==0.29 pyproj==3.6 pyshp==2.3.1 scipy==1.11 \
+            shapely==2.0
 
       - name: Coverage packages
         id: coverage
@@ -61,7 +63,9 @@ jobs:
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
           # Install Nightly builds from Scientific Python
-          python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib pyproj scipy shapely
+          python -m pip install --pre \
+            --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+            matplotlib pyproj scipy shapely
 
       - name: Install Cartopy
         id: install

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -9,6 +9,8 @@ on:
     - cron: "0 0 10 * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   tests:
     if: github.repository == 'scitools/cartopy'
@@ -27,12 +29,13 @@ jobs:
             use-network: false
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -120,7 +123,7 @@ jobs:
           coveralls --service=github
 
       - name: Upload image results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: failure()
         with:
           name: image-failures-${{ matrix.os }}-${{ matrix.python-version }}
@@ -137,7 +140,7 @@ jobs:
 
     steps:
       - name: Create issue on failure
-        uses: imjohnbo/issue-bot@v3
+        uses: imjohnbo/issue-bot@3188c6ce06249206709d3b1f274d0d4c5a521601  # v3.4.5
         with:
           title: "[TST] Upcoming dependency test failures"
           body: |
@@ -162,12 +165,13 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v4
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5  # v4.0.1
         with:
           auto-update-conda: true
           python-version: '3.14'
@@ -194,7 +198,7 @@ jobs:
               --mpl-results-path="cartopy_test_output-conda"
 
       - name: Upload image results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: failure()
         with:
           name: image-failures-conda

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,23 @@
+---
+name: Linting
+on: [pull_request]
+
+permissions: {}
+
+jobs:
+  pre-commit:
+    name: precommit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.x"
+      - uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d  # v2.0.5
+        with:
+          extra-args: --hook-stage manual --all-files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           path: dist
 
       - name: Build wheels for CPython
-        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55  # v4.1.0
         with:
           package-dir: dist/${{ needs.build_sdist.outputs.SDIST_NAME }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,13 @@ jobs:
       SDIST_NAME: ${{ steps.sdist.outputs.SDIST_NAME }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           # We need the full history to generate the proper version number
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         name: Install Python
         with:
           python-version: '3.11'
@@ -61,7 +62,7 @@ jobs:
         run: twine check dist/*
 
       - name: Upload sdist result
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
@@ -90,7 +91,7 @@ jobs:
 
     steps:
       - name: Download sdist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: cibw-sdist
           path: dist
@@ -103,7 +104,7 @@ jobs:
           CIBW_SKIP: "*_i686 cp3*t-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ matrix.cibw_archs }}
           path: ./wheelhouse/*.whl
@@ -123,11 +124,11 @@ jobs:
 
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: cibw-*
           path: dist
           merge-multiple: true
 
       - name: Publish Package
-        uses: pypa/gh-action-pypi-publish@v1.14.1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,6 @@
+---
+rules:
+  template-injection:
+    ignore:
+      # Remove after https://github.com/zizmorcore/zizmor/issues/2197
+      - ci-testing.yml:77:20

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,3 +46,7 @@ repos:
     hooks:
       - id: yamllint
         args: ["--strict", "--config-file=.yamllint.yml"]
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: a4727cbbcd26d7098e96b9cb738169b59711ae51  # frozen: v1.24.1
+    hooks:
+      - id: zizmor

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 ci:
   autofix_prs: false
   autoupdate_schedule: 'quarterly'
@@ -5,32 +6,31 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
-        # Prevent giant files from being committed
+      # Prevent giant files from being committed
       - id: check-added-large-files
-        # Check whether files parse as valid Python
+      # Check whether files parse as valid Python
       - id: check-ast
-        # Check for files that contain merge conflict strings
+      # Check for files that contain merge conflict strings
       - id: check-merge-conflict
-        # Attempts to load all TOML files to verify syntax
+      # Attempts to load all TOML files to verify syntax
       - id: check-toml
-        # Attempts to load all yaml files to verify syntax
+      # Attempts to load all yaml files to verify syntax
       - id: check-yaml
-        # Check for debugger imports and py37+ breakpoint() calls in python source
+      # Check for debugger imports and py37+ breakpoint() calls in python source
       - id: debug-statements
-        # Makes sure files end in a newline and only a newline
+      # Makes sure files end in a newline and only a newline
       - id: end-of-file-fixer
-        # Replaces or checks mixed line ending
+      # Replaces or checks mixed line ending
       - id: mixed-line-ending
-        # Protect specific branches from direct checkins (main)
+      # Protect specific branches from direct checkins (main)
       - id: no-commit-to-branch
-        # Trims trailing whitespace
+      # Trims trailing whitespace
       - id: trailing-whitespace
   - repo: https://github.com/codespell-project/codespell
     rev: 2ccb47ff45ad361a21071a7eedda4c37e6ae8c5a  # frozen: v2.4.2
     hooks:
-    - id: codespell
-      types_or: [python, markdown, rst]
-      additional_dependencies: [tomli]
+      - id: codespell
+        types_or: [python, markdown, rst]
   - repo: https://github.com/aio-libs/sort-all
     rev: 5d8f20f6bb58adc5f2d74542bdfade65a0244366  # frozen: v1.3.0
     hooks:
@@ -39,5 +39,10 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: c59bba8fb259db0fec2bbb77ad8ba51ea7341b56  # frozen: v0.15.20
     hooks:
-    - id: ruff-check
-      args: [--fix]
+      - id: ruff-check
+        args: [--fix]
+  - repo: https://github.com/adrienverge/yamllint
+    rev: cba56bcde1fdd01c1deb3f945e69764c291a6530  # frozen: v1.38.0
+    hooks:
+      - id: yamllint
+        args: ["--strict", "--config-file=.yamllint.yml"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
   autoupdate_schedule: 'quarterly'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v6.0.0"
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
         # Prevent giant files from being committed
       - id: check-added-large-files
@@ -26,18 +26,18 @@ repos:
         # Trims trailing whitespace
       - id: trailing-whitespace
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.4.2"
+    rev: 2ccb47ff45ad361a21071a7eedda4c37e6ae8c5a  # frozen: v2.4.2
     hooks:
     - id: codespell
       types_or: [python, markdown, rst]
       additional_dependencies: [tomli]
   - repo: https://github.com/aio-libs/sort-all
-    rev: "v1.3.0"
+    rev: 5d8f20f6bb58adc5f2d74542bdfade65a0244366  # frozen: v1.3.0
     hooks:
       - id: sort-all
         types: [file, python]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.15.20'
+    rev: c59bba8fb259db0fec2bbb77ad8ba51ea7341b56  # frozen: v0.15.20
     hooks:
     - id: ruff-check
       args: [--fix]

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 
 build:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,9 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    allow-non-breakable-words: true
+  truthy:
+    check-keys: false

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ include .gitattributes
 include .gitignore
 exclude .pre-commit-config.yaml
 exclude .readthedocs.yml
+exclude .yamllint.yml
 include CHANGES
 include LICENSE
 include environment.yml

--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@
  alt="zenodo" /></a>
 <a href="https://discourse.matplotlib.org/chat/c/cartopy/11">
 <img src="https://img.shields.io/badge/chat-Discourse-brightgreen" alt="Discourse Chat" /></a>
-<a href="https://results.pre-commit.ci/latest/github/SciTools/cartopy/main">
-<img src="https://results.pre-commit.ci/badge/github/SciTools/cartopy/main.svg"
- alt="pre-commit.ci" /></a>
 </p>
 <br>
 

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -30,8 +30,8 @@ to install all of the required dependencies
   # Install cartopy
   pip install -e .
 
-  # Optionally install pre-commit to help with linting
-  pre-commit install
+  # Optionally install prek to help with linting
+  prek install
 
 This will install all of the required dependencies for compiling the code, running the tests, and
 building the documentation. Remember to activate the `cartopy-dev` environment.

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@
 #   conda activate cartopy-dev
 #   pip install -e .
 #
+---
 name: cartopy-dev
 channels:
   - conda-forge
@@ -38,7 +39,7 @@ dependencies:
   - sphinx-gallery
   # Extras
   - fiona
-  - pre-commit
+  - prek
   - pykdtree
   - ruff
   - setuptools_scm


### PR DESCRIPTION
## Rationale

Like Matplotlib did before, switch from pre-commit to prek. Also add yamllint and zizmor, fixing issues pointed out by them.

## Implications

Faster pre-commit checks, more secure workflows, etc.

However, due to https://github.com/zizmorcore/zizmor/issues/2197 we may not want to merge this just yet. I've put it in draft for now.