### PR TITLE
Disable pickling for LineAccumulator

### DIFF
--- a/lib/cartopy/trace.pyx
+++ b/lib/cartopy/trace.pyx
@@ -47,6 +47,7 @@ cdef bool close(double a, double b):
 
 
 @cython.final
+@cython.auto_pickle(False)
 cdef class LineAccumulator:
     cdef list[Line] lines
 


### PR DESCRIPTION
## Rationale

There's not really any useful API here for Python, and we should probably deprecate access entirely, but disabling pickling will fix building with Cython 3.3.0

## Implications

Fixes #2722