### PR TITLE
Auto-detect RGB vs RGBA tile format instead of hardcoding it

### DIFF
--- a/lib/cartopy/io/__init__.py
+++ b/lib/cartopy/io/__init__.py
@@ -61,6 +61,19 @@ def fh_getter(fh, mode='r', needs_filename=False):
     return fh, filename
 
 
+def _ensure_tile_form(img, desired_tile_form=None):
+    """Convert a PIL image to ``desired_tile_form``.
+
+    If ``desired_tile_form`` is None, auto-detect: 'RGBA' if the image
+    has an alpha channel or palette transparency, else 'RGB'.
+    """
+    if desired_tile_form is None:
+        has_alpha = 'A' in img.mode or (
+            img.mode == 'P' and 'transparency' in img.info)
+        desired_tile_form = 'RGBA' if has_alpha else 'RGB'
+    return img.convert(desired_tile_form)
+
+
 class DownloadWarning(Warning):
     """Issued when a file is being downloaded by a :class:`Downloader`."""
     pass

--- a/lib/cartopy/io/__init__.py
+++ b/lib/cartopy/io/__init__.py
@@ -61,6 +61,10 @@ def fh_getter(fh, mode='r', needs_filename=False):
     return fh, filename
 
 
+# PIL modes that carry a genuine alpha channel.
+_ALPHA_MODES = frozenset({'RGBA', 'LA', 'PA', 'RGBa', 'La'})
+
+
 def _ensure_tile_form(img, desired_tile_form=None):
     """Convert a PIL image to ``desired_tile_form``.
 
@@ -68,9 +72,13 @@ def _ensure_tile_form(img, desired_tile_form=None):
     has an alpha channel or palette transparency, else 'RGB'.
     """
     if desired_tile_form is None:
-        has_alpha = 'A' in img.mode or (
+        has_alpha = img.mode in _ALPHA_MODES or (
             img.mode == 'P' and 'transparency' in img.info)
         desired_tile_form = 'RGBA' if has_alpha else 'RGB'
+    if img.mode == 'La':
+        # Pillow cannot convert the premultiplied 'La' mode directly to
+        # RGB/RGBA; go via its straight-alpha equivalent 'LA' first.
+        img = img.convert('LA')
     return img.convert(desired_tile_form)
 
 

--- a/lib/cartopy/io/img_nest.py
+++ b/lib/cartopy/io/img_nest.py
@@ -15,6 +15,8 @@ import numpy as np
 from PIL import Image
 import shapely
 
+from cartopy.io import _ensure_tile_form
+
 
 _img_class_attrs = ['filename', 'extent', 'origin', 'pixel_size']
 
@@ -432,7 +434,7 @@ class NestedImageCollection:
         """
         return iter(self._ancestry.get(collection_image, []))
 
-    desired_tile_form = 'RGB'
+    desired_tile_form = None
 
     def get_image(self, collection_image):
         """
@@ -455,13 +457,13 @@ class NestedImageCollection:
         Note
         ----
           The format of the retrieved image file data is controlled by
-          :attr:`~cartopy.io.img_nest.NestedImageCollection.desired_tile_form`,
-          which defaults to 'RGB' format.
+          :attr:`~cartopy.io.img_nest.NestedImageCollection.desired_tile_form`.
+          Defaults to ``None``, which auto-detects 'RGB' vs 'RGBA'.
 
         """
         img = collection_image[1]
         img_data = Image.open(img.filename)
-        img_data = img_data.convert(self.desired_tile_form)
+        img_data = _ensure_tile_form(img_data, self.desired_tile_form)
         return img_data, img.extent, img.origin
 
     @classmethod

--- a/lib/cartopy/io/img_tiles.py
+++ b/lib/cartopy/io/img_tiles.py
@@ -29,13 +29,14 @@ import shapely
 
 import cartopy
 import cartopy.crs as ccrs
+from cartopy.io import _ensure_tile_form
 
 
 class GoogleWTS(metaclass=ABCMeta):
     _MAX_THREADS = 24
 
     def __init__(self,
-                 desired_tile_form='RGB',
+                 desired_tile_form=None,
                  user_agent=f'CartoPy/{cartopy.__version__}',
                  cache=False,
                  *,
@@ -48,7 +49,11 @@ class GoogleWTS(metaclass=ABCMeta):
         Parameters
         ----------
         desired_tile_form : str, optional
-            The desired format of the tile (defaults to "RGB").
+            The desired format of the tile. If None (the default), the
+            format is auto-detected per tile: "RGBA" if the fetched image
+            has an alpha channel or palette transparency, otherwise "RGB".
+            Pass "RGB" or "RGBA" explicitly to force a particular form for
+            every tile regardless of its own transparency.
         user_agent : str, optional
             Some providers (like OSM) need a "user_agent" in the request (see
             Issue #1341). OSM may reject requests if there are too many of them,
@@ -263,7 +268,7 @@ class GoogleWTS(metaclass=ABCMeta):
                 img = Image.fromarray(np.full((256, 256, 3), (250, 250, 250),
                                               dtype=np.uint8))
 
-            img = img.convert(self.desired_tile_form)
+            img = _ensure_tile_form(img, self.desired_tile_form)
             if self.cache_path is not None:
                 np.save(cached_file, img, allow_pickle=False)
                 self.cache.add(cached_file)
@@ -273,7 +278,7 @@ class GoogleWTS(metaclass=ABCMeta):
 
 class GoogleTiles(GoogleWTS):
     def __init__(self,
-                 desired_tile_form='RGB',
+                 desired_tile_form=None,
                  style="street",
                  url=('https://mts0.google.com/vt/lyrs={style}'
                       '@177000000&hl=en&src=api&x={x}&y={y}&z={z}&s=G'),
@@ -282,7 +287,9 @@ class GoogleTiles(GoogleWTS):
         Parameters
         ----------
         desired_tile_form : str, optional
-            The desired format of the tile (defaults to "RGB").
+            The desired format of the tile. If None (the default), the
+            format is auto-detected from each tile (see
+            :class:`GoogleWTS`).
         style : str, optional
             The style for the Google Maps tiles.  One of 'street',
             'satellite', 'terrain', and 'only_streets'.  Defaults to 'street'.
@@ -369,6 +376,7 @@ class StadiaMapsTiles(GoogleWTS):
                  apikey,
                  style="alidade_smooth",
                  resolution="",
+                 desired_tile_form=None,
                  cache=False):
         """Retrieves tiles from stadiamaps.com.
 
@@ -401,6 +409,10 @@ class StadiaMapsTiles(GoogleWTS):
             Resolution of the images to return. Defaults to an empty string,
             standard resolution (256x256). You can also specify "@2x" for high
             resolution (512x512) tiles.
+        desired_tile_form : str, optional
+            The desired format of the tile. If None (the default), the
+            format is auto-detected from each tile (see
+            :class:`GoogleWTS`).
         cache : bool or pathlib.Path or str, optional
             To allow offline use, as well as not spam tile providers, Cartopy
             can create a local cache of previously fetched tiles. The default
@@ -410,7 +422,7 @@ class StadiaMapsTiles(GoogleWTS):
             the tiles are downloaded each time.
         """
 
-        super().__init__(desired_tile_form="RGBA", cache=cache,
+        super().__init__(desired_tile_form=desired_tile_form, cache=cache,
                          resolution=resolution, style=style)
         self.apikey = apikey
         if style == "stamen_watercolor":
@@ -462,35 +474,23 @@ class Stamen(GoogleWTS):
                       "StadiaMapsTiles class instead.")
 
         # preset layer configuration
-        layer_config = {
-          'terrain':            {'extension': 'png', 'opaque': True},
-          'terrain-background': {'extension': 'png', 'opaque': True},
-          'terrain-labels':     {'extension': 'png', 'opaque': False},
-          'terrain-lines':      {'extension': 'png', 'opaque': False},
-          'toner-background':   {'extension': 'png', 'opaque': True},
-          'toner':              {'extension': 'png', 'opaque': True},
-          'toner-hybrid':       {'extension': 'png', 'opaque': False},
-          'toner-labels':       {'extension': 'png', 'opaque': False},
-          'toner-lines':        {'extension': 'png', 'opaque': False},
-          'toner-lite':         {'extension': 'png', 'opaque': True},
-          'watercolor':         {'extension': 'jpg', 'opaque': True},
+        layer_extensions = {
+          'terrain':            'png',
+          'terrain-background': 'png',
+          'terrain-labels':     'png',
+          'terrain-lines':      'png',
+          'toner-background':   'png',
+          'toner':              'png',
+          'toner-hybrid':       'png',
+          'toner-labels':       'png',
+          'toner-lines':        'png',
+          'toner-lite':         'png',
+          'watercolor':         'jpg',
         }
-
-        # get layer information from dict
-        layer_info = layer_config.get(
-            style, {'extension': '.png', 'opaque': True})
-
-        # use optional desired_tile_form input if available
-        # otherwise, use preset value based on the layer name
-        if desired_tile_form is None:
-            if layer_info['opaque']:
-                desired_tile_form = 'RGB'
-            else:
-                desired_tile_form = 'RGBA'
 
         super().__init__(desired_tile_form=desired_tile_form, cache=cache,
                          style=style)
-        self.extension = layer_info['extension']
+        self.extension = layer_extensions.get(style, 'png')
 
     def _image_url(self, tile):
         x, y, z = tile
@@ -606,7 +606,7 @@ class MapboxStyleTiles(GoogleWTS):
                  access_token,
                  username,
                  map_id,
-                 desired_tile_form='RGB',
+                 desired_tile_form=None,
                  cache=False):
         """
         Set up a new instance to retrieve tiles from a Mapbox style.
@@ -631,7 +631,9 @@ class MapboxStyleTiles(GoogleWTS):
             may be private and if your access token does not have permissions
             to view this style, then map tile retrieval will fail.
         desired_tile_form : str, optional
-            The desired format of the tile (defaults to "RGB").
+            The desired format of the tile. If None (the default), the
+            format is auto-detected from each tile (see
+            :class:`GoogleWTS`).
         cache : bool or pathlib.Path or str, optional
             To allow offline use, as well as not spam tile providers, Cartopy
             can create a local cache of previously fetched tiles. The default
@@ -767,7 +769,7 @@ class OrdnanceSurvey(GoogleWTS):
     def __init__(self,
                  apikey,
                  layer='Road_3857',
-                 desired_tile_form='RGB',
+                 desired_tile_form=None,
                  cache=False):
         """
         Parameters
@@ -782,7 +784,9 @@ class OrdnanceSurvey(GoogleWTS):
             - https://apidocs.os.uk/docs/layer-information
             - https://apidocs.os.uk/docs/map-styles
         desired_tile_form : str, optional
-            The desired format of the tile (defaults to "RGB").
+            The desired format of the tile. If None (the default), the
+            format is auto-detected from each tile (see
+            :class:`GoogleWTS`).
         cache : bool or pathlib.Path or str, optional
             To allow offline use, as well as not spam tile providers, Cartopy
             can create a local cache of previously fetched tiles. The default
@@ -870,7 +874,7 @@ class AzureMapsTiles(GoogleWTS):
                  subscription_key,
                  tileset_id="microsoft.imagery",
                  api_version="2.0",
-                 desired_tile_form='RGB',
+                 desired_tile_form=None,
                  cache=False):
         """
         Set up a new instance to retrieve tiles from Azure Maps.
@@ -890,7 +894,9 @@ class AzureMapsTiles(GoogleWTS):
         api_version
             API version to use. Defaults to 2.0 as recommended by Microsoft.
         desired_tile_form : str, optional
-            The desired format of the tile (defaults to "RGB").
+            The desired format of the tile. If None (the default), the
+            format is auto-detected from each tile (see
+            :class:`GoogleWTS`).
         cache : bool or pathlib.Path or str, optional
             To allow offline use, as well as not spam tile providers, Cartopy
             can create a local cache of previously fetched tiles. The default
@@ -926,7 +932,7 @@ class LINZMapsTiles(GoogleWTS):
                  apikey,
                  layer_id,
                  api_version="v4",
-                 desired_tile_form='RGB',
+                 desired_tile_form=None,
                  cache=False):
         """
         Set up a new instance to retrieve tiles from The LINZ
@@ -946,7 +952,9 @@ class LINZMapsTiles(GoogleWTS):
         api_version
             API version to use. Defaults to v4 for now.
         desired_tile_form : str, optional
-            The desired format of the tile (defaults to "RGB").
+            The desired format of the tile. If None (the default), the
+            format is auto-detected from each tile (see
+            :class:`GoogleWTS`).
         cache : bool or pathlib.Path or str, optional
             To allow offline use, as well as not spam tile providers, Cartopy
             can create a local cache of previously fetched tiles. The default

--- a/lib/cartopy/tests/test_img_nest.py
+++ b/lib/cartopy/tests/test_img_nest.py
@@ -255,6 +255,27 @@ def test_nest(nest_from_config):
     assert nest_z0_z1._ancestry == nest_z0_z1_from_pickle._ancestry
 
 
+def test_nested_image_collection_get_image_auto_detects_tile_form(tmp_path):
+    opaque_path = tmp_path / 'opaque.png'
+    Image.new('RGB', (2, 2), (255, 0, 0)).save(opaque_path)
+    transparent_path = tmp_path / 'transparent.png'
+    Image.new('RGBA', (2, 2), (255, 0, 0, 128)).save(transparent_path)
+
+    collection_image = (
+        'test', cimg_nest.Img(opaque_path, (0, 1, 0, 1), 'lower', (1, 1)))
+    nest = cimg_nest.NestedImageCollection('test', None, [])
+    assert nest.desired_tile_form is None
+
+    img_data, _, _ = nest.get_image(collection_image)
+    assert img_data.mode == 'RGB'
+
+    collection_image = (
+        'test',
+        cimg_nest.Img(transparent_path, (0, 1, 0, 1), 'lower', (1, 1)))
+    img_data, _, _ = nest.get_image(collection_image)
+    assert img_data.mode == 'RGBA'
+
+
 def test_img_pickle_round_trip():
     """Check that __getstate__ for Img instances is working correctly."""
 

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -4,12 +4,14 @@
 # See LICENSE in the root of the repository for full licensing details.
 
 import hashlib
+import io
 import os
 import types
 import warnings
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal as assert_arr_almost
+from PIL import Image
 import pytest
 import shapely
 
@@ -21,6 +23,7 @@ if not _HAS_PYKDTREE_OR_SCIPY:
 
 from cartopy import config
 import cartopy.crs as ccrs
+from cartopy.io import _ensure_tile_form
 import cartopy.io.img_tiles as cimgt
 import cartopy.io.ogc_clients as ogc
 
@@ -123,6 +126,74 @@ def test_google_wts():
     assert_arr_almost(gt.tileextent((0, 2, 2)), KNOWN_EXTENTS[(0, 2, 2)])
     assert_arr_almost(gt.tileextent((2, 2, 2)), KNOWN_EXTENTS[(2, 2, 2)])
     assert_arr_almost(gt.tileextent((8, 9, 4)), KNOWN_EXTENTS[(8, 9, 4)])
+
+
+@pytest.mark.parametrize("mode,info,expected", [
+    ("RGB", {}, "RGB"),
+    ("RGBA", {}, "RGBA"),
+    ("LA", {}, "RGBA"),
+    ("L", {}, "RGB"),
+    ("P", {}, "RGB"),
+    ("P", {"transparency": 0}, "RGBA"),
+])
+def test_ensure_tile_form_auto_detect(mode, info, expected):
+    img = Image.new(mode, (1, 1))
+    img.info.update(info)
+    assert _ensure_tile_form(img).mode == expected
+
+
+@pytest.mark.parametrize("desired_tile_form", ["RGB", "RGBA"])
+def test_ensure_tile_form_explicit(desired_tile_form):
+    img = Image.new("P", (1, 1))
+    assert _ensure_tile_form(img, desired_tile_form).mode == desired_tile_form
+
+
+def _png_bytes(mode, color):
+    img = Image.new(mode, (2, 2), color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _fake_urlopen(img_bytes):
+    class _Response:
+        def read(self):
+            return img_bytes
+
+        def close(self):
+            pass
+
+    def urlopen(request, *args, **kwargs):
+        return _Response()
+
+    return urlopen
+
+
+def test_get_image_auto_detects_tile_form(monkeypatch):
+    gt = cimgt.GoogleTiles()
+    assert gt.desired_tile_form is None
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        _fake_urlopen(_png_bytes("RGB", (255, 0, 0))))
+    img, _, _ = gt.get_image((0, 0, 0))
+    assert img.mode == "RGB"
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        _fake_urlopen(_png_bytes("RGBA", (255, 0, 0, 128))))
+    img, _, _ = gt.get_image((0, 0, 0))
+    assert img.mode == "RGBA"
+
+
+def test_get_image_explicit_tile_form_overrides_detection(monkeypatch):
+    gt = cimgt.GoogleTiles(desired_tile_form="RGB")
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        _fake_urlopen(_png_bytes("RGBA", (255, 0, 0, 128))))
+    img, _, _ = gt.get_image((0, 0, 0))
+    assert img.mode == "RGB"
 
 
 def test_tile_bbox_y0_at_south_pole():

--- a/lib/cartopy/tests/test_img_tiles.py
+++ b/lib/cartopy/tests/test_img_tiles.py
@@ -132,9 +132,12 @@ def test_google_wts():
     ("RGB", {}, "RGB"),
     ("RGBA", {}, "RGBA"),
     ("LA", {}, "RGBA"),
+    ("RGBa", {}, "RGBA"),
+    ("La", {}, "RGBA"),
     ("L", {}, "RGB"),
     ("P", {}, "RGB"),
     ("P", {"transparency": 0}, "RGBA"),
+    ("LAB", {}, "RGB"),
 ])
 def test_ensure_tile_form_auto_detect(mode, info, expected):
     img = Image.new(mode, (1, 1))


### PR DESCRIPTION
desired_tile_form now defaults to None on GoogleWTS and all its subclasses (and on NestedImageCollection). When left as None, the format is detected per image from its PIL mode/info: RGBA if it carries an alpha channel or palette transparency, otherwise RGB. Explicitly passing "RGB" or "RGBA" still forces that form for every tile.

Closes #2729