### PR TITLE
TST: recognise a git worktree in the license header check

### DIFF
--- a/lib/cartopy/tests/test_coding_standards.py
+++ b/lib/cartopy/tests/test_coding_standards.py
@@ -48,8 +48,8 @@ class TestLicenseHeaders:
             or cannot be found by subprocess, an IOError may also be raised.
 
         """
-        # Check the ".git" folder exists at the repo dir.
-        if not (REPO_DIR / '.git').is_dir():
+        # Check the repo dir is under git.
+        if not (REPO_DIR / '.git').exists():
             raise ValueError(f'{REPO_DIR} is not a git repository.')
 
         output = subprocess.check_output(['git', 'ls-tree', '-z', '-r',


### PR DESCRIPTION
I've started using worktrees a lot more now and this test was being skipped unnecessarily.