### PR TITLE
crs.py: reduce epislon floating point

### DIFF
--- a/lib/cartopy/crs.py
+++ b/lib/cartopy/crs.py
@@ -759,7 +759,7 @@ class Projection(CRS, metaclass=ABCMeta):
     def _determine_longitude_bounds(self, central_longitude):
         # In new proj, using exact limits will wrap-around, so subtract a
         # small epsilon:
-        epsilon = 1e-10
+        epsilon = 1e-7
         minlon = -180 + central_longitude
         maxlon = 180 + central_longitude
         if central_longitude > 0:
@@ -2656,7 +2656,7 @@ class InterruptedGoodeHomolosine(Projection):
             raise ValueError(msg)
 
         minlon, maxlon = self._determine_longitude_bounds(central_longitude)
-        epsilon = 1e-10
+        epsilon = 1e-7
 
         # Obtain boundary points
         n = 31

--- a/lib/cartopy/tests/crs/test_mercator.py
+++ b/lib/cartopy/tests/crs/test_mercator.py
@@ -92,3 +92,16 @@ def test_scale_factor():
 
     assert_almost_equal(crs.boundary.bounds,
                         [-18808021, -14585266, 18808021, 17653216], decimal=0)
+
+
+def test_high_precision_central_longitude():
+    '''
+    For the fix to github issue #2576
+
+    How precise should we accept as an input to a map?
+    '''
+    clon = -169.40000000042403
+    proj = ccrs.Mercator(central_longitude=clon, max_latitude=54.11250000143449)
+    bounds = proj.boundary.bounds
+    width = bounds[2] - bounds[0]
+    assert width > 1, f"Boundary width {width} is to small small"


### PR DESCRIPTION
## Rationale
Fixes: #2576

### the code to exercise (mostly ripped from the issue)
```python
import cartopy.crs as ccrs
import numpy as np

bounds = (
    -172.32916666697352,
    -166.4708333338745,
    50.50416666824549,
    54.11250000143449,
)
xmin, xmax, ymin, ymax = bounds
clon = (xmin + xmax) / 2

print(f"central_longitude (high precision): {clon}")

proj = ccrs.Mercator(
    central_longitude=clon,
    max_latitude=ymax,
    globe=None,
)

b = proj.boundary.bounds
width = b[2] - b[0]
print(f"Boundary bounds: {b}")
print(f"Width: {width} this to small")

print()

new_clon = np.round(clon, decimals=2)
print(f"central_longitude (rounded): {new_clon}")

proj2 = ccrs.Mercator(
    central_longitude=new_clon,
    max_latitude=ymax,
    globe=None,
)

b2 = proj2.boundary.bounds
width2 = b2[2] - b2[0]
print(f"Boundary bounds: {b2}")
print(f"Width: {width2} this correct")
```

### Output Before Fix
```
central_longitude (high precision): -169.40000000042403
Boundary bounds: (-20037508.331704494, -15496570.739723718, 20037508.34274204, 7156848.148765069)
Width: 1.1127442121505737e-05 this to small

central_longitude (rounded): -169.4
Boundary bounds: (-20037508.331657287, -15496570.739723718, 20037508.342789244, 7156848.148765069)
Width: 40075016.67444653 this correct
```

### Output After Fix
```
central_longitude (high precision): -169.40000000042403
Boundary bounds: (-20037508.331704494, -15496570.739723718, 20037508.34274204, 7156848.148765069)
Width: 40075016.67444654 this to small  # The comment is wrong now but the value is right

central_longitude (rounded): -169.4
Boundary bounds: (-20037508.331657287, -15496570.739723718, 20037508.342789244, 7156848.148765069)
Width: 40075016.67444653 this correct
```

## Implications
Part of me doesn't think this change is worth adding because at an even deeper precision you can still hit this issue. The other part thinks this is reasonable because 1e-7 is still extremely small on the size of a map. I am interested in your thoughts on this PR either way.

Alternatively `_determine_longitude_bounds` could instead normalize the longitude before applying epsilon. This is what I would do at first glance but it does add complexity. 

Reference: 
https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html

## Checklist
 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing.
I added a test for high precision plots.