### PR TITLE
Skip title positioning logic when there are no titles

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -514,6 +514,12 @@ class GeoAxes(matplotlib.axes.Axes):
         if self._autotitlepos is not None and not self._autotitlepos:
             return
 
+        titles = (self.title, self._left_title, self._right_title)
+
+        if not any(title.get_text() for title in titles):
+            # If the titles are all empty, there is no need to update their positions.
+            return
+
         from cartopy.mpl.gridliner import Gridliner
         gridliners = [a for a in self.artists if isinstance(a, Gridliner)]
         if not gridliners:
@@ -542,7 +548,6 @@ class GeoAxes(matplotlib.axes.Axes):
             return
 
         # Loop on titles to adjust
-        titles = (self.title, self._left_title, self._right_title)
         for title in titles:
             x, y0 = title.get_position()
             y = max(1.0, yn)


### PR DESCRIPTION
<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale

<!-- Please provide detail as to *why* you are making this change. -->
There is no point in adjusting title positions if the title strings are empty.  I started looking at this a couple of years ago but then fell down the rabbit hole of https://github.com/matplotlib/matplotlib/pull/28300 and forgot to come back and do it here!

## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
GeoAxes without titles should draw a little quicker, and not be affected next time a bug appears in the title positioning logic (e.g. #2682).

<!--
## Checklist

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.

 * Note that you will automatically be asked to sign the
   [Contributor Licence Agreement](https://cla-assistant.io/SciTools/)
   (CLA), if you have not already done so.

-->
