### PR TITLE
Fix deepcopy/pickle of CRS subclasses created from WKT

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -118,6 +118,12 @@ class Globe:
         return OrderedDict((k, v) for k, v in proj4_params if v is not None)
 
 
+def _CRS_reconstruct(cls, state):
+    obj = cls.__new__(cls)
+    obj.__setstate__(state)
+    return obj
+
+
 class CRS(pyproj.crs.CustomConstructorCRS):
     """
     Define a Coordinate Reference System using proj. The :class:`cartopy.crs.CRS`
@@ -214,11 +220,9 @@ class CRS(pyproj.crs.CustomConstructorCRS):
             # State can be reproduced by the proj4_params and globe inputs.
             return self.__class__, self.input
         else:
-            # Produces a stateless instance of this class (e.g. an empty tuple).
-            # The state will then be added via __getstate__ and __setstate__.
-            # We are forced to this approach because a CRS does not store
-            # the constructor keyword arguments in its state.
-            return self.__class__, (), self.__getstate__()
+            # Use a factory that calls __new__ then __setstate__, avoiding
+            # __init__ which subclasses may not support with zero arguments.
+            return _CRS_reconstruct, (self.__class__, self.__getstate__())
 
     def __getstate__(self):
         """Return the full state of this instance for reconstruction
@@ -232,7 +236,7 @@ class CRS(pyproj.crs.CustomConstructorCRS):
         # be re-created (in __setstate__) from the other arguments.
         state.pop('proj4', None)
         state.pop('proj4_init', None)
-        state['proj4_params'] = self.proj4_params
+        state['proj4_params'] = self.proj4_params or self.proj4_init
         return state
 
     def __setstate__(self, state):

--- a/lib/cartopy/tests/test_crs.py
+++ b/lib/cartopy/tests/test_crs.py
@@ -255,7 +255,8 @@ class TestCRS:
     [ccrs.NorthPolarStereo, dict(central_longitude=42.5,
                                  globe=ccrs.Globe(ellipse="helmert"))],
     [ccrs.CRS, dict(proj4_params="3088")],
-    [ccrs.epsg, dict(code="3088")]
+    [ccrs.epsg, dict(code="3088")],
+    [ccrs.Projection, dict(proj4_params=pyproj.CRS.from_epsg(4326))],
 ])
 def proj_to_copy(request):
     cls, kwargs = request.param


### PR DESCRIPTION
## Rationale
Fixes: #2571

### The code to exercise:
```python
import copy
import cartopy.crs as ccrs
from pyproj import CRS

copy.deepcopy(ccrs.Projection(CRS.from_epsg(4326)))
```

### Before fix
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[1], line 5
      2 import cartopy.crs as ccrs
      3 from pyproj import CRS
----> 5 copy.deepcopy(ccrs.Projection(CRS.from_epsg(4326)))

File ~/micromamba/envs/pycodas/lib/python3.11/copy.py:172, in deepcopy(x, memo, _nil)
    170                 y = x
    171             else:
--> 172                 y = _reconstruct(x, memo, *rv)
    174 # If is its own copy, don't memoize.
    175 if y is not x:

File ~/micromamba/envs/pycodas/lib/python3.11/copy.py:265, in _reconstruct(x, memo, func, args, state, listiter, dictiter, deepcopy)
    263 if deep and args:
    264     args = (deepcopy(arg, memo) for arg in args)
--> 265 y = func(*args)
    266 if deep:
    267     memo[id(x)] = y

File ~/project/cartopy/lib/cartopy/crs.py:670, in Projection.__init__(self, *args, **kwargs)
    669 def __init__(self, *args, **kwargs):
--> 670     super().__init__(*args, **kwargs)
    671     self.bounds = None
    672     if self.area_of_use:
    673         # Convert lat/lon bounds to projected bounds.
    674         # Geographic area of the entire dataset referenced to WGS 84
    675         # NB. We can't use a polygon transform at this stage because
    676         # that relies on the existence of the map boundary... the very
    677         # thing we're trying to work out! ;-)

TypeError: CRS.__init__() missing 1 required positional argument: 'proj4_params'
```

### After Fix
```
Out[1]:
<Geographic 2D CRS: EPSG:4326>
Name: WGS 84
Axis Info [ellipsoidal]:
- Lat[north]: Geodetic latitude (degree)
- Lon[east]: Geodetic longitude (degree)
Area of Use:
- name: World.
- bounds: (-180.0, -90.0, 180.0, 90.0)
Datum: World Geodetic System 1984 ensemble
- Ellipsoid: WGS 84
- Prime Meridian: Greenwich
```


## Implications
`__new__` skips `__init__`, so any `__init__` side effects run only from `__setstate__`   (which calls `CRS.__init__`).

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
