### PR TITLE
Fix boundary flooding when panning axes with a non-data-transform boundary

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -203,6 +203,7 @@ class _ViewClippedPathPatch(mpatches.PathPatch):
         self._original_path = mpath.Path(np.empty((0, 2)))
         super().__init__(self._original_path, **kwargs)
         self._axes = axes
+        self._boundary_in_data_coords = True
 
         # We need to use a TransformWrapper as our transform so that we can
         # update the transform without breaking others' references to this one.
@@ -214,14 +215,19 @@ class _ViewClippedPathPatch(mpatches.PathPatch):
 
     def set_boundary(self, path, transform):
         self._original_path = cpath._ensure_path_closed(path)
+        # viewLim is in data coordinates, so only clip to it when the
+        # boundary itself is in data coordinates.
+        self._boundary_in_data_coords = transform is self._axes.transData
         self.set_transform(transform)
         self.stale = True
 
     def _adjust_location(self):
         if self.stale:
-            self.set_path(
-                cpath._ensure_path_closed(
-                    self._original_path.clip_to_bbox(self.axes.viewLim)))
+            path = self._original_path
+            if self._boundary_in_data_coords:
+                path = cpath._ensure_path_closed(
+                    path.clip_to_bbox(self.axes.viewLim))
+            self.set_path(path)
             # Some places in matplotlib's transform stack cache the actual
             # path so we trigger an update by invalidating the transform.
             self._trans_wrap.invalidate()
@@ -235,20 +241,24 @@ class _ViewClippedPathPatch(mpatches.PathPatch):
 class GeoSpine(mspines.Spine):
     def __init__(self, axes, **kwargs):
         self._original_path = mpath.Path(np.empty((0, 2)))
+        self._boundary_in_data_coords = True
         kwargs.setdefault('clip_on', False)
         super().__init__(axes, 'geo', self._original_path, **kwargs)
 
     def set_boundary(self, path, transform):
         # Make sure path is closed (required by "Path.clip_to_bbox")
         self._original_path = cpath._ensure_path_closed(path)
+        self._boundary_in_data_coords = transform is self.axes.transData
         self.set_transform(transform)
         self.stale = True
 
     def _adjust_location(self):
         if self.stale:
-            self._path = cpath._ensure_path_closed(
-                self._original_path.clip_to_bbox(self.axes.viewLim)
-                )
+            path = self._original_path
+            if self._boundary_in_data_coords:
+                path = cpath._ensure_path_closed(
+                    path.clip_to_bbox(self.axes.viewLim))
+            self._path = path
 
     def get_window_extent(self, renderer=None):
         # make sure the location is updated so that transforms etc are

--- a/lib/cartopy/tests/mpl/test_axes.py
+++ b/lib/cartopy/tests/mpl/test_axes.py
@@ -156,6 +156,35 @@ def test_geoaxes_set_boundary_clipping():
     return fig
 
 
+def test_geoaxes_set_boundary_survives_panning():
+    """A transAxes boundary must survive panning far from the initial view."""
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1, projection=ccrs.SouthPolarStereo())
+    ax.set_extent([-180, 180, -90, -60], ccrs.PlateCarree())
+    circle = mpath.Path.circle(center=(0.5, 0.5), radius=0.5)
+    ax.set_boundary(circle, transform=ax.transAxes)
+
+    xlim0 = ax.get_xlim()
+    ylim0 = ax.get_ylim()
+    width = xlim0[1] - xlim0[0]
+    height = ylim0[1] - ylim0[0]
+
+    # Pan well past the initial view.
+    ax.set_xlim(xlim0[0] - width, xlim0[1] - width)
+    ax.set_ylim(ylim0[0] + height, ylim0[1] + height)
+
+    fig.draw_without_rendering()
+
+    for artist in (ax.patch, ax.spines['geo']):
+        path = artist.get_path()
+        assert len(path.vertices) > 0
+        bbox = path.get_extents()
+        assert bbox.x0 == pytest.approx(0, abs=1e-9)
+        assert bbox.x1 == pytest.approx(1, abs=1e-9)
+        assert bbox.y0 == pytest.approx(0, abs=1e-9)
+        assert bbox.y1 == pytest.approx(1, abs=1e-9)
+
+
 def test_shared_axes_zoom_propagation():
     fig = plt.figure()
     proj = ccrs.PlateCarree()


### PR DESCRIPTION
_ViewClippedPathPatch and GeoSpine clipped a custom set_boundary() path against axes.viewLim (data coordinates) unconditionally, even when the path was given in a different transform (e.g. transAxes). Panning far enough made the clip produce an empty path, which disabled clipping and let features flood the whole figure.

Noticed this while panning around on the example `always_circular_stereo.py` on main where it would invert itself with a flood if you go up and left or down and right far enough.