### PR TITLE
img_tiles.py: Add Defaults 'RGBA' for 'only_streets'

### DIFF
--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -273,7 +273,7 @@ class GoogleWTS(metaclass=ABCMeta):
 
 class GoogleTiles(GoogleWTS):
     def __init__(self,
-                 desired_tile_form='RGB',
+                 desired_tile_form=None,
                  style="street",
                  url=('https://mts0.google.com/vt/lyrs={style}'
                       '@177000000&hl=en&src=api&x={x}&y={y}&z={z}&s=G'),
@@ -282,7 +282,9 @@ class GoogleTiles(GoogleWTS):
         Parameters
         ----------
         desired_tile_form : str, optional
-            The desired format of the tile (defaults to "RGB").
+            The desired format of the tile. Defaults to "RGBA" for the
+            'only_streets' style to preserve transparency, and "RGB"
+            for all other styles.
         style : str, optional
             The style for the Google Maps tiles.  One of 'street',
             'satellite', 'terrain', and 'only_streets'.  Defaults to 'street'.
@@ -313,6 +315,12 @@ class GoogleTiles(GoogleWTS):
             raise ValueError(
                 f"The {style!r} style requires pillow with jpeg decoding "
                 "support.")
+        if desired_tile_form is None:
+            if style == "only_streets":
+                desired_tile_form = "RGBA"
+            else:
+                desired_tile_form = "RGB"
+
         super().__init__(style=style,
                          desired_tile_form=desired_tile_form, cache=cache)
 

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -96,6 +96,18 @@ def test_google_tile_styles():
         cimgt.GoogleTiles(style="random_style")
 
 
+def test_google_tiles_desired_tile_form_defaults():
+    '''
+    See issue https://github.com/SciTools/cartopy/issues/762
+
+    Before this only_streets would have a black background not
+    a map.  the RGBA makes it see through so the map is visible
+    '''
+    assert cimgt.GoogleTiles().desired_tile_form == "RGB"
+    assert cimgt.GoogleTiles(style="only_streets").desired_tile_form == "RGBA"
+    assert cimgt.GoogleTiles(desired_tile_form="L").desired_tile_form == "L"
+
+
 def test_google_wts():
     gt = cimgt.GoogleTiles()
 


### PR DESCRIPTION
## Rationale
Fixes: #762

### Code to exercise change:
```python
import matplotlib.pyplot as plt
import cartopy.crs as ccrs
from cartopy.io import img_tiles

tiles_sat = img_tiles.GoogleTiles(style='satellite')
tiles_str = img_tiles.GoogleTiles(style='only_streets')

ax = plt.axes(projection=tiles_sat.crs)
ax.set_extent([31, 35.5, 34, 36], ccrs.Geodetic())
ax.add_image(tiles_sat, 8)
ax.add_image(tiles_str, 8)
plt.title('Cyprus - Hybrid (satellite + streets overlay)')
plt.show()
```

### Output before change
<img width="500" height="301" alt="image" src="https://github.com/user-attachments/assets/5efb4522-2636-407c-9120-6e8a2ce5910d" />

### Output after change
<img width="498" height="306" alt="image" src="https://github.com/user-attachments/assets/9643510f-6650-4533-9c30-8fe4b32b4b0c" />

## Implications
With this setup it only affects when `style='only_streets'`.  It might be cleaner to just change the default itself to RGBA like below:

```python
....
class GoogleTiles(GoogleWTS):
    def __init__(self,
                 desired_tile_form='RGBA',
                 style="street",
                 url=('https://mts0.google.com/vt/lyrs={style}'
...
```

Let me know if this is your preference.

It does look like for stadia the just set all defaults to RGBA https://github.com/SciTools/cartopy/pull/2269